### PR TITLE
feat: skip builds for arm

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         go: [ '1.16.4' ]
-        arch_os: [ 'darwin_amd64', 'linux_amd64', 'linux_arm64']
+        arch_os: [ 'darwin_amd64', 'linux_amd64' ]
     steps:
       - uses: actions/checkout@v2.3.4
 
@@ -73,7 +73,7 @@ jobs:
       - build
     strategy:
       matrix:
-        arch_os: [ 'linux_amd64', 'linux_arm64']
+        arch_os: [ 'linux_amd64' ]
     steps:
       - uses: actions/checkout@v2.3.4
 
@@ -147,4 +147,4 @@ jobs:
         run: |
           make push-container-manifest-dev \
             BUILD_TAG=${{ steps.extract_tag.outputs.tag }} \
-            PLATFORMS="linux/amd64 linux/arm64"
+            PLATFORMS="linux/amd64"

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -149,4 +149,4 @@ jobs:
         run: |
           make push-container-manifest \
             BUILD_TAG=${{ steps.extract_tag.outputs.tag }} \
-            PLATFORMS="linux/amd64 linux/arm64"
+            PLATFORMS="linux/amd64"

--- a/otelcolbuilder/Makefile
+++ b/otelcolbuilder/Makefile
@@ -43,7 +43,7 @@ build:
 	chmod +x ./cmd/$(BINARY_NAME)
 
 .PHONY: otelcol-sumo-all-sys
-otelcol-sumo-all-sys: otelcol-sumo-darwin_amd64 otelcol-sumo-linux_amd64 otelcol-sumo-linux_arm64 otelcol-sumo-windows_amd64
+otelcol-sumo-all-sys: otelcol-sumo-darwin_amd64 otelcol-sumo-linux_amd64 otelcol-sumo-windows_amd64
 
 .PHONY: otelcol-sumo-darwin_amd64
 otelcol-sumo-darwin_amd64:


### PR DESCRIPTION
Disable arm builds due to: https://github.com/golang/go/issues/46766

```
GOOS=linux   GOARCH=arm64 make build BINARY_NAME=otelcol-sumo-linux_arm64
make[1]: Entering directory '/home/runner/work/sumologic-otel-collector/sumologic-otel-collector/otelcolbuilder'
CGO_ENABLED=0 opentelemetry-collector-builder \
	--go go \
	--version "v0.0.2-8-g3f0a322966" \
	--config .otelcol-builder.yaml \
	--output-path ./cmd \
	--name otelcol-sumo-linux_arm64
2021-06-16T13:36:17.427Z	INFO	cmd/root.go:99	OpenTelemetry Collector distribution builder	{"version": "dev", "date": "unknown"}
2021-06-16T13:36:17.427Z	INFO	cmd/root.go:115	Using config file	{"path": ".otelcol-builder.yaml"}
2021-06-16T13:36:17.428Z	INFO	builder/main.go:90	Sources created	{"path": "./cmd"}
2021-06-16T13:36:17.484Z	INFO	builder/main.go:126	Getting go modules
2021-06-16T13:36:54.898Z	INFO	builder/main.go:107	Compiling
Error: failed to compile the OpenTelemetry Collector distribution: exit status 2. Output: "# github.com/golang/snappy\n/home/runner/go/pkg/mod/github.com/golang/snappy@v0.0.3/encode_arm64.s:385: arm64 doesn't support scaled register format\n/home/runner/go/pkg/mod/github.com/golang/snappy@v0.0.3/encode_arm64.s:675: arm64 doesn't support scaled register format\nasm: assembly of /home/runner/go/pkg/mod/github.com/golang/snappy@v0.0.3/encode_arm64.s failed\n"
failed to compile the OpenTelemetry Collector distribution: exit status 2. Output: "# github.com/golang/snappy\n/home/runner/go/pkg/mod/github.com/golang/snappy@v0.0.3/encode_arm64.s:385: arm64 doesn't support scaled register format\n/home/runner/go/pkg/mod/github.com/golang/snappy@v0.0.3/encode_arm64.s:675: arm64 doesn't support scaled register format\nasm: assembly of /home/runner/go/pkg/mod/github.com/golang/snappy@v0.0.3/encode_arm64.s failed\n"
Usage:
  opentelemetry-collector-builder [flags]
emetry-collector-builder [command]
```
[link](https://github.com/SumoLogic/sumologic-otel-collector/runs/2839698976?check_suite_focus=true)