### PR TITLE
feat(sumologcexporter): add otlp logs support

### DIFF
--- a/pkg/exporter/sumologicexporter/README.md
+++ b/pkg/exporter/sumologicexporter/README.md
@@ -9,7 +9,7 @@ The following configuration options are supported:
 Empty string means no compression
 - `max_request_body_size` (optional): Max HTTP request body size in bytes before compression (if applied). By default `1_048_576` (1MB) is used.
 - `metadata_attributes` (optional): List of regexes for attributes which should be send as metadata
-- `log_format` (optional) (logs only): Format to use when sending logs to Sumo. (default `json`) (possible values: `json`, `text`)
+- `log_format` (optional) (logs only): Format to use when sending logs to Sumo. (default `json`) (possible values: `json`, `text`, `otlp`)
 - `metric_format` (optional) (metrics only): Format of the metrics to be sent (default is `prometheus`) (possible values: `carbon2`, `graphite`, `prometheus`).
 - `graphite_template` (default=`%{_metric_}`) (optional) (metrics only): Template for Graphite format.
 [Source templates](#source-templates) are going to be applied.

--- a/pkg/exporter/sumologicexporter/config.go
+++ b/pkg/exporter/sumologicexporter/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	// Format to post logs into Sumo. (default json)
 	//   * text - Logs will appear in Sumo Logic in text format.
 	//   * json - Logs will appear in Sumo Logic in json format.
+	//   * otlp - Logs will be send in otlp format and will appear in Sumo Logic in text format.
 	LogFormat LogFormatType `mapstructure:"log_format"`
 
 	// Metrics related configuration
@@ -94,6 +95,8 @@ const (
 	TextFormat LogFormatType = "text"
 	// JSONFormat represents log_format: json
 	JSONFormat LogFormatType = "json"
+	// OTLPLogFormat represents log_format: otlp
+	OTLPLogFormat LogFormatType = "otlp"
 	// GraphiteFormat represents metric_format: text
 	GraphiteFormat MetricFormatType = "graphite"
 	// Carbon2Format represents metric_format: json

--- a/pkg/exporter/sumologicexporter/exporter.go
+++ b/pkg/exporter/sumologicexporter/exporter.go
@@ -49,6 +49,7 @@ func initExporter(cfg *Config) (*sumologicexporter, error) {
 	switch cfg.LogFormat {
 	case JSONFormat:
 	case TextFormat:
+	case OTLPLogFormat:
 	default:
 		return nil, fmt.Errorf("unexpected log format: %s", cfg.LogFormat)
 	}


### PR DESCRIPTION
Add support for OTLP format for logs. This implementation doesn't respect HTTP restriction like message size. This is done such way due to simplicity and urgency of the solution

https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#otlphttp-request
https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/logs/v1/logs.proto