### PR TITLE
feat(sumologicexporter): allows `.`, `/`, `:` and `_` for prometheus key

### DIFF
--- a/pkg/exporter/sumologicexporter/exporter_test.go
+++ b/pkg/exporter/sumologicexporter/exporter_test.go
@@ -509,7 +509,7 @@ func TestAllMetricsSuccess(t *testing.T) {
 	test := prepareExporterTest(t, createTestConfig(), []func(w http.ResponseWriter, req *http.Request){
 		func(w http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
-			expected := `test_metric_data{test="test_value",test2="second_value"} 14500 1605534165000
+			expected := `test.metric.data{test="test_value",test2="second_value"} 14500 1605534165000
 gauge_metric_name{foo="bar",remote_name="156920",url="http://example_url"} 124 1608124661166
 gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1608124662166`
 			assert.Equal(t, expected, body)
@@ -559,7 +559,7 @@ func TestAllMetricsFailed(t *testing.T) {
 			w.WriteHeader(500)
 
 			body := extractBody(t, req)
-			expected := `test_metric_data{test="test_value",test2="second_value"} 14500 1605534165000
+			expected := `test.metric.data{test="test_value",test2="second_value"} 14500 1605534165000
 gauge_metric_name{foo="bar",remote_name="156920",url="http://example_url"} 124 1608124661166
 gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1608124662166`
 			assert.Equal(t, expected, body)
@@ -587,7 +587,7 @@ func TestMetricsPartiallyFailed(t *testing.T) {
 			w.WriteHeader(500)
 
 			body := extractBody(t, req)
-			expected := `test_metric_data{test="test_value",test2="second_value"} 14500 1605534165000`
+			expected := `test.metric.data{test="test_value",test2="second_value"} 14500 1605534165000`
 			assert.Equal(t, expected, body)
 			assert.Equal(t, "application/vnd.sumologic.prometheus", req.Header.Get("Content-Type"))
 		},
@@ -643,7 +643,7 @@ func TestMetricsDifferentMetadata(t *testing.T) {
 			w.WriteHeader(500)
 
 			body := extractBody(t, req)
-			expected := `test_metric_data{test="test_value",test2="second_value",key1="value1"} 14500 1605534165000`
+			expected := `test.metric.data{test="test_value",test2="second_value",key1="value1"} 14500 1605534165000`
 			assert.Equal(t, expected, body)
 			assert.Equal(t, "application/vnd.sumologic.prometheus", req.Header.Get("Content-Type"))
 		},
@@ -826,7 +826,7 @@ func TestMetricsPrometheusFormatMetadataFilter(t *testing.T) {
 	test := prepareExporterTest(t, createTestConfig(), []func(w http.ResponseWriter, req *http.Request){
 		func(w http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
-			expected := `test_metric_data{test="test_value",test2="second_value",key1="value1",key2="value2"} 14500 1605534165000`
+			expected := `test.metric.data{test="test_value",test2="second_value",key1="value1",key2="value2"} 14500 1605534165000`
 			assert.Equal(t, expected, body)
 			assert.Equal(t, "application/vnd.sumologic.prometheus", req.Header.Get("Content-Type"))
 		},
@@ -881,7 +881,7 @@ func TestPushMetrics_AttributeTranslation(t *testing.T) {
 				"X-Sumo-Category": "harry-potter",
 				"X-Sumo-Host":     "undefined",
 			},
-			expectedBody: `test_metric_data{test="test_value",test2="second_value",host="harry-potter",InstanceType="wizard"} 14500 1605534165000`,
+			expectedBody: `test.metric.data{test="test_value",test2="second_value",host="harry-potter",InstanceType="wizard"} 14500 1605534165000`,
 		},
 		{
 			name: "enabled_with_ot_host_name_template_set_in_source_host",
@@ -899,7 +899,7 @@ func TestPushMetrics_AttributeTranslation(t *testing.T) {
 				"X-Sumo-Category": "harry-potter",
 				"X-Sumo-Host":     "harry-potter",
 			},
-			expectedBody: `test_metric_data{test="test_value",test2="second_value",host="harry-potter",InstanceType="wizard"} 14500 1605534165000`,
+			expectedBody: `test.metric.data{test="test_value",test2="second_value",host="harry-potter",InstanceType="wizard"} 14500 1605534165000`,
 		},
 		{
 			name: "enabled_with_proper_host_template_set_in_source_host_but_not_specified_in_metadata_attributes",
@@ -918,7 +918,7 @@ func TestPushMetrics_AttributeTranslation(t *testing.T) {
 				"X-Sumo-Category": "undefined",
 				"X-Sumo-Host":     "undefined",
 			},
-			expectedBody: `test_metric_data{test="test_value",test2="second_value",host="harry-potter",InstanceType="wizard"} 14500 1605534165000`,
+			expectedBody: `test.metric.data{test="test_value",test2="second_value",host="harry-potter",InstanceType="wizard"} 14500 1605534165000`,
 		},
 		{
 			name: "disabled",
@@ -935,7 +935,7 @@ func TestPushMetrics_AttributeTranslation(t *testing.T) {
 				"X-Sumo-Category": "harry-potter",
 				"X-Sumo-Host":     "undefined",
 			},
-			expectedBody: `test_metric_data{test="test_value",test2="second_value",host_name="harry-potter",host_type="wizard"} 14500 1605534165000`,
+			expectedBody: `test.metric.data{test="test_value",test2="second_value",host.name="harry-potter",host.type="wizard"} 14500 1605534165000`,
 		},
 		{
 			name: "disabled_with_ot_host_name_template_set_in_source_host",
@@ -952,7 +952,7 @@ func TestPushMetrics_AttributeTranslation(t *testing.T) {
 				"X-Sumo-Category": "harry-potter",
 				"X-Sumo-Host":     "harry-potter",
 			},
-			expectedBody: `test_metric_data{test="test_value",test2="second_value",host_name="harry-potter",host_type="wizard"} 14500 1605534165000`,
+			expectedBody: `test.metric.data{test="test_value",test2="second_value",host.name="harry-potter",host.type="wizard"} 14500 1605534165000`,
 		},
 	}
 

--- a/pkg/exporter/sumologicexporter/prometheus_formatter.go
+++ b/pkg/exporter/sumologicexporter/prometheus_formatter.go
@@ -42,7 +42,7 @@ const (
 )
 
 func newPrometheusFormatter() (prometheusFormatter, error) {
-	sanitNameRegex, err := regexp.Compile(`[^0-9a-zA-Z]`)
+	sanitNameRegex, err := regexp.Compile(`[^0-9a-zA-Z\./_:]`)
 	if err != nil {
 		return prometheusFormatter{}, err
 	}
@@ -84,7 +84,7 @@ func (f *prometheusFormatter) tags2String(attr pdata.AttributeMap, labels pdata.
 }
 
 // sanitizeKey returns sanitized key string by replacing
-// all non-alphanumeric chars with `_`
+// all non-allowed chars with `_`
 func (f *prometheusFormatter) sanitizeKey(s string) string {
 	return f.sanitNameRegex.ReplaceAllString(s, "_")
 }

--- a/pkg/exporter/sumologicexporter/prometheus_formatter_test.go
+++ b/pkg/exporter/sumologicexporter/prometheus_formatter_test.go
@@ -26,8 +26,8 @@ func TestSanitizeKey(t *testing.T) {
 	f, err := newPrometheusFormatter()
 	require.NoError(t, err)
 
-	key := "&^*123-abc-ABC!?"
-	expected := "___123_abc_ABC__"
+	key := "&^*123-abc-ABC!./?_:"
+	expected := "___123_abc_ABC_./__:"
 	assert.Equal(t, expected, f.sanitizeKey(key))
 }
 
@@ -35,8 +35,8 @@ func TestSanitizeValue(t *testing.T) {
 	f, err := newPrometheusFormatter()
 	require.NoError(t, err)
 
-	value := `&^*123-abc-ABC!?"\\n`
-	expected := `&^*123-abc-ABC!?\"\\\n`
+	value := `&^*123-abc-ABC!?./"\\n`
+	expected := `&^*123-abc-ABC!?./\"\\\n`
 	assert.Equal(t, expected, f.sanitizeValue(value))
 }
 

--- a/pkg/exporter/sumologicexporter/sender_test.go
+++ b/pkg/exporter/sumologicexporter/sender_test.go
@@ -780,7 +780,7 @@ func TestSendMetrics(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
 		func(w http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
-			expected := `test_metric_data{test="test_value",test2="second_value"} 14500 1605534165000
+			expected := `test.metric.data{test="test_value",test2="second_value"} 14500 1605534165000
 gauge_metric_name{foo="bar",remote_name="156920",url="http://example_url"} 124 1608124661166
 gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1608124662166`
 			assert.Equal(t, expected, body)
@@ -806,7 +806,7 @@ func TestSendMetricsSplit(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
 		func(w http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
-			expected := `test_metric_data{test="test_value",test2="second_value"} 14500 1605534165000`
+			expected := `test.metric.data{test="test_value",test2="second_value"} 14500 1605534165000`
 			assert.Equal(t, expected, body)
 		},
 		func(w http.ResponseWriter, req *http.Request) {
@@ -833,7 +833,7 @@ func TestSendMetricsSplitFailedOne(t *testing.T) {
 			w.WriteHeader(500)
 
 			body := extractBody(t, req)
-			expected := `test_metric_data{test="test_value",test2="second_value"} 14500 1605534165000`
+			expected := `test.metric.data{test="test_value",test2="second_value"} 14500 1605534165000`
 			assert.Equal(t, expected, body)
 		},
 		func(w http.ResponseWriter, req *http.Request) {
@@ -861,7 +861,7 @@ func TestSendMetricsSplitFailedAll(t *testing.T) {
 			w.WriteHeader(500)
 
 			body := extractBody(t, req)
-			expected := `test_metric_data{test="test_value",test2="second_value"} 14500 1605534165000`
+			expected := `test.metric.data{test="test_value",test2="second_value"} 14500 1605534165000`
 			assert.Equal(t, expected, body)
 		},
 		func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Allow `.` and `/` for prometheus key

Signed-off-by: Dominik Rosiek <drosiek@sumologic.com>