### PR TITLE
Add backoff mechanism to registration call

### DIFF
--- a/pkg/extension/sumologicextension/README.md
+++ b/pkg/extension/sumologicextension/README.md
@@ -53,6 +53,11 @@ and can be used as an authenticator for the
 * `time_zone`: defines the time zone of the collector. For a list of all possible
   values, refer to the `TZ` column in
   https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
+* `backoff`: defines backoff mechanism for retry in case of failed registration.
+  [Exponential algorithm](https://pkg.go.dev/github.com/cenkalti/backoff/v4#ExponentialBackOff) is being used.
+  * `initial_interval` - initial interval of backoff (default: `500ms`)
+  * `max_interval` - maximum interval of backoff (default: `1m`)
+  * `max_elapsed_time` - time after which registration fails definitely (default: `15m`)
 
 [credentials_help]: https://help.sumologic.com/Manage/Security/Access-Keys
 [fields_help]: https://help.sumologic.com/Manage/Fields

--- a/pkg/extension/sumologicextension/config.go
+++ b/pkg/extension/sumologicextension/config.go
@@ -70,9 +70,22 @@ type Config struct {
 	// For a list of possible values, refer to the "TZ" column in
 	// https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List.
 	TimeZone string `mapstructure:"time_zone"`
+
+	// BackOff defines configuration of collector registration backoff algorithm
+	// Exponential algorithm is being used.
+	// Please see following link for details: https://github.com/cenkalti/backoff
+	BackOff backOffConfig `mapstructure:"backoff"`
 }
 
 type credentials struct {
 	AccessID  string `mapstructure:"access_id"`
 	AccessKey string `mapstructure:"access_key"`
+}
+
+// backOff configuration. See following link for details:
+// https://pkg.go.dev/github.com/cenkalti/backoff/v4#ExponentialBackOff
+type backOffConfig struct {
+	InitialInterval time.Duration `mapstructure:"initial_interval"`
+	MaxInterval     time.Duration `mapstructure:"max_interval"`
+	MaxElapsedTime  time.Duration `mapstructure:"max_elapsed_time"`
 }

--- a/pkg/extension/sumologicextension/extension_test.go
+++ b/pkg/extension/sumologicextension/extension_test.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/api"
 	"github.com/stretchr/testify/assert"
@@ -632,4 +633,83 @@ func TestCollectorCheckingCredentialsFoundInLocalStorage(t *testing.T) {
 		})
 	}
 
+}
+
+func TestRegisterEmptyCollectorNameWithBackoff(t *testing.T) {
+	var retriesLimit int32 = 5
+	t.Parallel()
+
+	hostname, err := os.Hostname()
+	require.NoError(t, err)
+	srv := httptest.NewServer(func() http.HandlerFunc {
+		var reqCount int32
+
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			// TODO Add payload verification - verify if collectorName is set properly
+			reqNum := atomic.AddInt32(&reqCount, 1)
+
+			switch true {
+
+			// register
+			case reqNum <= retriesLimit:
+				require.Equal(t, registerUrl, req.URL.Path)
+
+				authHeader := req.Header.Get("Authorization")
+				token := base64.StdEncoding.EncodeToString(
+					[]byte("dummy_access_id:dummy_access_key"),
+				)
+				assert.Equal(t, "Basic "+token, authHeader,
+					"collector didn't send correct Authorization header with registration request")
+
+				if reqCount < retriesLimit {
+					w.WriteHeader(http.StatusNotFound)
+				} else {
+
+					_, err := w.Write([]byte(`{
+						"collectorCredentialId": "aaaaaaaaaaaaaaaaaaaa",
+						"collectorCredentialKey": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+						"collectorId": "000000000FFFFFFF"
+					}`))
+
+					if err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+					}
+				}
+
+			// heartbeat
+			case reqNum == retriesLimit+1:
+				assert.Equal(t, heartbeatUrl, req.URL.Path)
+				w.WriteHeader(204)
+
+			// should not produce any more requests
+			default:
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		})
+	}())
+
+	dir, err := os.MkdirTemp("", "otelcol-sumo-store-credentials-test-*")
+	t.Cleanup(func() {
+		srv.Close()
+		os.RemoveAll(dir)
+	})
+	require.NoError(t, err)
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.CollectorName = ""
+	cfg.ExtensionSettings = config.ExtensionSettings{}
+	cfg.ApiBaseUrl = srv.URL
+	cfg.Credentials.AccessID = "dummy_access_id"
+	cfg.Credentials.AccessKey = "dummy_access_key"
+	cfg.CollectorCredentialsDirectory = dir
+	cfg.BackOff.InitialInterval = time.Millisecond
+	cfg.BackOff.MaxInterval = time.Millisecond
+
+	se, err := newSumologicExtension(cfg, zap.NewNop())
+	require.NoError(t, err)
+	require.NoError(t, se.Start(context.Background(), componenttest.NewNopHost()))
+	regexPattern := fmt.Sprintf("%s-%s", hostname, uuidRegex)
+	matched, err := regexp.MatchString(regexPattern, se.collectorName)
+	require.NoError(t, err)
+	assert.True(t, matched)
 }

--- a/pkg/extension/sumologicextension/factory.go
+++ b/pkg/extension/sumologicextension/factory.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/cenkalti/backoff"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/extension/extensionhelper"
@@ -54,6 +55,11 @@ func createDefaultConfig() config.Extension {
 		Clobber:                       false,
 		Ephemeral:                     false,
 		TimeZone:                      "",
+		BackOff: backOffConfig{
+			InitialInterval: backoff.DefaultInitialInterval,
+			MaxInterval:     backoff.DefaultMaxInterval,
+			MaxElapsedTime:  backoff.DefaultMaxElapsedTime,
+		},
 	}
 }
 

--- a/pkg/extension/sumologicextension/factory_test.go
+++ b/pkg/extension/sumologicextension/factory_test.go
@@ -20,6 +20,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
@@ -38,6 +39,11 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 		HeartBeatInterval:             DefaultHeartbeatInterval,
 		ApiBaseUrl:                    DefaultApiBaseUrl,
 		CollectorCredentialsDirectory: defaultCredsPath,
+		BackOff: backOffConfig{
+			InitialInterval: backoff.DefaultInitialInterval,
+			MaxInterval:     backoff.DefaultMaxInterval,
+			MaxElapsedTime:  backoff.DefaultMaxElapsedTime,
+		},
 	}, cfg)
 
 	assert.NoError(t, configcheck.ValidateConfig(cfg))

--- a/pkg/extension/sumologicextension/go.mod
+++ b/pkg/extension/sumologicextension/go.mod
@@ -3,6 +3,8 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumol
 go 1.14
 
 require (
+	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect
 	github.com/mattn/go-colorable v0.1.7 // indirect


### PR DESCRIPTION
```
vagrant@sumologic-otel-collector:/sumologic/otelcolbuilder$ make build && ./cmd/otelcol-sumo --config /sumologic/tmp/config.yaml
CGO_ENABLED=0 opentelemetry-collector-builder \
        --go go \
        --version "v0.0.18-1-g61795eede9" \
        --config .otelcol-builder.yaml \
        --output-path ./cmd \
        --name otelcol-sumo
2021-08-10T08:27:52.255Z        INFO    cmd/root.go:99  OpenTelemetry Collector distribution builder    {"version": "0.29.0", "date": "2021-06-25T14:36:50Z"}
2021-08-10T08:27:52.256Z        INFO    cmd/root.go:115 Using config file       {"path": ".otelcol-builder.yaml"}
2021-08-10T08:27:52.256Z        INFO    builder/main.go:55      You're building a distribution with non-aligned version of the builder. Compilation may fail due to API changes. Please upgrade your builder or API        {"builder-version": "0.29.0"}
2021-08-10T08:27:52.272Z        INFO    builder/main.go:90      Sources created {"path": "./cmd"}
2021-08-10T08:27:52.313Z        INFO    builder/main.go:126     Getting go modules
2021-08-10T08:27:52.683Z        INFO    builder/main.go:107     Compiling
2021-08-10T08:27:53.776Z        INFO    builder/main.go:113     Compiled        {"binary": "./cmd/otelcol-sumo"}
chmod +x ./cmd/otelcol-sumo
2021-08-10T08:27:53.907Z        info    service/collector.go:296        Starting otelcol-sumo...        {"Version": "v0.0.18-1-g61795eede9", "NumCPU": 8}
2021-08-10T08:27:53.907Z        info    service/collector.go:235        Loading configuration...
2021-08-10T08:27:53.909Z        info    service/collector.go:251        Applying configuration...
2021-08-10T08:27:53.912Z        info    builder/exporters_builder.go:264        Exporter was built.     {"kind": "exporter", "name": "sumologic"}
2021-08-10T08:27:53.912Z        info    builder/pipelines_builder.go:214        Pipeline was built.     {"pipeline_name": "logs", "pipeline_datatype": "logs"}
2021-08-10T08:27:53.918Z        info    builder/receivers_builder.go:227        Receiver was built.     {"kind": "receiver", "name": "filelog", "datatype": "logs"}
2021-08-10T08:27:53.918Z        info    service/service.go:143  Starting extensions...
2021-08-10T08:27:53.918Z        info    builder/extensions_builder.go:54        Extension is starting...        {"kind": "extension", "name": "sumologic"}
2021-08-10T08:27:53.918Z        info    sumologicextension@v0.31.0/extension.go:213     Locally stored credentials not found, registering the collector {"kind": "extension", "name": "sumologic"}
2021-08-10T08:27:53.919Z        info    sumologicextension@v0.31.0/extension.go:270     Calling register API    {"kind": "extension", "name": "sumologic", "URL": "https://collectors.sumologic.com/api/v1/collector/register"}
2021-08-10T08:27:54.699Z        warn    sumologicextension@v0.31.0/extension.go:331     Collector registration failed:  {"kind": "extension", "name": "sumologic", "error": "failed to register the collector, got HTTP status code: 401"}
2021-08-10T08:27:55.365Z        warn    sumologicextension@v0.31.0/extension.go:331     Collector registration failed:  {"kind": "extension", "name": "sumologic", "error": "failed to register the collector, got HTTP status code: 400"}
2021-08-10T08:27:57.046Z        warn    sumologicextension@v0.31.0/extension.go:331     Collector registration failed:  {"kind": "extension", "name": "sumologic", "error": "failed to register the collector, got HTTP status code: 400"}
2021-08-10T08:27:59.300Z        warn    sumologicextension@v0.31.0/extension.go:331     Collector registration failed:  {"kind": "extension", "name": "sumologic", "error": "failed to register the collector, got HTTP status code: 400"}

2021-08-10T08:28:11.599Z        warn    sumologicextension@v0.31.0/extension.go:331     Collector registration failed:  {"kind": "extension", "name": "sumologic", "error": "failed to register the collector, got HTTP status code: 400"}

2021-08-10T08:28:29.507Z        warn    sumologicextension@v0.31.0/extension.go:331     Collector registration failed:  {"kind": "extension", "name": "sumologic", "error": "failed to register the collector, got HTTP status code: 400"}
2021-08-10T08:28:56.642Z        warn    sumologicextension@v0.31.0/extension.go:331     Collector registration failed:  {"kind": "extension", "name": "sumologic", "error": "failed to register the collector, got HTTP status code: 400"}
2021-08-10T08:30:17.947Z        warn    sumologicextension@v0.31.0/extension.go:331     Collector registration failed:  {"kind": "extension", "name": "sumologic", "error": "failed to register the collector, got HTTP status code: 400"}
2021-08-10T08:31:00.648Z        warn    sumologicextension@v0.31.0/extension.go:331     Collector registration failed:  {"kind": "extension", "name": "sumologic", "error": "failed to register the collector, got HTTP status code: 400"}
2021-08-10T08:32:18.062Z        warn    sumologicextension@v0.31.0/extension.go:331     Collector registration failed:  {"kind": "extension", "name": "sumologic", "error": "failed to register the collector, got HTTP status code: 400"}
2021-08-10T08:33:33.454Z        warn    sumologicextension@v0.31.0/extension.go:331     Collector registration failed:  {"kind": "extension", "name": "sumologic", "error": "failed to register the collector, got HTTP status code: 400"}
2021-08-10T08:34:13.466Z        warn    sumologicextension@v0.31.0/extension.go:331     Collector registration failed:  {"kind": "extension", "name": "sumologic", "error": "failed to register the collector, got HTTP status code: 400"}
```