### PR TITLE
fix(k8sprocessor): namespace does not need to be in extracted metadata

### DIFF
--- a/pkg/processor/k8sprocessor/kube/client.go
+++ b/pkg/processor/k8sprocessor/kube/client.go
@@ -373,6 +373,7 @@ func (c *WatchClient) extractField(v string, r FieldExtractionRule) string {
 func (c *WatchClient) addOrUpdatePod(pod *api_v1.Pod) {
 	newPod := &Pod{
 		Name:      pod.Name,
+		Namespace: pod.Namespace,
 		Address:   pod.Status.PodIP,
 		PodUID:    string(pod.UID),
 		StartTime: pod.Status.StartTime,
@@ -403,8 +404,8 @@ func (c *WatchClient) addOrUpdatePod(pod *api_v1.Pod) {
 		c.Pods[PodIdentifier(pod.Status.PodIP)] = newPod
 	}
 	// Use pod_name.namespace_name identifier
-	if newPod.Name != "" && newPod.Attributes[c.Rules.Tags.Namespace] != "" {
-		c.Pods[PodIdentifier(fmt.Sprintf("%s.%s", newPod.Name, newPod.Attributes[c.Rules.Tags.Namespace]))] = newPod
+	if newPod.Name != "" && newPod.Namespace != "" {
+		c.Pods[PodIdentifier(fmt.Sprintf("%s.%s", newPod.Name, newPod.Namespace))] = newPod
 	}
 }
 

--- a/pkg/processor/k8sprocessor/kube/client_test.go
+++ b/pkg/processor/k8sprocessor/kube/client_test.go
@@ -334,6 +334,37 @@ func TestGetIgnoredPod(t *testing.T) {
 func TestGetPod(t *testing.T) {
 	c, _ := newTestClient(t)
 
+	pod := &api_v1.Pod{}
+	pod.Status.PodIP = "1.1.1.1"
+	pod.UID = "1234"
+	pod.Name = "pod_name"
+	pod.Namespace = "namespace_name"
+	c.handlePodAdd(pod)
+
+	expected := &Pod{
+		Name:       "pod_name",
+		Namespace:  "namespace_name",
+		Address:    "1.1.1.1",
+		PodUID:     "1234",
+		Attributes: map[string]string{},
+	}
+
+	got, ok := c.GetPod(PodIdentifier("1.1.1.1"))
+	assert.Equal(t, got, expected)
+	assert.True(t, ok)
+
+	got, ok = c.GetPod(PodIdentifier("1234"))
+	assert.Equal(t, got, expected)
+	assert.True(t, ok)
+
+	got, ok = c.GetPod(PodIdentifier("pod_name.namespace_name"))
+	assert.Equal(t, got, expected)
+	assert.True(t, ok)
+}
+
+func TestGetPodWhenNamespaceInExtractedMetadata(t *testing.T) {
+	c, _ := newTestClient(t)
+
 	c.Rules.Namespace = true
 	c.Rules.Tags.Namespace = "namespace"
 
@@ -345,9 +376,10 @@ func TestGetPod(t *testing.T) {
 	c.handlePodAdd(pod)
 
 	expected := &Pod{
-		Name:    "pod_name",
-		Address: "1.1.1.1",
-		PodUID:  "1234",
+		Name:      "pod_name",
+		Namespace: "namespace_name",
+		Address:   "1.1.1.1",
+		PodUID:    "1234",
 		Attributes: map[string]string{
 			"namespace": "namespace_name",
 		},

--- a/pkg/processor/k8sprocessor/kube/kube.go
+++ b/pkg/processor/k8sprocessor/kube/kube.go
@@ -78,6 +78,7 @@ type APIClientsetProvider func(config k8sconfig.APIConfig) (kubernetes.Interface
 // Pod represents a kubernetes pod.
 type Pod struct {
 	Name       string
+	Namespace  string
 	Address    string
 	PodUID     string
 	Attributes map[string]string


### PR DESCRIPTION
Fix: namespace does not need to be in extracted metadata when there is following configuration

```
pod_association:
- from: build_hostname
```
without this fix it is required to this section to configuration:

```
extract:
  metadata:
   - namespace
```
related to: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1762