### PR TITLE
sumologicextension: don't allocate timer on every heartbeat

### DIFF
--- a/pkg/extension/sumologicextension/extension.go
+++ b/pkg/extension/sumologicextension/extension.go
@@ -236,11 +236,12 @@ func (se *SumologicExtension) heartbeatLoop() {
 		cancel()
 	}()
 
-	se.logger.Info("Heartbeat heartbeat API initialized. Starting sending hearbeat requests")
+	se.logger.Info("Heartbeat API initialized. Starting sending hearbeat requests")
+	timer := time.NewTimer(se.conf.HeartBeatInterval)
 	for {
 		select {
 		case <-se.closeChan:
-			se.logger.Info("Heartbeat sender turn off")
+			se.logger.Info("Heartbeat sender turned off")
 			return
 		default:
 			if err := se.sendHeartbeat(ctx); err != nil {
@@ -250,9 +251,12 @@ func (se *SumologicExtension) heartbeatLoop() {
 			}
 
 			select {
-			case <-time.After(se.conf.HeartBeatInterval):
+			case <-timer.C:
+				timer.Stop()
+				timer.Reset(se.conf.HeartBeatInterval)
 			case <-se.closeChan:
 			}
+
 		}
 	}
 }


### PR DESCRIPTION
`time.After` allocates a new timer on every call. Avoid that by reusing timer.

```go
package main

import (
	"sync/atomic"
	"testing"
	"time"
)

const period = time.Nanosecond

func BenchmarkAfter(b *testing.B) {
	for i := 0; i < b.N; i++ {
		select {
		case <-time.After(period):
		}
	}
}

func BenchmarkStopResetOnlyAfterTick(b *testing.B) {
	timer := time.NewTimer(period)
	for i := 0; i < b.N; i++ {
		select {
		case <-timer.C:
			timer.Stop()
			timer.Reset(period)
		}

	}
}
```

```
goos: darwin
goarch: amd64
pkg: timer
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkAfter
BenchmarkAfter-16                                4462508               790.0 ns/op           200 B/op          3 allocs/op
BenchmarkStopResetOnlyAfterTick
BenchmarkStopResetOnlyAfterTick-16               6640293               550.2 ns/op             0 B/op          0 allocs/op
```