### PR TITLE
refactor(sumologicextension): rename collector credentials path to directory

### DIFF
--- a/pkg/extension/sumologicextension/README.md
+++ b/pkg/extension/sumologicextension/README.md
@@ -43,8 +43,9 @@ and can be used as an authenticator for the
   (default: `https://collectors.sumologic.com`)
 * `heartbeat_interval`: interval that will be used for sending heartbeats
   (default: `15s`)
-* `collector_credentials_path`: path where registration info will be stored after
-  successful collector registration (default: `$HOME/.sumologic-otel-collector`)
+* `collector_credentials_directory`: directory where state files with registration
+  info will be stored after successful collector registration
+  (default: `$HOME/.sumologic-otel-collector`)
 * `clobber`: defines whether to delete any existing collector with the same name
   and create a new one upon registration (default: `false`)
 * `ephemeral`: defines whether the collector will be deleted after 12 hours

--- a/pkg/extension/sumologicextension/config.go
+++ b/pkg/extension/sumologicextension/config.go
@@ -51,9 +51,10 @@ type Config struct {
 
 	HeartBeatInterval time.Duration `mapstructure:"heartbeat_interval"`
 
-	// CollectorCredentialsPath is the path to directory where collector credentials
-	// are stored. Default value is $HOME/.sumologic-otel-collector
-	CollectorCredentialsPath string `mapstructure:"collector_credentials_path"`
+	// CollectorCredentialsDirectory is the directory where state files
+	// with collector credentials will be stored after successful collector
+	// registration. Default value is $HOME/.sumologic-otel-collector
+	CollectorCredentialsDirectory string `mapstructure:"collector_credentials_directory"`
 
 	// Clobber defines whether to delete any existing collector with the same
 	// name and create a new one upon registration.

--- a/pkg/extension/sumologicextension/credentials.go
+++ b/pkg/extension/sumologicextension/credentials.go
@@ -58,7 +58,7 @@ func (cr credsGetter) CheckCollectorCredentials(key string) bool {
 	if err != nil {
 		return false
 	}
-	path := path.Join(cr.conf.CollectorCredentialsPath, filenameHash)
+	path := path.Join(cr.conf.CollectorCredentialsDirectory, filenameHash)
 	if _, err := os.Stat(path); err != nil {
 		return false
 	}
@@ -73,7 +73,7 @@ func (cr credsGetter) GetStoredCredentials(key string) (CollectorCredentials, er
 		return CollectorCredentials{}, err
 	}
 
-	path := path.Join(cr.conf.CollectorCredentialsPath, filenameHash)
+	path := path.Join(cr.conf.CollectorCredentialsDirectory, filenameHash)
 	creds, err := os.Open(path)
 	if err != nil {
 		return CollectorCredentials{}, err

--- a/pkg/extension/sumologicextension/extension.go
+++ b/pkg/extension/sumologicextension/extension.go
@@ -167,17 +167,17 @@ func (se *SumologicExtension) Shutdown(ctx context.Context) error {
 }
 
 // storeCollectorCredentials stores collector credentials in a file in directory
-// as specified in CollectorCredentialsPath. The credentials are encrypted using
+// as specified in CollectorCredentialsDirectory. The credentials are encrypted using
 // hashed collector name.
 func (se *SumologicExtension) storeCollectorCredentials(credentials CollectorCredentials) error {
-	if err := ensureStoreCredentialsDir(se.conf.CollectorCredentialsPath); err != nil {
+	if err := ensureStoreCredentialsDir(se.conf.CollectorCredentialsDirectory); err != nil {
 		return err
 	}
 	filenameHash, err := hash(se.hashKey)
 	if err != nil {
 		return err
 	}
-	path := path.Join(se.conf.CollectorCredentialsPath, filenameHash)
+	path := path.Join(se.conf.CollectorCredentialsDirectory, filenameHash)
 	collectorCreds, err := json.Marshal(credentials)
 	if err != nil {
 		return err

--- a/pkg/extension/sumologicextension/extension_test.go
+++ b/pkg/extension/sumologicextension/extension_test.go
@@ -154,7 +154,7 @@ func TestStoreCredentials(t *testing.T) {
 
 		srv := getServer()
 		cfg := getConfig(srv.URL)
-		cfg.CollectorCredentialsPath = dir
+		cfg.CollectorCredentialsDirectory = dir
 
 		// Ensure the directory doesn't exist before running the extension
 		require.NoError(t, os.RemoveAll(dir))
@@ -182,7 +182,7 @@ func TestStoreCredentials(t *testing.T) {
 
 		srv := getServer()
 		cfg := getConfig(srv.URL)
-		cfg.CollectorCredentialsPath = dir
+		cfg.CollectorCredentialsDirectory = dir
 
 		// Ensure the directory has 600 permissions
 		require.NoError(t, os.Chmod(dir, 0600))
@@ -210,7 +210,7 @@ func TestStoreCredentials(t *testing.T) {
 
 		srv := getServer()
 		cfg := getConfig(srv.URL)
-		cfg.CollectorCredentialsPath = dir
+		cfg.CollectorCredentialsDirectory = dir
 
 		fi, err := os.Stat(dir)
 		require.NoError(t, err)
@@ -268,7 +268,7 @@ func TestRegisterEmptyCollectorName(t *testing.T) {
 	cfg.ApiBaseUrl = srv.URL
 	cfg.Credentials.AccessID = "dummy_access_id"
 	cfg.Credentials.AccessKey = "dummy_access_key"
-	cfg.CollectorCredentialsPath = dir
+	cfg.CollectorCredentialsDirectory = dir
 
 	se, err := newSumologicExtension(cfg, zap.NewNop())
 	require.NoError(t, err)
@@ -312,7 +312,7 @@ func TestRegisterEmptyCollectorNameClobber(t *testing.T) {
 	cfg.ApiBaseUrl = srv.URL
 	cfg.Credentials.AccessID = "dummy_access_id"
 	cfg.Credentials.AccessKey = "dummy_access_key"
-	cfg.CollectorCredentialsPath = dir
+	cfg.CollectorCredentialsDirectory = dir
 	cfg.Clobber = true
 
 	se, err := newSumologicExtension(cfg, zap.NewNop())

--- a/pkg/extension/sumologicextension/factory.go
+++ b/pkg/extension/sumologicextension/factory.go
@@ -47,13 +47,13 @@ func createDefaultConfig() config.Extension {
 	defaultCredsPath := path.Join(homePath, collectorCredentialsDirectory)
 
 	return &Config{
-		ExtensionSettings:        config.NewExtensionSettings(config.NewID(typeStr)),
-		ApiBaseUrl:               DefaultApiBaseUrl,
-		HeartBeatInterval:        DefaultHeartbeatInterval,
-		CollectorCredentialsPath: defaultCredsPath,
-		Clobber:                  false,
-		Ephemeral:                false,
-		TimeZone:                 "",
+		ExtensionSettings:             config.NewExtensionSettings(config.NewID(typeStr)),
+		ApiBaseUrl:                    DefaultApiBaseUrl,
+		HeartBeatInterval:             DefaultHeartbeatInterval,
+		CollectorCredentialsDirectory: defaultCredsPath,
+		Clobber:                       false,
+		Ephemeral:                     false,
+		TimeZone:                      "",
 	}
 }
 

--- a/pkg/extension/sumologicextension/factory_test.go
+++ b/pkg/extension/sumologicextension/factory_test.go
@@ -34,10 +34,10 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 	require.NoError(t, err)
 	defaultCredsPath := path.Join(homePath, collectorCredentialsDirectory)
 	assert.Equal(t, &Config{
-		ExtensionSettings:        config.NewExtensionSettings(config.NewID(typeStr)),
-		HeartBeatInterval:        DefaultHeartbeatInterval,
-		ApiBaseUrl:               DefaultApiBaseUrl,
-		CollectorCredentialsPath: defaultCredsPath,
+		ExtensionSettings:             config.NewExtensionSettings(config.NewID(typeStr)),
+		HeartBeatInterval:             DefaultHeartbeatInterval,
+		ApiBaseUrl:                    DefaultApiBaseUrl,
+		CollectorCredentialsDirectory: defaultCredsPath,
 	}, cfg)
 
 	assert.NoError(t, configcheck.ValidateConfig(cfg))


### PR DESCRIPTION
After first round of feedback it seems this setting is not obvious hence renaming it from `collector_credentials_path` to `collector_credentials_directory`