### PR TITLE
fix: set HOME in container image and assign proper ownership to it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,19 @@ RUN chmod 755 /otelcol-sumo
 FROM alpine:3.13 as certs
 RUN apk --update add ca-certificates
 
+FROM alpine:3.13 as directories
+RUN mkdir /etc/otel/
+
 FROM scratch
 ARG BUILD_TAG=latest
 ENV TAG $BUILD_TAG
 ARG USER_UID=10001
 USER ${USER_UID}
+ENV HOME /etc/otel/
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=otelcol /otelcol-sumo /otelcol-sumo
+COPY --from=directories --chown=${USER_UID}:${USER_UID} /etc/otel/ /etc/otel/
 EXPOSE 55680 55679
 ENTRYPOINT ["/otelcol-sumo"]
 CMD ["--config", "/etc/otel/config.yaml"]

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -7,14 +7,19 @@ RUN chmod 755 /otelcol-sumo
 FROM alpine:3.13 as certs
 RUN apk --update add ca-certificates
 
+FROM alpine:3.13 as directories
+RUN mkdir /etc/otel/
+
 FROM golang:1.17.0
 ARG BUILD_TAG=latest
 ENV TAG $BUILD_TAG
 ARG USER_UID=10001
 USER ${USER_UID}
+ENV HOME /etc/otel/
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=otelcol /otelcol-sumo /otelcol-sumo
+COPY --from=directories --chown=${USER_UID}:${USER_UID} /etc/otel/ /etc/otel/
 EXPOSE 55680 55679
 ENTRYPOINT ["/otelcol-sumo"]
 CMD ["--config", "/etc/otel/config.yaml"]

--- a/Dockerfile_local
+++ b/Dockerfile_local
@@ -9,14 +9,19 @@ RUN make build
 FROM alpine:3.13 as certs
 RUN apk --update add ca-certificates
 
+FROM alpine:3.13 as directories
+RUN mkdir /etc/otel/
+
 FROM scratch
 ARG BUILD_TAG=latest
 ENV TAG $BUILD_TAG
 ARG USER_UID=10001
 USER ${USER_UID}
+ENV HOME /etc/otel/
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /src/otelcolbuilder/cmd/otelcol-sumo /otelcol-sumo
+COPY --from=directories --chown=${USER_UID}:${USER_UID} /etc/otel/ /etc/otel/
 EXPOSE 55680 55679
 ENTRYPOINT ["/otelcol-sumo"]
 CMD ["--config", "/etc/otel/config.yaml"]

--- a/Makefile
+++ b/Makefile
@@ -80,11 +80,18 @@ _build:
 		--tag $(IMG):$(TAG) \
 		.
 
-.PHONY: build-container
+.PHONY: build-container-local
 build-container-local:
 	$(MAKE) _build \
 		IMG="$(IMAGE_NAME)-local" \
 		DOCKERFILE="Dockerfile_local" \
+		TAG="$(BUILD_TAG)"
+
+.PHONY: build-container-dev
+build-container-dev:
+	$(MAKE) _build \
+		IMG="$(IMAGE_NAME)-dev" \
+		DOCKERFILE="Dockerfile_dev" \
 		TAG="$(BUILD_TAG)"
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This is to avoid:

```
2021-09-03T12:23:13.005Z  error   sumologicextension@v0.33.0/extension.go:225     Unable to store collector credentials   {"kind": "extension", "name": "sumologic", "error": "mkdir /.sumologic-otel-collector: permission denied"}
```