### PR TITLE
feat(sumologicexporter): add support for `-` to prometheus format

### DIFF
--- a/pkg/exporter/sumologicexporter/prometheus_formatter.go
+++ b/pkg/exporter/sumologicexporter/prometheus_formatter.go
@@ -42,7 +42,7 @@ const (
 )
 
 func newPrometheusFormatter() (prometheusFormatter, error) {
-	sanitNameRegex, err := regexp.Compile(`[^0-9a-zA-Z\./_:]`)
+	sanitNameRegex, err := regexp.Compile(`[^0-9a-zA-Z\./_:\-]`)
 	if err != nil {
 		return prometheusFormatter{}, err
 	}

--- a/pkg/exporter/sumologicexporter/prometheus_formatter_test.go
+++ b/pkg/exporter/sumologicexporter/prometheus_formatter_test.go
@@ -27,7 +27,7 @@ func TestSanitizeKey(t *testing.T) {
 	require.NoError(t, err)
 
 	key := "&^*123-abc-ABC!./?_:"
-	expected := "___123_abc_ABC_./__:"
+	expected := "___123-abc-ABC_./__:"
 	assert.Equal(t, expected, f.sanitizeKey(key))
 }
 


### PR DESCRIPTION
We need it for compatibility with fluentd. If metadata label contains `-` it should be send as `-` instead of `_`

Signed-off-by: Dominik Rosiek <drosiek@sumologic.com>