### PR TITLE
chore: don't use deprecated pdata.AttributeValueToString

### DIFF
--- a/pkg/exporter/sumologicexporter/carbon_formatter.go
+++ b/pkg/exporter/sumologicexporter/carbon_formatter.go
@@ -44,7 +44,7 @@ func carbon2TagString(record metricPair) string {
 		returnValue = append(returnValue, fmt.Sprintf(
 			"%s=%s",
 			sanitizeCarbonString(k),
-			sanitizeCarbonString(pdata.AttributeValueToString(v)),
+			sanitizeCarbonString(v.AsString()),
 		))
 		return true
 	})

--- a/pkg/exporter/sumologicexporter/fields.go
+++ b/pkg/exporter/sumologicexporter/fields.go
@@ -44,7 +44,7 @@ func (f fields) string() string {
 			fmt.Sprintf(
 				"%s=%s",
 				f.sanitizeField(k),
-				f.sanitizeField(pdata.AttributeValueToString(v)),
+				f.sanitizeField(v.AsString()),
 			),
 		)
 		return true

--- a/pkg/exporter/sumologicexporter/graphite_formatter.go
+++ b/pkg/exporter/sumologicexporter/graphite_formatter.go
@@ -65,7 +65,7 @@ func (gf *graphiteFormatter) format(f fields, metricName string) string {
 			attr, ok := f.orig.Get(matchset)
 			var value string
 			if ok {
-				value = pdata.AttributeValueToString(attr)
+				value = attr.AsString()
 			} else {
 				value = ""
 			}

--- a/pkg/exporter/sumologicexporter/prometheus_formatter.go
+++ b/pkg/exporter/sumologicexporter/prometheus_formatter.go
@@ -74,7 +74,7 @@ func (f *prometheusFormatter) tags2String(attr pdata.AttributeMap, labels pdata.
 			fmt.Sprintf(
 				`%s="%s"`,
 				f.sanitizeKey(k),
-				f.sanitizeValue(pdata.AttributeValueToString(v)),
+				f.sanitizeValue(v.AsString()),
 			),
 		)
 		return true

--- a/pkg/exporter/sumologicexporter/sender.go
+++ b/pkg/exporter/sumologicexporter/sender.go
@@ -175,7 +175,7 @@ func (s *sender) createRequest(ctx context.Context, pipeline PipelineType, data 
 
 // logToText converts LogRecord to a plain text line, returns it and error eventually
 func (s *sender) logToText(record pdata.LogRecord) string {
-	return pdata.AttributeValueToString(record.Body())
+	return record.Body().AsString()
 }
 
 // logToJSON converts LogRecord to a json line, returns it and error eventually

--- a/pkg/exporter/sumologicexporter/source_format.go
+++ b/pkg/exporter/sumologicexporter/source_format.go
@@ -17,8 +17,6 @@ package sumologicexporter
 import (
 	"fmt"
 	"regexp"
-
-	"go.opentelemetry.io/collector/model/pdata"
 )
 
 type sourceFormats struct {
@@ -80,7 +78,7 @@ func (s *sourceFormat) format(f fields) string {
 	for _, matchset := range s.matches {
 		v, ok := f.orig.Get(matchset)
 		if ok {
-			labels = append(labels, pdata.AttributeValueToString(v))
+			labels = append(labels, v.AsString())
 		} else {
 			labels = append(labels, unrecognizedAttributeValue)
 		}


### PR DESCRIPTION
It was removed in https://github.com/open-telemetry/opentelemetry-collector/pull/3953 and it's already not available in https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.35.0