### PR TITLE
fix(telegrafreceiver): use correct context when consuming metrics

### DIFF
--- a/pkg/receiver/telegrafreceiver/receiver.go
+++ b/pkg/receiver/telegrafreceiver/receiver.go
@@ -64,7 +64,7 @@ func (r *telegrafreceiver) Start(ctx context.Context, host component.Host) error
 		ch := make(chan telegraf.Metric)
 		go func() {
 			if rErr := r.agent.RunWithChannel(rctx, ch); rErr != nil {
-				r.logger.Error("Problem starting receiver: %v", zap.Error(rErr))
+				r.logger.Error("Problem starting receiver", zap.Error(rErr))
 			}
 		}()
 
@@ -96,7 +96,7 @@ func (r *telegrafreceiver) Start(ctx context.Context, host component.Host) error
 						continue
 					}
 
-					if fErr = r.consumer.ConsumeMetrics(ctx, ms); fErr != nil {
+					if fErr = r.consumer.ConsumeMetrics(rctx, ms); fErr != nil {
 						r.logger.Error("ConsumeMetrics() error",
 							zap.String("error", fErr.Error()),
 						)


### PR DESCRIPTION
Use context which is connected to `cancel` stored in the receiver struct so that calls to `Shutdown` actually cancel the context used for consuming metrics.