### PR TITLE
ci: don't use go1.17-beta1 for builds

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -13,7 +13,9 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.17.0-beta1' ]
+        # TODO: When [1] gets resolved use 1.17 for builds on darwin again.
+        # [1]: https://github.com/golang/go/issues/46080#issuecomment-864265977 
+        go: [ '1.16.5' ]
         # TODO: add arm64 when fix for
         # https://github.com/golang/go/issues/46766#event-4898300932
         # gets released in next 1.17 beta/rc.
@@ -81,7 +83,9 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        go: [ '1.17.0-beta1' ]
+        # TODO: When [1] gets resolved use 1.17 for builds on darwin again.
+        # [1]: https://github.com/golang/go/issues/46080#issuecomment-864265977 
+        go: [ '1.16.5' ]
         # TODO:
         # when telegraf dependency gets removed for any reason merge MacOS
         # builds with other OSes. Until this happens test/build it separately

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.16.4', '1.17.0-beta1' ]
+        go: [ '1.16.5', '1.17.0-beta1' ]
         # TODO:
         # when telegraf dependency gets removed for any reason merge MacOS
         # builds with other OSes. Until this happens test/build it separately
@@ -75,7 +75,7 @@ jobs:
         #
         # Possibly related to https://github.com/golang/go/issues/46080
         # Failed CI build https://github.com/SumoLogic/sumologic-otel-collector/runs/2972810531
-        go: [ '1.16.4'  ]
+        go: [ '1.16.5' ]
         arch_os: [ 'darwin_amd64' ]
     steps:
       - uses: actions/checkout@v2.3.4
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.16.4', '1.17.0-beta1' ]
+        go: [ '1.16.5', '1.17.0-beta1' ]
         arch_os: [ 'linux_amd64' ]
     steps:
       - uses: actions/checkout@v2.3.4
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.17.0-beta1' ]
+        go: [ '1.16.5', '1.17.0-beta1' ]
         arch_os: [ 'linux_amd64' ]
     steps:
       - uses: actions/checkout@v2.3.4
@@ -189,7 +189,9 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        go: [ '1.17.0-beta1' ]
+        # TODO: When [1] gets resolved use 1.17 for builds on darwin again.
+        # [1]: https://github.com/golang/go/issues/46080#issuecomment-864265977 
+        go: [ '1.16.5' ]
         # TODO:
         # when telegraf dependency gets removed for any reason merge MacOS
         # builds with other OSes. Until this happens test/build it separately

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.17.0-beta1' ]
+        # TODO: When [1] gets resolved use 1.17 for builds on darwin again.
+        # [1]: https://github.com/golang/go/issues/46080#issuecomment-864265977 
+        go: [ '1.16.5' ]
         # TODO:
         # when telegraf dependency gets removed for any reason merge MacOS
         # builds with other OSes. Until this happens test/build it separately
@@ -85,7 +87,9 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        go: [ '1.17.0-beta1' ]
+        # TODO: When [1] gets resolved use 1.17 for builds on darwin again.
+        # [1]: https://github.com/golang/go/issues/46080#issuecomment-864265977 
+        go: [ '1.16.5' ]
         # TODO:
         # when telegraf dependency gets removed for any reason merge MacOS
         # builds with other OSes. Until this happens test/build it separately


### PR DESCRIPTION
Due to a [beta toolchain bug](https://github.com/golang/go/issues/46080#issuecomment-864265977) don't use go1.17-beta1 for darwin builds, tests and release binaries (to release for all OSes using the same toolchain).