### PR TITLE
feat(sumologicexporter): add clear_logs_timestamp option

### DIFF
--- a/pkg/exporter/sumologicexporter/README.md
+++ b/pkg/exporter/sumologicexporter/README.md
@@ -33,6 +33,12 @@ exporters:
     # maximum connection timeout is 55s, default = 5s
     timeout: <timeout>
 
+    # defines if timestamp for logs should be set to 0,
+    # it indicates that backend will extract timestamp from logs,
+    # this option affects OTLP format only
+    # default = true
+    clear_logs_timestamp: {true, false}
+
     # For below described source and graphite template related configuration,
     # please refer to "Source templates" documentation chapter from this document.
 

--- a/pkg/exporter/sumologicexporter/config.go
+++ b/pkg/exporter/sumologicexporter/config.go
@@ -83,6 +83,12 @@ type Config struct {
 	SourceHost string `mapstructure:"source_host"`
 	// Name of the client
 	Client string `mapstructure:"client"`
+
+	// ClearTimestamp defines if timestamp for logs should be set to 0.
+	// It indicates that backend will extract timestamp from logs.
+	// This option affects OTLP format only.
+	// By default this is true.
+	ClearLogsTimestamp bool `mapstructure:"clear_logs_timestamp"`
 }
 
 // CreateDefaultHTTPClientSettings returns default http client settings
@@ -165,4 +171,6 @@ const (
 	DefaultTranslateAttributes bool = true
 	// DefaultTranslateTelegrafMetrics defines default TranslateTelegrafMetrics
 	DefaultTranslateTelegrafMetrics bool = true
+	// DefaultClearTimestamp defines default ClearLogsTimestamp value
+	DefaultClearLogsTimestamp bool = true
 )

--- a/pkg/exporter/sumologicexporter/sender.go
+++ b/pkg/exporter/sumologicexporter/sender.go
@@ -274,7 +274,13 @@ func (s *sender) sendOTLPLogs(ctx context.Context, flds fields) ([]pdata.LogReco
 	logs := ill.Logs()
 	logs.EnsureCapacity(len(s.logBuffer))
 	for _, record := range s.logBuffer {
-		record.CopyTo(logs.AppendEmpty())
+		log := logs.AppendEmpty()
+		record.CopyTo(log)
+
+		// Clear timestamp if required
+		if s.config.ClearLogsTimestamp {
+			log.SetTimestamp(0)
+		}
 	}
 
 	s.addResourceAttributes(rl.Resource().Attributes(), flds)


### PR DESCRIPTION
setting it to true indicates that backend will be responsible for timestamp parsing

Signed-off-by: Dominik Rosiek <drosiek@sumologic.com>