### PR TITLE
fix(ansible): strip read permission for config for others

### DIFF
--- a/examples/ansible/install_sumologic_otel_collector.yaml
+++ b/examples/ansible/install_sumologic_otel_collector.yaml
@@ -52,7 +52,7 @@
         dest: /etc/otelcol-sumo/config.yaml
         owner: opentelemetry
         group: opentelemetry
-        mode: 0644
+        mode: 0640
     - name: Creating systemd service file
       template:
         src: systemd_service.j2

--- a/examples/puppet/modules/install_otel_collector/manifests/init.pp
+++ b/examples/puppet/modules/install_otel_collector/manifests/init.pp
@@ -32,7 +32,7 @@ class install_otel_collector {
 
    file {"/etc/otelcol-sumo/config.yaml":
      source => "puppet:///modules/install_otel_collector/config.yaml",
-     mode => "644",
+     mode => "640",
    }
 
    group {"opentelemetry":


### PR DESCRIPTION
This change is done due to security good practice, as config can contain sensitive data

Signed-off-by: Dominik Rosiek <drosiek@sumologic.com>