### PR TITLE
feat(k8sprocessor): support metadata enrichment for pod.namespace identifier

### DIFF
--- a/pkg/processor/k8sprocessor/doc.go
+++ b/pkg/processor/k8sprocessor/doc.go
@@ -24,9 +24,12 @@
 // Following rule types are available:
 //   from: "resource_attribute" - allows to specify the attribute name to lookup up in the list of attributes of the received Resource.
 //     The specified attribute, if it is present, identifies the Pod that is represented by the Resource.
-//     (the value can contain either IP address or Pod UID)
+//     (the value can contain either IP address, Pod UID or be in `pod_name.namespace_name` format).
+//     For `pod_name.namespace_name` format, always attributes for actual matching pod will be added.
 //   from: "connection" - takes the IP attribute from connection context (if available) and automatically
 //     associates it with "k8s.pod.ip" attribute
+//   from: "build_hostname" - build hostname from k8s.pod.name concatenated with k8s.namespace.name using dot as separator
+//     and proceed as for `pod_name.namespace_name` format for `resource_attributes` pod_association.
 // Pod association configuration.
 // pod_association:
 //  - from: resource_attribute

--- a/pkg/processor/k8sprocessor/kube/client.go
+++ b/pkg/processor/k8sprocessor/kube/client.go
@@ -412,6 +412,10 @@ func (c *WatchClient) addOrUpdatePod(pod *api_v1.Pod) {
 		}
 		c.Pods[PodIdentifier(pod.Status.PodIP)] = newPod
 	}
+	// Use pod_name.namespace_name identifier
+	if newPod.Name != "" && newPod.Attributes[c.Rules.Tags.Namespace] != "" {
+		c.Pods[PodIdentifier(fmt.Sprintf("%s.%s", newPod.Name, newPod.Attributes[c.Rules.Tags.Namespace]))] = newPod
+	}
 }
 
 func (c *WatchClient) forgetPod(pod *api_v1.Pod) {

--- a/pkg/processor/k8sprocessor/kube/client_test.go
+++ b/pkg/processor/k8sprocessor/kube/client_test.go
@@ -330,6 +330,41 @@ func TestGetIgnoredPod(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestGetPod(t *testing.T) {
+	c, _ := newTestClient(t)
+
+	c.Rules.Namespace = true
+	c.Rules.Tags.Namespace = "namespace"
+
+	pod := &api_v1.Pod{}
+	pod.Status.PodIP = "1.1.1.1"
+	pod.UID = "1234"
+	pod.Name = "pod_name"
+	pod.Namespace = "namespace_name"
+	c.handlePodAdd(pod)
+
+	expected := &Pod{
+		Name:    "pod_name",
+		Address: "1.1.1.1",
+		PodUID:  "1234",
+		Attributes: map[string]string{
+			"namespace": "namespace_name",
+		},
+	}
+
+	got, ok := c.GetPod(PodIdentifier("1.1.1.1"))
+	assert.Equal(t, got, expected)
+	assert.True(t, ok)
+
+	got, ok = c.GetPod(PodIdentifier("1234"))
+	assert.Equal(t, got, expected)
+	assert.True(t, ok)
+
+	got, ok = c.GetPod(PodIdentifier("pod_name.namespace_name"))
+	assert.Equal(t, got, expected)
+	assert.True(t, ok)
+}
+
 func TestHandlerWrongType(t *testing.T) {
 	c, logs := newTestClientWithRulesAndFilters(t, ExtractionRules{}, Filters{})
 	assert.Equal(t, logs.Len(), 0)

--- a/pkg/processor/k8sprocessor/processor.go
+++ b/pkg/processor/k8sprocessor/processor.go
@@ -102,10 +102,14 @@ func (kp *kubernetesprocessor) ProcessLogs(ctx context.Context, ld pdata.Logs) (
 func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pdata.Resource) {
 
 	podIdentifierKey, podIdentifierValue := extractPodID(ctx, resource.Attributes(), kp.podAssociations)
-	if podIdentifierKey == "" {
+	if podIdentifierValue == "" {
 		return
 	}
-	resource.Attributes().InsertString(podIdentifierKey, string(podIdentifierValue))
+
+	if podIdentifierKey != "" {
+		resource.Attributes().InsertString(podIdentifierKey, string(podIdentifierValue))
+	}
+
 	if kp.passthroughMode {
 		return
 	}


### PR DESCRIPTION
sync with https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/4310 ba01b0758

plus minor fixes in `doc.go`

Signed-off-by: Dominik Rosiek <drosiek@sumologic.com>