### PR TITLE
ci: add lll linter to golangci-lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,6 +17,13 @@ linters-settings:
   unused:
     go: "1.16"
 
+  lll:
+    # max line length, lines longer will be reported. Default is 120.
+    # '\t' is counted as 1 character by default, and can be changed with the tab-width option
+    line-length: 185
+    # tab width in spaces. Default to 1.
+    tab-width: 8
+
 linters:
   disable-all: false
   enable:
@@ -27,6 +34,7 @@ linters:
     - goimports
     - misspell
     - noctx
+    - lll
   disable:
     - maligned
     - prealloc

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ golint:
 .PHONY: install-golint
 install-golangci-lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
-	sh -s -- -b $(shell go env GOPATH)/bin v1.40.1
+	sh -s -- -b $(shell go env GOPATH)/bin v1.41.1
 
 .PHONY: for-all
 for-all:

--- a/pkg/exporter/sumologicexporter/exporter_test.go
+++ b/pkg/exporter/sumologicexporter/exporter_test.go
@@ -414,6 +414,7 @@ func TestAllMetricsOTLP(t *testing.T) {
 	test := prepareExporterTest(t, createTestConfig(), []func(w http.ResponseWriter, req *http.Request){
 		func(w http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
+			//nolint:lll
 			expected := "\nf\n/\n\x14\n\x04test\x12\f\n\ntest_value\n\x17\n\x05test2\x12\x0e\n\fsecond_value\x123\n\x00\x12/\n\x10test.metric.data\x1a\x05bytes2\x14\n\x12\x19\x00\x12\x94\v\xd1\x00H\x16!\xa48\x00\x00\x00\x00\x00\x00\n\xba\x01\n\x0e\n\f\n\x03foo\x12\x05\n\x03bar\x12\xa7\x01\n\x00\x12\xa2\x01\n\x11gauge_metric_name\"\x8c\x01\nD\n\x15\n\vremote_name\x12\x06156920\n\x19\n\x03url\x12\x12http://example_url\x19\x80GX\xef\xdb4Q\x16!|\x00\x00\x00\x00\x00\x00\x00\nD\n\x15\n\vremote_name\x12\x06156955\n\x19\n\x03url\x12\x12http://another_url\x19\x80\x11\xf3*\xdc4Q\x16!\xf5\x00\x00\x00\x00\x00\x00\x00"
 			assert.Equal(t, expected, body)
 			assert.Equal(t, "application/x-protobuf", req.Header.Get("Content-Type"))

--- a/pkg/exporter/sumologicexporter/sender_test.go
+++ b/pkg/exporter/sumologicexporter/sender_test.go
@@ -404,6 +404,7 @@ func TestSendLogsOTLP(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
 		func(w http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
+			//nolint:lll
 			assert.Equal(t, "\n\x80\x01\n\x00\x12|\n\x00\x127*\r\n\vExample log2\x10\n\x04key1\x12\b\n\x06value12\x10\n\x04key2\x12\b\n\x06value2J\x00R\x00\x12?*\x15\n\x13Another example log2\x10\n\x04key1\x12\b\n\x06value12\x10\n\x04key2\x12\b\n\x06value2J\x00R\x00", body)
 			assert.Equal(t, "key1=value, key2=value2", req.Header.Get("X-Sumo-Fields"))
 			assert.Equal(t, "otelcol", req.Header.Get("X-Sumo-Client"))
@@ -811,6 +812,7 @@ func TestSendCarbon2Metrics(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
 		func(w http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
+			//nolint:lll
 			expected := `test=test_value test2=second_value _unit=m/s escape_me=:invalid_ metric=true metric=test.metric.data unit=bytes  14500 1605534165
 foo=bar metric=gauge_metric_name  124 1608124661
 foo=bar metric=gauge_metric_name  245 1608124662`

--- a/pkg/extension/sumologicextension/extension_test.go
+++ b/pkg/extension/sumologicextension/extension_test.go
@@ -79,7 +79,7 @@ func TestBasicStart(t *testing.T) {
 		if req.URL.Path == registerUrl {
 			_, err := w.Write([]byte(`{
 				"collectorCredentialId": "aaaaaaaaaaaaaaaaaaaa",
-				"collectorCredentialKey": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+				"collectorCredentialKey": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
 				"collectorId": "000000000FFFFFFF"
 			}`))
 
@@ -116,7 +116,7 @@ func TestStoreCredentials(t *testing.T) {
 			if req.URL.Path == registerUrl {
 				_, err := w.Write([]byte(`{
 				"collectorCredentialId": "aaaaaaaaaaaaaaaaaaaa",
-				"collectorCredentialKey": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+				"collectorCredentialKey": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
 				"collectorId": "000000000FFFFFFF"
 			}`))
 

--- a/pkg/processor/cascadingfilterprocessor/sampling/always_sample_test.go
+++ b/pkg/processor/cascadingfilterprocessor/sampling/always_sample_test.go
@@ -32,7 +32,10 @@ func newAlwaysSample() *policyEvaluator {
 
 func TestEvaluate_AlwaysSample(t *testing.T) {
 	filter := newAlwaysSample()
-	decision := filter.Evaluate(pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}), newTraceStringAttrs(map[string]pdata.AttributeValue{}, "example", "value"))
+	decision := filter.Evaluate(
+		pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}),
+		newTraceStringAttrs(map[string]pdata.AttributeValue{}, "example", "value"),
+	)
 	assert.Equal(t, decision, Sampled)
 }
 

--- a/pkg/processor/k8sprocessor/client_test.go
+++ b/pkg/processor/k8sprocessor/client_test.go
@@ -41,7 +41,16 @@ func selectors() (labels.Selector, fields.Selector) {
 }
 
 // newFakeClient instantiates a new FakeClient object and satisfies the ClientProvider type
-func newFakeClient(_ *zap.Logger, apiCfg k8sconfig.APIConfig, rules kube.ExtractionRules, filters kube.Filters, associations []kube.Association, _ kube.APIClientsetProvider, _ kube.InformerProvider, _ kube.OwnerProvider) (kube.Client, error) {
+func newFakeClient(
+	_ *zap.Logger,
+	apiCfg k8sconfig.APIConfig,
+	rules kube.ExtractionRules,
+	filters kube.Filters,
+	associations []kube.Association,
+	_ kube.APIClientsetProvider,
+	_ kube.InformerProvider,
+	_ kube.OwnerProvider,
+) (kube.Client, error) {
 	cs := fake.NewSimpleClientset()
 
 	ls, fs := selectors()

--- a/pkg/processor/k8sprocessor/doc.go
+++ b/pkg/processor/k8sprocessor/doc.go
@@ -17,11 +17,13 @@
 // The processor automatically discovers k8s resources (pods), extracts metadata from them and adds the
 // extracted metadata to the relevant spans, metrics and logs. The processor uses the kubernetes API to discover all pods
 // running in a cluster, keeps a record of their IP addresses, pod UIDs and interesting metadata.
-// The rules for associating the data passing through the processor (spans, metrics and logs) with specific Pod Metadata are configured via "pod_association" key.
+// The rules for associating the data passing through the processor (spans, metrics and logs)
+// with specific Pod Metadata are configured via "pod_association" key.
 // It represents a list of rules that are executed in the specified order until the first one is able to do the match.
 // Each rule is specified as a pair of from (representing the rule type) and name (representing the extracted key name).
 // Following rule types are available:
-//   from: "resource_attribute" - allows to specify the attribute name to lookup up in the list of attributes of the received Resource. The specified attribute, if it is present, identifies the Pod that is represented by the Resource.
+//   from: "resource_attribute" - allows to specify the attribute name to lookup up in the list of attributes of the received Resource.
+//     The specified attribute, if it is present, identifies the Pod that is represented by the Resource.
 //     (the value can contain either IP address or Pod UID)
 //   from: "connection" - takes the IP attribute from connection context (if available) and automatically
 //     associates it with "k8s.pod.ip" attribute

--- a/pkg/processor/k8sprocessor/kube/client.go
+++ b/pkg/processor/k8sprocessor/kube/client.go
@@ -58,7 +58,16 @@ type WatchClient struct {
 var dRegex = regexp.MustCompile(`^(.*)-[0-9a-zA-Z]*-[0-9a-zA-Z]*$`)
 
 // New initializes a new k8s Client.
-func New(logger *zap.Logger, apiCfg k8sconfig.APIConfig, rules ExtractionRules, filters Filters, associations []Association, newClientSet APIClientsetProvider, newInformer InformerProvider, newOwnerProviderFunc OwnerProvider) (Client, error) {
+func New(
+	logger *zap.Logger,
+	apiCfg k8sconfig.APIConfig,
+	rules ExtractionRules,
+	filters Filters,
+	associations []Association,
+	newClientSet APIClientsetProvider,
+	newInformer InformerProvider,
+	newOwnerProviderFunc OwnerProvider,
+) (Client, error) {
 	c := &WatchClient{
 		logger:          logger,
 		Rules:           rules,

--- a/pkg/processor/k8sprocessor/processor_test.go
+++ b/pkg/processor/k8sprocessor/processor_test.go
@@ -217,7 +217,16 @@ func TestProcessorBadConfig(t *testing.T) {
 }
 
 func TestProcessorBadClientProvider(t *testing.T) {
-	clientProvider := func(_ *zap.Logger, _ k8sconfig.APIConfig, _ kube.ExtractionRules, _ kube.Filters, _ []kube.Association, _ kube.APIClientsetProvider, _ kube.InformerProvider, _ kube.OwnerProvider) (kube.Client, error) {
+	clientProvider := func(
+		_ *zap.Logger,
+		_ k8sconfig.APIConfig,
+		_ kube.ExtractionRules,
+		_ kube.Filters,
+		_ []kube.Association,
+		_ kube.APIClientsetProvider,
+		_ kube.InformerProvider,
+		_ kube.OwnerProvider,
+	) (kube.Client, error) {
 		return nil, fmt.Errorf("bad client error")
 	}
 

--- a/pkg/processor/sourceprocessor/source_processor.go
+++ b/pkg/processor/sourceprocessor/source_processor.go
@@ -226,9 +226,18 @@ func (stp *sourceTraceProcessor) ConsumeTraces(ctx context.Context, td pdata.Tra
 		stp.fillOtherMeta(atts)
 		filledOtherMeta = true
 
-		filledAnySource = stp.sourceHostFiller.fillResourceOrUseAnnotation(&atts, stp.annotationAttribute(sourceHostSpecialAnnotation), stp.keys) || filledAnySource
-		filledAnySource = stp.sourceCategoryFiller.fillResourceOrUseAnnotation(&atts, stp.annotationAttribute(sourceCategorySpecialAnnotation), stp.keys) || filledAnySource
-		filledAnySource = stp.sourceNameFiller.fillResourceOrUseAnnotation(&atts, stp.annotationAttribute(sourceNameSpecialAnnotation), stp.keys) || filledAnySource
+		filledAnySource = stp.sourceHostFiller.fillResourceOrUseAnnotation(&atts,
+			stp.annotationAttribute(sourceHostSpecialAnnotation),
+			stp.keys,
+		) || filledAnySource
+		filledAnySource = stp.sourceCategoryFiller.fillResourceOrUseAnnotation(&atts,
+			stp.annotationAttribute(sourceCategorySpecialAnnotation),
+			stp.keys,
+		) || filledAnySource
+		filledAnySource = stp.sourceNameFiller.fillResourceOrUseAnnotation(&atts,
+			stp.annotationAttribute(sourceNameSpecialAnnotation),
+			stp.keys,
+		) || filledAnySource
 
 		ilss := rs.InstrumentationLibrarySpans()
 		totalSpans := 0

--- a/pkg/receiver/telegrafreceiver/converter.go
+++ b/pkg/receiver/telegrafreceiver/converter.go
@@ -194,7 +194,7 @@ func newDoubleCounter(key string, value float64, t time.Time, separateField bool
 	pm.SetDataType(pdata.MetricDataTypeDoubleSum)
 	// "[...] OTLP Sum is either translated into a Timeseries Counter, when
 	// the sum is monotonic, or a Gauge when the sum is not monotonic."
-	// https://github.com/open-telemetry/opentelemetry-specification/blob/7fc28733eb3791ebcc98fed0d858a7961f1e95b2/specification/metrics/datamodel.md#opentelemetry-protocol-data-model
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/7fc28733/specification/metrics/datamodel.md#opentelemetry-protocol-data-model
 	ds := pm.DoubleSum()
 	ds.SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
 	ds.SetIsMonotonic(true)
@@ -214,7 +214,7 @@ func newIntCounter(key string, value int64, t time.Time, separateField bool) pda
 	pm.SetDataType(pdata.MetricDataTypeIntSum)
 	// "[...] OTLP Sum is either translated into a Timeseries Counter, when
 	// the sum is monotonic, or a Gauge when the sum is not monotonic."
-	// https://github.com/open-telemetry/opentelemetry-specification/blob/7fc28733eb3791ebcc98fed0d858a7961f1e95b2/specification/metrics/datamodel.md#opentelemetry-protocol-data-model
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/7fc28733/specification/metrics/datamodel.md#opentelemetry-protocol-data-model
 	ds := pm.IntSum()
 	ds.SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
 	ds.SetIsMonotonic(true)


### PR DESCRIPTION
Set conservative limit of line length to 185 (to not include too many changes in the repo).