### PR TITLE
chore: bump telegraf to v1.19.0-sumo-2 to add carbon2 parser

### DIFF
--- a/otelcolbuilder/.otelcol-builder.yaml
+++ b/otelcolbuilder/.otelcol-builder.yaml
@@ -67,7 +67,7 @@ replaces:
   # ----------------------------------------------------------------------------
   # Customized receivers
   - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/telegrafreceiver => ./../../pkg/receiver/telegrafreceiver
-  - github.com/influxdata/telegraf => github.com/sumologic/telegraf v1.19.0-sumo-1
+  - github.com/influxdata/telegraf => github.com/sumologic/telegraf v1.19.0-sumo-2
 
   # ----------------------------------------------------------------------------
   # Customized exporters


### PR DESCRIPTION
Use https://github.com/SumoLogic/telegraf/releases/tag/v1.19.0-sumo-2 in order to add carbon2 parser