### PR TITLE
sumologicexporter: do not overwrite attributes using metadata translation

### DIFF
--- a/pkg/exporter/sumologicexporter/README.md
+++ b/pkg/exporter/sumologicexporter/README.md
@@ -96,6 +96,8 @@ exporters:
 Metadata translation changes some of the attribute keys from OpenTelemetry convention to Sumo convention.
 For example, OpenTelemetry convention for the attribute containing Kubernetes pod name is `k8s.pod.name`,
 but Sumo expects it to be in attribute named `pod`.
+If attribute with target name eg. `pod` already exists,
+translation is not being done for corresponding attribute (`k8s.pod.name` in this example).
 
 This feature is turned on by default.
 To turn it off, set the `translate_metadata` configuration option to `false`.
@@ -124,6 +126,7 @@ Below is a list of all metadata keys that are being translated.
 | k8s.replicaset.name     | replicaset       |
 | k8s.statefulset.name    | statefulset      |
 | service.name            | service          |
+| file.path.resolved      | _sourceName      |
 
 ## Source Templates
 

--- a/pkg/exporter/sumologicexporter/translate_metadata.go
+++ b/pkg/exporter/sumologicexporter/translate_metadata.go
@@ -42,6 +42,7 @@ var metadataTranslations = map[string]string{
 	"k8s.replicaset.name":     "replicaset",
 	"k8s.statefulset.name":    "statefulset",
 	"service.name":            "service",
+	"file.path.resolved":      "_sourceName",
 }
 
 // translateMetadata renames metadata keys according to metadataTranslations.

--- a/pkg/exporter/sumologicexporter/translate_metadata.go
+++ b/pkg/exporter/sumologicexporter/translate_metadata.go
@@ -49,7 +49,11 @@ var metadataTranslations = map[string]string{
 func translateMetadata(attributes pdata.AttributeMap) {
 	attributes.Range(func(otKey string, value pdata.AttributeValue) bool {
 		if sumoKey, ok := metadataTranslations[otKey]; ok {
-			attributes.Upsert(sumoKey, value)
+			// do not rename attribute if target name already exists
+			if _, ok := attributes.Get(sumoKey); ok {
+				return true
+			}
+			attributes.Insert(sumoKey, value)
 			attributes.Delete(otKey)
 		}
 		return true

--- a/pkg/exporter/sumologicexporter/translate_metadata_test.go
+++ b/pkg/exporter/sumologicexporter/translate_metadata_test.go
@@ -62,7 +62,7 @@ func TestTranslateMetadataLeavesOtherAttributesUnchanged(t *testing.T) {
 	assertAttribute(t, metadata, "three", "three1")
 }
 
-func TestTranslateMetadataOverwritesExistingAttribute(t *testing.T) {
+func TestTranslateMetadataDoesNotOverwriteExistingAttribute(t *testing.T) {
 	metadata := pdata.NewAttributeMap()
 	metadata.InsertString("host", "host1")
 	metadata.InsertString("host.name", "hostname1")
@@ -70,11 +70,11 @@ func TestTranslateMetadataOverwritesExistingAttribute(t *testing.T) {
 
 	translateMetadata(metadata)
 
-	assert.Equal(t, 1, metadata.Len())
-	assertAttribute(t, metadata, "host", "hostname1")
+	assert.Equal(t, 2, metadata.Len())
+	assertAttribute(t, metadata, "host", "host1")
 }
 
-func TestTranslateMetadataOverwritesMultipleExistingAttributes(t *testing.T) {
+func TestTranslateMetadataDoesNotOverwriteMultipleExistingAttributes(t *testing.T) {
 	// Note: Current implementation of pdata.AttributeMap does not allow to insert duplicate keys.
 	// See https://cloud-native.slack.com/archives/C01N5UCHTEH/p1624020829067500
 	metadata := pdata.NewAttributeMap()
@@ -86,8 +86,8 @@ func TestTranslateMetadataOverwritesMultipleExistingAttributes(t *testing.T) {
 
 	translateMetadata(metadata)
 
-	assert.Equal(t, 1, metadata.Len())
-	assertAttribute(t, metadata, "host", "hostname1")
+	assert.Equal(t, 2, metadata.Len())
+	assertAttribute(t, metadata, "host", "host1")
 }
 
 func assertAttribute(t *testing.T, metadata pdata.AttributeMap, attributeName string, expectedValue string) {


### PR DESCRIPTION
User should be able to write it owns attributes (especially _source ones) and we shouldn't overwrite it