### PR TITLE
refactor: Change mechanism of building encryption hash

### DIFF
--- a/pkg/extension/sumologicextension/README.md
+++ b/pkg/extension/sumologicextension/README.md
@@ -89,10 +89,16 @@ service:
 
 ## Storing credentials
 
-When collector is starting first time Sumo Logic extension is using `access_key` and `access_id` to register collector with API.
-After registration extension gets collector credentials which are used to authenticate instance of collector.
-Credentials are stored on filesystem in `collector_credentials_path` which is by default set to `$HOME/.sumologic-otel-collector`.
-Name of file that contains credentials is created by hashing combination of `collector_name`, `access_id` and `access_key`.
-This mechanism allows to keep a state of collector (whether is registered or not).
-When collector is restarting it checks if state file exists in `collector_credentials_path`.
-If user want to register collector on the same machine and use another state file, need add the collector name to otc config.
+When collector is starting for the first time, Sumo Logic extension is using `access_key` and `access_id`
+to register collector with API.
+Upon registration, the extension gets collector credentials which are used to authenticate the collector
+when sending request to API (heartbeats, sending data etc).
+Credentials are stored on local filesystem to be reused when collector gets restarted (to prevent re-registration).a
+The path that's used to store the credentials files is configured via `collector_credentials_path` which is by default
+set to `$HOME/.sumologic-otel-collector`.
+Name of that file that contains the credentials is created by hashing a string being a combination of `collector_name`, `access_id` and `access_key`.
+This mechanism allows to keep the state of the collector (whether it is registered or not).
+When collector is restarting it checks if the state file exists in `collector_credentials_path`.
+If one would like to register another collector on the same machine then `collector_name` configuration property
+has to be specified in order to register the collector under that specific name which will be used to create
+a separate state file.

--- a/pkg/extension/sumologicextension/README.md
+++ b/pkg/extension/sumologicextension/README.md
@@ -90,13 +90,13 @@ service:
 ## Storing credentials
 
 When collector is starting for the first time, Sumo Logic extension is using `access_key` and `access_id`
-to register collector with API.
+to register the collector with API.
 Upon registration, the extension gets collector credentials which are used to authenticate the collector
 when sending request to API (heartbeats, sending data etc).
-Credentials are stored on local filesystem to be reused when collector gets restarted (to prevent re-registration).a
+Credentials are stored on local filesystem to be reused when collector gets restarted (to prevent re-registration).
 The path that's used to store the credentials files is configured via `collector_credentials_path` which is by default
 set to `$HOME/.sumologic-otel-collector`.
-Name of that file that contains the credentials is created by hashing a string being a combination of `collector_name`, `access_id` and `access_key`.
+Name of that file that contains the credentials is created by hashing a string which is a combination of `collector_name`, `access_id` and `access_key`.
 This mechanism allows to keep the state of the collector (whether it is registered or not).
 When collector is restarting it checks if the state file exists in `collector_credentials_path`.
 If one would like to register another collector on the same machine then `collector_name` configuration property

--- a/pkg/extension/sumologicextension/README.md
+++ b/pkg/extension/sumologicextension/README.md
@@ -86,3 +86,13 @@ service:
       processors: []
       exporters: [sumologic]
 ```
+
+## Storing credentials
+
+When collector is starting first time Sumo Logic extension is using `access_key` and `access_id` to register collector with API.
+After registration extension gets collector credentials which are used to authenticate instance of collector.
+Credentials are stored on filesystem in `collector_credentials_path` which is by default set to `$HOME/.sumologic-otel-collector`.
+Name of file that contains credentials is created by hashing combination of `collector_name`, `access_id` and `access_key`.
+This mechanism allows to keep a state of collector (whether is registered or not).
+When collector is restarting it checks if state file exists in `collector_credentials_path`.
+If user want to register collector on the same machine and use another state file, need add the collector name to otc config.

--- a/pkg/extension/sumologicextension/api/register.go
+++ b/pkg/extension/sumologicextension/api/register.go
@@ -26,6 +26,7 @@ type OpenRegisterRequestPayload struct {
 }
 
 type OpenRegisterResponsePayload struct {
+	CollectorName          string `json:"collectorName"`
 	CollectorCredentialId  string `json:"collectorCredentialId"`
 	CollectorCredentialKey string `json:"collectorCredentialKey"`
 	CollectorId            string `json:"collectorId"`

--- a/pkg/extension/sumologicextension/api/register.go
+++ b/pkg/extension/sumologicextension/api/register.go
@@ -26,7 +26,6 @@ type OpenRegisterRequestPayload struct {
 }
 
 type OpenRegisterResponsePayload struct {
-	CollectorName          string `json:"collectorName"`
 	CollectorCredentialId  string `json:"collectorCredentialId"`
 	CollectorCredentialKey string `json:"collectorCredentialKey"`
 	CollectorId            string `json:"collectorId"`

--- a/pkg/extension/sumologicextension/credentials.go
+++ b/pkg/extension/sumologicextension/credentials.go
@@ -48,7 +48,8 @@ type credsGetter struct {
 // CheckCollectorCredentials checks if collector credentials can be found in path
 // configured in the config.
 func (cr credsGetter) CheckCollectorCredentials() bool {
-	filenameHash, err := hash(cr.conf.CollectorName)
+	key := cr.conf.CollectorName + cr.conf.Credentials.AccessID + cr.conf.Credentials.AccessKey
+	filenameHash, err := hash(key)
 	if err != nil {
 		return false
 	}
@@ -62,7 +63,8 @@ func (cr credsGetter) CheckCollectorCredentials() bool {
 // GetStoredCredentials retrieves collector credentials stored in local file system and then decrypts it
 // using hashed collector name as passphrase.
 func (cr credsGetter) GetStoredCredentials() (api.OpenRegisterResponsePayload, error) {
-	filenameHash, err := hash(cr.conf.CollectorName)
+	key := cr.conf.CollectorName + cr.conf.Credentials.AccessID + cr.conf.Credentials.AccessKey
+	filenameHash, err := hash(key)
 	if err != nil {
 		return api.OpenRegisterResponsePayload{}, err
 	}

--- a/pkg/extension/sumologicextension/credentials.go
+++ b/pkg/extension/sumologicextension/credentials.go
@@ -33,8 +33,8 @@ import (
 
 // CredsGetter is an interface to get collector authentication data
 type CredsGetter interface {
-	CheckCollectorCredentials() bool
-	GetStoredCredentials() (api.OpenRegisterResponsePayload, error)
+	CheckCollectorCredentials(string) bool
+	GetStoredCredentials(string) (api.OpenRegisterResponsePayload, error)
 	RegisterCollector(ctx context.Context) (api.OpenRegisterResponsePayload, error)
 }
 
@@ -47,8 +47,8 @@ type credsGetter struct {
 
 // CheckCollectorCredentials checks if collector credentials can be found in path
 // configured in the config.
-func (cr credsGetter) CheckCollectorCredentials() bool {
-	key := cr.conf.CollectorName + cr.conf.Credentials.AccessID + cr.conf.Credentials.AccessKey
+func (cr credsGetter) CheckCollectorCredentials(key string) bool {
+	// key := cr.collectorName + cr.conf.Credentials.AccessID + cr.conf.Credentials.AccessKey
 	filenameHash, err := hash(key)
 	if err != nil {
 		return false
@@ -62,8 +62,8 @@ func (cr credsGetter) CheckCollectorCredentials() bool {
 
 // GetStoredCredentials retrieves collector credentials stored in local file system and then decrypts it
 // using hashed collector name as passphrase.
-func (cr credsGetter) GetStoredCredentials() (api.OpenRegisterResponsePayload, error) {
-	key := cr.conf.CollectorName + cr.conf.Credentials.AccessID + cr.conf.Credentials.AccessKey
+func (cr credsGetter) GetStoredCredentials(key string) (api.OpenRegisterResponsePayload, error) {
+	// key := cr.collectorName + cr.conf.Credentials.AccessID + cr.conf.Credentials.AccessKey
 	filenameHash, err := hash(key)
 	if err != nil {
 		return api.OpenRegisterResponsePayload{}, err
@@ -81,7 +81,7 @@ func (cr credsGetter) GetStoredCredentials() (api.OpenRegisterResponsePayload, e
 		return api.OpenRegisterResponsePayload{}, err
 	}
 
-	collectorCreds, err := decrypt(encryptedCreds, cr.conf.CollectorName)
+	collectorCreds, err := decrypt(encryptedCreds, key)
 	if err != nil {
 		return api.OpenRegisterResponsePayload{}, err
 	}

--- a/pkg/extension/sumologicextension/credentials.go
+++ b/pkg/extension/sumologicextension/credentials.go
@@ -48,7 +48,6 @@ type credsGetter struct {
 // CheckCollectorCredentials checks if collector credentials can be found in path
 // configured in the config.
 func (cr credsGetter) CheckCollectorCredentials(key string) bool {
-	// key := cr.collectorName + cr.conf.Credentials.AccessID + cr.conf.Credentials.AccessKey
 	filenameHash, err := hash(key)
 	if err != nil {
 		return false
@@ -63,7 +62,6 @@ func (cr credsGetter) CheckCollectorCredentials(key string) bool {
 // GetStoredCredentials retrieves collector credentials stored in local file system and then decrypts it
 // using hashed collector name as passphrase.
 func (cr credsGetter) GetStoredCredentials(key string) (api.OpenRegisterResponsePayload, error) {
-	// key := cr.collectorName + cr.conf.Credentials.AccessID + cr.conf.Credentials.AccessKey
 	filenameHash, err := hash(key)
 	if err != nil {
 		return api.OpenRegisterResponsePayload{}, err

--- a/pkg/extension/sumologicextension/extension.go
+++ b/pkg/extension/sumologicextension/extension.go
@@ -110,18 +110,12 @@ func (se *SumologicExtension) Start(ctx context.Context, host component.Host) er
 		if err != nil {
 			return err
 		}
-		colName := colCreds.CollectorName
+		se.collectorName = colCreds.CollectorName
 		if !se.conf.Clobber {
-			// collectorName is not set when it is configured empty in config file, and there is state file which means
-			// that the collector was previously registered with generated name. Getting this name from state file and
-			// override it in the starting up collector.
-			if se.collectorName == "" {
-				se.collectorName = colName
-			}
 			se.logger.Info("Found stored credentials, skipping registration")
 		} else {
 			se.logger.Info("Locally stored credentials found, but clobber flag is set: re-registering the collector")
-			if colCreds, err = se.credentialsGetter.RegisterCollector(ctx, colName); err != nil {
+			if colCreds, err = se.credentialsGetter.RegisterCollector(ctx, se.collectorName); err != nil {
 				return err
 			}
 			if err := se.storeCollectorCredentials(colCreds); err != nil {

--- a/pkg/extension/sumologicextension/extension.go
+++ b/pkg/extension/sumologicextension/extension.go
@@ -138,7 +138,8 @@ func (se *SumologicExtension) storeCollectorCredentials(credentials api.OpenRegi
 	if err := ensureStoreCredentialsDir(se.conf.CollectorCredentialsPath); err != nil {
 		return err
 	}
-	filenameHash, err := hash(se.conf.CollectorName)
+	key := se.conf.CollectorName + se.conf.Credentials.AccessID + se.conf.Credentials.AccessKey
+	filenameHash, err := hash(key)
 	if err != nil {
 		return err
 	}

--- a/pkg/extension/sumologicextension/extension_test.go
+++ b/pkg/extension/sumologicextension/extension_test.go
@@ -16,10 +16,12 @@ package sumologicextension
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,6 +29,10 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.uber.org/zap"
+)
+
+const (
+	uuidRegex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
 )
 
 func TestBasicExtensionConstruction(t *testing.T) {
@@ -76,6 +82,7 @@ func TestBasicExtensionConstruction(t *testing.T) {
 
 func TestBasicStart(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// TODO Add payload verification - verify if collectorName is set properly
 		if req.URL.Path == registerUrl {
 			_, err := w.Write([]byte(`{
 				"collectorCredentialId": "aaaaaaaaaaaaaaaaaaaa",
@@ -112,6 +119,7 @@ func TestBasicStart(t *testing.T) {
 
 func TestStoreCredentials(t *testing.T) {
 	getServer := func() *httptest.Server {
+		// TODO Add payload verification - verify if collectorName is set properly
 		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			if req.URL.Path == registerUrl {
 				_, err := w.Write([]byte(`{
@@ -225,4 +233,102 @@ func TestStoreCredentials(t *testing.T) {
 		srv.Close()
 		require.NoError(t, se.Start(context.Background(), componenttest.NewNopHost()))
 	})
+}
+
+func TestRegisterEmptyCollectorName(t *testing.T) {
+	hostname, err := os.Hostname()
+	require.NoError(t, err)
+	// TODO Add payload verification - verify if collectorName is set properly
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == registerUrl {
+			_, err := w.Write([]byte(`{
+				"collectorCredentialId": "aaaaaaaaaaaaaaaaaaaa",
+				"collectorCredentialKey": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+				"collectorId": "000000000FFFFFFF"
+			}`))
+
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			return
+		}
+	}))
+
+	dir, err := os.MkdirTemp("", "otelcol-sumo-store-credentials-test-*")
+	t.Cleanup(func() {
+		srv.Close()
+		os.RemoveAll(dir)
+	})
+	require.NoError(t, err)
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.CollectorName = ""
+	cfg.ExtensionSettings = config.ExtensionSettings{}
+	cfg.ApiBaseUrl = srv.URL
+	cfg.Credentials.AccessID = "dummy_access_id"
+	cfg.Credentials.AccessKey = "dummy_access_key"
+	cfg.CollectorCredentialsPath = dir
+
+	se, err := newSumologicExtension(cfg, zap.NewNop())
+	require.NoError(t, err)
+	require.NoError(t, se.Start(context.Background(), componenttest.NewNopHost()))
+	regexPattern := fmt.Sprintf("%s-%s", hostname, uuidRegex)
+	matched, err := regexp.MatchString(regexPattern, se.collectorName)
+	require.NoError(t, err)
+	assert.True(t, matched)
+}
+
+func TestRegisterEmptyCollectorNameClobber(t *testing.T) {
+	hostname, err := os.Hostname()
+	require.NoError(t, err)
+	// TODO Add payload verification - verify if collectorName is set properly
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == registerUrl {
+			_, err := w.Write([]byte(`{
+				"collectorCredentialId": "aaaaaaaaaaaaaaaaaaaa",
+				"collectorCredentialKey": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+				"collectorId": "000000000FFFFFFF"
+			}`))
+
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			return
+		}
+	}))
+
+	dir, err := os.MkdirTemp("", "otelcol-sumo-store-credentials-test-*")
+	t.Cleanup(func() {
+		srv.Close()
+		os.RemoveAll(dir)
+	})
+	require.NoError(t, err)
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.CollectorName = ""
+	cfg.ExtensionSettings = config.ExtensionSettings{}
+	cfg.ApiBaseUrl = srv.URL
+	cfg.Credentials.AccessID = "dummy_access_id"
+	cfg.Credentials.AccessKey = "dummy_access_key"
+	cfg.CollectorCredentialsPath = dir
+	cfg.Clobber = true
+
+	se, err := newSumologicExtension(cfg, zap.NewNop())
+	require.NoError(t, err)
+	require.NoError(t, se.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, se.Shutdown(context.Background()))
+	assert.NotEmpty(t, se.collectorName)
+	regexPattern := fmt.Sprintf("%s-%s", hostname, uuidRegex)
+	matched, err := regexp.MatchString(regexPattern, se.collectorName)
+	require.NoError(t, err)
+	assert.True(t, matched)
+	colCreds, err := se.credentialsGetter.GetStoredCredentials(se.hashKey)
+	require.NoError(t, err)
+	colName := colCreds.CollectorName
+	se, err = newSumologicExtension(cfg, zap.NewNop())
+	require.NoError(t, err)
+	require.NoError(t, se.Start(context.Background(), componenttest.NewNopHost()))
+	assert.Equal(t, se.collectorName, colName)
 }

--- a/pkg/extension/sumologicextension/extension_test.go
+++ b/pkg/extension/sumologicextension/extension_test.go
@@ -153,7 +153,8 @@ func TestStoreCredentials(t *testing.T) {
 
 		se, err := newSumologicExtension(cfg, zap.NewNop())
 		require.NoError(t, err)
-		fileName, err := hash(cfg.CollectorName)
+		key := cfg.CollectorName + cfg.Credentials.AccessID + cfg.Credentials.AccessKey
+		fileName, err := hash(key)
 		require.NoError(t, err)
 		credsPath := path.Join(dir, fileName)
 		require.NoFileExists(t, credsPath)
@@ -180,7 +181,8 @@ func TestStoreCredentials(t *testing.T) {
 
 		se, err := newSumologicExtension(cfg, zap.NewNop())
 		require.NoError(t, err)
-		fileName, err := hash(cfg.CollectorName)
+		key := cfg.CollectorName + cfg.Credentials.AccessID + cfg.Credentials.AccessKey
+		fileName, err := hash(key)
 		require.NoError(t, err)
 		credsPath := path.Join(dir, fileName)
 		require.NoFileExists(t, credsPath)
@@ -210,7 +212,8 @@ func TestStoreCredentials(t *testing.T) {
 
 		se, err := newSumologicExtension(cfg, zap.NewNop())
 		require.NoError(t, err)
-		fileName, err := hash(cfg.CollectorName)
+		key := cfg.CollectorName + cfg.Credentials.AccessID + cfg.Credentials.AccessKey
+		fileName, err := hash(key)
 		require.NoError(t, err)
 		credsPath := path.Join(dir, fileName)
 		require.NoFileExists(t, credsPath)

--- a/pkg/extension/sumologicextension/extension_test.go
+++ b/pkg/extension/sumologicextension/extension_test.go
@@ -153,7 +153,7 @@ func TestStoreCredentials(t *testing.T) {
 
 		se, err := newSumologicExtension(cfg, zap.NewNop())
 		require.NoError(t, err)
-		key := cfg.CollectorName + cfg.Credentials.AccessID + cfg.Credentials.AccessKey
+		key := createHashKey(cfg)
 		fileName, err := hash(key)
 		require.NoError(t, err)
 		credsPath := path.Join(dir, fileName)
@@ -181,7 +181,7 @@ func TestStoreCredentials(t *testing.T) {
 
 		se, err := newSumologicExtension(cfg, zap.NewNop())
 		require.NoError(t, err)
-		key := cfg.CollectorName + cfg.Credentials.AccessID + cfg.Credentials.AccessKey
+		key := createHashKey(cfg)
 		fileName, err := hash(key)
 		require.NoError(t, err)
 		credsPath := path.Join(dir, fileName)
@@ -212,7 +212,7 @@ func TestStoreCredentials(t *testing.T) {
 
 		se, err := newSumologicExtension(cfg, zap.NewNop())
 		require.NoError(t, err)
-		key := cfg.CollectorName + cfg.Credentials.AccessID + cfg.Credentials.AccessKey
+		key := createHashKey(cfg)
 		fileName, err := hash(key)
 		require.NoError(t, err)
 		credsPath := path.Join(dir, fileName)

--- a/pkg/extension/sumologicextension/go.mod
+++ b/pkg/extension/sumologicextension/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect
 	github.com/gogo/googleapis v1.3.0 // indirect
+	github.com/google/uuid v1.2.0
 	github.com/hashicorp/go-immutable-radix v1.2.0 // indirect
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect
 	github.com/mattn/go-colorable v0.1.7 // indirect


### PR DESCRIPTION
Change mechanism of building encryption hash. Use combination of collector name, access ID and access key.

Signed-off-by: Patryk Matyjasek <pmatyjasek@sumologic.com>