### PR TITLE
fix(sumologicexporter): do not use sumologic extension if endpoint is set

### DIFF
--- a/pkg/exporter/sumologicexporter/exporter.go
+++ b/pkg/exporter/sumologicexporter/exporter.go
@@ -478,6 +478,12 @@ func (se *sumologicexporter) start(ctx context.Context, host component.Host) err
 		se.dataUrlLogs = httpSettings.Endpoint
 		se.dataUrlMetrics = httpSettings.Endpoint
 		se.dataUrlTraces = httpSettings.Endpoint
+
+		// Clean authenticator if set to sumologic.
+		// Setting to null in configuration doesn't work, so we have to force it that way.
+		if httpSettings.Auth != nil && strings.HasPrefix(httpSettings.Auth.AuthenticatorName, "sumologic") {
+			httpSettings.Auth = nil
+		}
 	} else {
 		return fmt.Errorf("no auth extension and no endpoint specified")
 	}


### PR DESCRIPTION
Setting `auth: null`, or `auth.authenticator: null` in configiuration doesn't clear the authenticator configuration. In order to that we have to do it in code