### PR TITLE
ci: set CGO_ENABLED to 1 on darwin builds

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -17,7 +17,78 @@ jobs:
         # TODO: add arm64 when fix for
         # https://github.com/golang/go/issues/46766#event-4898300932
         # gets released in next 1.17 beta/rc.
-        arch_os: [ 'darwin_amd64', 'linux_amd64' ]
+        # TODO:
+        # when telegraf dependency gets removed for any reason merge MacOS
+        # builds with other OSes. Until this happens test/build it separately
+        # due to CGO_RELATED cross compilation issues.
+        # Exemplar failed workflow:
+        # https://github.com/SumoLogic/sumologic-otel-collector/runs/2963259368
+        arch_os: [ 'linux_amd64' ]
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+      - name: Fetch current branch
+        run: ./ci/fetch_current_branch.sh
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+          stable: 'false'
+
+      # As described in
+      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
+      - uses: actions/cache@v2
+        with:
+          path: |
+            /home/runner/go/pkg/mod
+            /home/runner/.cache/go-build
+          key: ${{matrix.arch_os}}-go-${{matrix.go}}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{matrix.arch_os}}-go-${{matrix.go}}-
+
+      - name: Install opentelemetry-collector-builder
+        run: make install
+        working-directory: ./otelcolbuilder
+
+      - name: Build
+        run: make otelcol-sumo-${{matrix.arch_os}}
+        working-directory: ./otelcolbuilder
+
+      - name: Show included modules
+        working-directory: ./otelcolbuilder/cmd
+        run: |
+          go version -m otelcol-sumo-${{matrix.arch_os}} | \
+          grep -E "/(receiver|exporter|processor|extension)/" | \
+          tee otelcol-sumo-${{matrix.arch_os}}_modules.txt
+
+      - name: Store binary as action artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: otelcol-sumo-${{matrix.arch_os}}
+          path: ./otelcolbuilder/cmd/otelcol-sumo-${{matrix.arch_os}}
+          if-no-files-found: error
+
+      - name: Store list of included modules as action artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: otelcol-sumo-${{matrix.arch_os}}_modules.txt
+          path: ./otelcolbuilder/cmd/otelcol-sumo-${{matrix.arch_os}}_modules.txt
+          if-no-files-found: error
+
+  build-mac:
+    name: Build
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        go: [ '1.17.0-beta1' ]
+        # TODO:
+        # when telegraf dependency gets removed for any reason merge MacOS
+        # builds with other OSes. Until this happens test/build it separately
+        # due to CGO_RELATED cross compilation issues.
+        # Exemplar failed workflow:
+        # https://github.com/SumoLogic/sumologic-otel-collector/runs/2963259368
+        arch_os: [ 'darwin_amd64' ]
     steps:
       - uses: actions/checkout@v2.3.4
 
@@ -75,6 +146,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
       - build
+      - build-mac
     strategy:
       matrix:
         # TODO: add arm64 when fix for

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -34,7 +34,49 @@ jobs:
     strategy:
       matrix:
         go: [ '1.16.4', '1.17.0-beta1' ]
-        arch_os: [ 'darwin_amd64', 'linux_amd64']
+        # TODO:
+        # when telegraf dependency gets removed for any reason merge MacOS
+        # builds with other OSes. Until this happens test/build it separately
+        # due to CGO_RELATED cross compilation issues.
+        # Exemplar failed workflow:
+        # https://github.com/SumoLogic/sumologic-otel-collector/runs/2963259368
+        arch_os: [ 'linux_amd64' ]
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+          stable: 'false'
+
+      # As described in
+      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
+      - uses: actions/cache@v2
+        with:
+          path: |
+            /home/runner/go/pkg/mod
+            /home/runner/.cache/go-build
+          key: ${{matrix.arch_os}}-go-pkg-${{matrix.go}}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{matrix.arch_os}}-go-pkg-${{matrix.go}}-
+
+      - name: Run tests
+        run: make gotest
+
+  test-mac:
+    name: Test
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        # TODO: Don't test on 1.17.0-beta1 for now due to a strange bug in 1.17
+        # causing SIGSEGV: segmentation violation on darwin when testing
+        # telegrafreceiver.
+        #
+        # Possibly related to https://github.com/golang/go/issues/46080
+        # Failed CI build https://github.com/SumoLogic/sumologic-otel-collector/runs/2972810531
+        go: [ '1.16.4'  ]
+        arch_os: [ 'darwin_amd64' ]
     steps:
       - uses: actions/checkout@v2.3.4
 
@@ -97,7 +139,64 @@ jobs:
     strategy:
       matrix:
         go: [ '1.17.0-beta1' ]
-        arch_os: [ 'darwin_amd64', 'linux_amd64']
+        arch_os: [ 'linux_amd64' ]
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+      - name: Fetch current branch
+        run: ./ci/fetch_current_branch.sh
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+          stable: 'false'
+
+      # As described in
+      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
+      - uses: actions/cache@v2
+        with:
+          path: |
+            /home/runner/go/pkg/mod
+            /home/runner/.cache/go-build
+          key: ${{matrix.arch_os}}-go-${{matrix.go}}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{matrix.arch_os}}-go-${{matrix.go}}-
+
+      - name: Install opentelemetry-collector-builder
+        run: make install
+        working-directory: ./otelcolbuilder
+
+      - name: Build
+        run: make otelcol-sumo-${{matrix.arch_os}}
+        working-directory: ./otelcolbuilder
+
+      - name: Show included modules
+        working-directory: ./otelcolbuilder/cmd
+        run: |
+          go version -m otelcol-sumo-${{matrix.arch_os}} | \
+          grep -E "/(receiver|exporter|processor|extension)/"
+
+      - name: Store binary as action artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: otelcol-sumo-${{matrix.arch_os}}
+          path: ./otelcolbuilder/cmd/otelcol-sumo-${{matrix.arch_os}}
+          if-no-files-found: error
+
+  build-mac:
+    name: Build
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        go: [ '1.17.0-beta1' ]
+        # TODO:
+        # when telegraf dependency gets removed for any reason merge MacOS
+        # builds with other OSes. Until this happens test/build it separately
+        # due to CGO_RELATED cross compilation issues.
+        # Exemplar failed workflow:
+        # https://github.com/SumoLogic/sumologic-otel-collector/runs/2963259368
+        arch_os: [ 'darwin_amd64' ]
     steps:
       - uses: actions/checkout@v2.3.4
 

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -16,7 +16,83 @@ jobs:
     strategy:
       matrix:
         go: [ '1.17.0-beta1' ]
-        arch_os: [ 'darwin_amd64', 'linux_amd64']
+        # TODO:
+        # when telegraf dependency gets removed for any reason merge MacOS
+        # builds with other OSes. Until this happens test/build it separately
+        # due to CGO_RELATED cross compilation issues.
+        # Exemplar failed workflow:
+        # https://github.com/SumoLogic/sumologic-otel-collector/runs/2963259368
+        arch_os: [ 'linux_amd64']
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+      - name: Fetch current branch
+        run: ./ci/fetch_current_branch.sh
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+          stable: 'false'
+
+      # As described in
+      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
+      - uses: actions/cache@v2
+        with:
+          path: |
+            /home/runner/go/pkg/mod
+            /home/runner/.cache/go-build
+          key: ${{matrix.arch_os}}-go-${{matrix.go}}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{matrix.arch_os}}-go-${{matrix.go}}-
+
+      - name: Install opentelemetry-collector-builder
+        run: make install
+        working-directory: ./otelcolbuilder
+
+      - name: Build
+        run: make otelcol-sumo-${{matrix.arch_os}}
+        working-directory: ./otelcolbuilder
+
+      - name: Extract tag
+        id: extract_tag
+        run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/v})"
+
+      - name: Set filename
+        id: set_filename
+        run: echo "::set-output name=filename::$(echo otelcol-sumo-${{ steps.extract_tag.outputs.tag }}-${{matrix.arch_os}})"
+
+      - name: Rename to include tag in filename
+        run: cp otelcol-sumo-${{matrix.arch_os}} ${{ steps.set_filename.outputs.filename }}
+        working-directory: ./otelcolbuilder/cmd
+
+      - name: Show included modules
+        working-directory: ./otelcolbuilder/cmd
+        run: |
+          go version -m ${{ steps.set_filename.outputs.filename }} | \
+          grep -E "/(receiver|exporter|processor|extension)/" | \
+          tee otelcol-sumo-${{matrix.arch_os}}_modules.txt
+
+      - name: Store binary as action artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{matrix.arch_os}}
+          path: ./otelcolbuilder/cmd/${{ steps.set_filename.outputs.filename }}
+          if-no-files-found: error
+
+  build-mac:
+    name: Build
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        go: [ '1.17.0-beta1' ]
+        # TODO:
+        # when telegraf dependency gets removed for any reason merge MacOS
+        # builds with other OSes. Until this happens test/build it separately
+        # due to CGO_RELATED cross compilation issues.
+        # Exemplar failed workflow:
+        # https://github.com/SumoLogic/sumologic-otel-collector/runs/2963259368
+        arch_os: [ 'darwin_amd64' ]
     steps:
       - uses: actions/checkout@v2.3.4
 
@@ -79,6 +155,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
       - build
+      - build-mac
     strategy:
       matrix:
         arch_os: [ 'linux_amd64']
@@ -200,6 +277,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
       - build
+      - build-mac
       - build-container-images
       - push-docker-manifest
     steps:

--- a/otelcolbuilder/Makefile
+++ b/otelcolbuilder/Makefile
@@ -6,6 +6,21 @@ BUILDER_BIN_PATH ?= ${HOME}/bin/opentelemetry-collector-builder
 VERSION ?= "$(shell git describe --tags --abbrev=10)"
 GO ?= go
 
+# Builds for darwin need to be built with CGO_ENABLED set to 1 because some telegraf
+# plugins that are used within the telegrafreceiver are implemented with CGO.
+# Example of this might be the cpu input plugin using gopsutil to the cpu stats.
+#
+# https://github.com/shirou/gopsutil/blob/7ea80628/cpu/cpu_darwin_nocgo.go
+# https://github.com/shirou/gopsutil/blob/7ea80628/cpu/cpu_darwin.go
+ifeq ($(shell go env GOOS),darwin)
+CGO_ENABLED ?= 1
+else
+# CGO_ENABLED=0 is used becuase we don't want to rely on c libs and opentelemetry
+# also builds their binaries this way.
+# ref: https://github.com/open-telemetry/opentelemetry-collector/blob/4c503ddc/Makefile#L254-L256
+CGO_ENABLED ?= 0
+endif
+
 .PHONY: install
 install:
 	go install ${BUILDER_REPO}@v$(BUILDER_VERSION)
@@ -32,11 +47,7 @@ install-bin-darwin:
 build:
 # Need to specify go path because otherwise opentelemetry-collector-builder
 # uses /usr/bin/go which on Github Actions is using preinstalled 1.15.12 by default.
-# 
-# CGO_ENABLED=0 is used becuase we don't want to rely on c libs and opentelemetry
-# also builds their binaries this way.
-# ref: https://github.com/open-telemetry/opentelemetry-collector/blob/4c503ddc16aab9cf725b9e780cbdcf140a3dde52/Makefile#L254-L256
-	CGO_ENABLED=0 opentelemetry-collector-builder \
+	CGO_ENABLED=${CGO_ENABLED} opentelemetry-collector-builder \
 		--go ${GO} \
 		--version ${VERSION} \
 		--config .otelcol-builder.yaml \


### PR DESCRIPTION
Builds for darwin need to be built with CGO_ENABLED set to 1 because some telegraf plugins that are used within the telegrafreceiver are implemented with CGO.
Example of this might be the cpu input plugin using gopsutil to the cpu stats.

https://github.com/shirou/gopsutil/blob/7ea80628/cpu/cpu_darwin_nocgo.go
https://github.com/shirou/gopsutil/blob/7ea80628/cpu/cpu_darwin.go

Without this user will see the following error from the telegraf agent:

```
2021/07/01 15:41:45 E! [inputs.cpu] Error in plugin: error getting CPU info: not implemented yet
```

---

Additionally don't cross compile darwin builds on linux but just use Mac runners on github. See this failed build for an example: https://github.com/SumoLogic/sumologic-otel-collector/runs/2963259368