### PR TITLE
refactor: use klauspost/compress for compression

### DIFF
--- a/pkg/exporter/sumologicexporter/compress.go
+++ b/pkg/exporter/sumologicexporter/compress.go
@@ -16,11 +16,12 @@ package sumologicexporter
 
 import (
 	"bytes"
-	"compress/flate"
-	"compress/gzip"
 	"fmt"
 	"io"
 	"io/ioutil"
+
+	"github.com/klauspost/compress/flate"
+	"github.com/klauspost/compress/gzip"
 )
 
 type compressor struct {
@@ -34,7 +35,7 @@ type encoder interface {
 	Reset(dst io.Writer)
 }
 
-// newCompressor takes encoding format and returns compressor struct and error eventually
+// newCompressor takes encoding format and returns the compressor and an error.
 func newCompressor(format CompressEncodingType) (compressor, error) {
 	var (
 		writer encoder

--- a/pkg/exporter/sumologicexporter/go.mod
+++ b/pkg/exporter/sumologicexporter/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumolo
 go 1.15
 
 require (
+	github.com/klauspost/compress v1.13.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector v0.26.1-0.20210513162346-453d1d0dd603

--- a/pkg/exporter/sumologicexporter/go.sum
+++ b/pkg/exporter/sumologicexporter/go.sum
@@ -654,8 +654,9 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.4.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.9.5/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
-github.com/klauspost/compress v1.12.2 h1:2KCfW3I9M7nSc5wOqXAlW2v2U6v+w6cbjvbfp+OykW8=
 github.com/klauspost/compress v1.12.2/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
+github.com/klauspost/compress v1.13.1 h1:wXr2uRxZTJXHLly6qhJabee5JqIhTRoLBhDOA74hDEQ=
+github.com/klauspost/compress v1.13.1/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/crc32 v0.0.0-20161016154125-cb6bfca970f6/go.mod h1:+ZoRqAPRLkC4NPOvfYeR5KNOrY6TD+/sAC3HXPZgDYg=
 github.com/klauspost/pgzip v1.0.2-0.20170402124221-0bf5dcad4ada/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=


### PR DESCRIPTION
Use more performant optimized packages for compression: [github.com/klauspost/compress](https://github.com/klauspost/compress)

Benchmark results:

old:

```
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkCompression
BenchmarkCompression/deflate
BenchmarkCompression/deflate-16                   203900             17899 ns/op           86267 B/op         20 allocs/op
BenchmarkCompression/gzip
BenchmarkCompression/gzip-16                      175705             20847 ns/op           87679 B/op         22 allocs/op
PASS
ok      github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter    31.009s
Execution time: 0h:00m:32s sec                                                                                                                                                                                                                                
```

new:
```
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkCompression
BenchmarkCompression/deflate
BenchmarkCompression/deflate-16                   140374             26205 ns/op           86265 B/op         20 allocs/op
BenchmarkCompression/gzip
BenchmarkCompression/gzip-16                       48931             68006 ns/op           87689 B/op         22 allocs/op
PASS
ok      github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter    20.145s
```

benchstat:

```                                            
name                    old time/op    new time/op    delta
Compression/deflate-16    26.2µs ± 0%    17.9µs ± 0%  -31.70%
Compression/gzip-16       68.0µs ± 0%    20.8µs ± 0%  -69.35%

name                    old alloc/op   new alloc/op   delta
Compression/deflate-16    86.3kB ± 0%    86.3kB ± 0%   +0.00%
Compression/gzip-16       87.7kB ± 0%    87.7kB ± 0%   -0.01%

name                    old allocs/op  new allocs/op  delta
Compression/deflate-16      20.0 ± 0%      20.0 ± 0%    0.00%
Compression/gzip-16         22.0 ± 0%      22.0 ± 0%    0.00%
```