### PR TITLE
sumologicextension: allow cancelling collector registration with context

### DIFF
--- a/pkg/extension/sumologicextension/extension.go
+++ b/pkg/extension/sumologicextension/extension.go
@@ -330,19 +330,27 @@ func (se *SumologicExtension) registerCollector(ctx context.Context, collectorNa
 func (se *SumologicExtension) registerCollectorWithBackoff(ctx context.Context, collectorName string) (CollectorCredentials, error) {
 	se.backOff.Reset()
 	for {
-		resp, err := se.registerCollector(ctx, collectorName)
+		creds, err := se.registerCollector(ctx, collectorName)
 		if err == nil {
-			return resp, nil
+			return creds, nil
 		}
 
-		se.logger.Warn("Collector registration failed: ", zap.Error(err))
+		se.logger.Warn("Collector registration failed", zap.Error(err))
 
 		nbo := se.backOff.NextBackOff()
 		// Return error if backoff reaches the limit or uncoverable error is spotted
 		if _, ok := err.(*backoff.PermanentError); nbo == se.backOff.Stop || ok {
-			return CollectorCredentials{}, fmt.Errorf("collector registration failed: %v", err)
+			return CollectorCredentials{}, fmt.Errorf("collector registration failed: %w", err)
 		}
-		time.Sleep(nbo)
+
+		t := time.NewTimer(nbo)
+		defer t.Stop()
+
+		select {
+		case <-t.C:
+		case <-ctx.Done():
+			return CollectorCredentials{}, fmt.Errorf("collector registration cancelled: %w", ctx.Err())
+		}
 	}
 }
 


### PR DESCRIPTION
Instead of using `time.Sleep()` use `time.NewTimer()`'s channel so that we can listen on it and on `context.Done()`