### PR TITLE
clarify pod_name behavior and change default key names to fit convention

### DIFF
--- a/pkg/processor/k8sprocessor/config.go
+++ b/pkg/processor/k8sprocessor/config.go
@@ -102,10 +102,10 @@ type ExtractConfig struct {
 //
 // - tag_name represents the name of the tag that will be added to the span.
 //   When not specified a default tag name will be used of the format:
-//       k8s.pod.annotations.<annotation key>
-//       k8s.pod.labels.<label key>
+//       k8s.pod.annotation.<annotation key>
+//       k8s.pod.label.<label key>
 //   For example, if tag_name is not specified and the key is git_sha,
-//   then the attribute name will be `k8s.pod.annotations.git_sha`.
+//   then the attribute name will be `k8s.pod.annotation.git_sha`.
 //
 //- key represents the annotation name. This must exactly match an annotation name.
 //  To capture all keys, `*` can be used

--- a/pkg/processor/sourceprocessor/README.md
+++ b/pkg/processor/sourceprocessor/README.md
@@ -7,18 +7,18 @@ It has certain expectations on the label names used by `k8sprocessor` which migh
 
 ## Config
 
-- `collector` (default = ""): name of the collector, put in `collector` tag
-- `source` (default = "traces"): name of the source, put in `_source` tag
-- `source_name` (default = "%{namespace}.%{pod}.%{container}"): `_sourceName` template
-- `source_category` (default = "%{namespace}/%{pod_name}"): `_sourceCategory` template
-- `source_category_prefix` (default = "kubernetes/"): prefix added before each `_sourceCategory` value
-- `source_category_replace_dash` (default = "/"): character which all dashes (`-`) are being replaced to
+- `collector` (default = ``): name of the collector, put in `collector` tag
+- `source` (default = `traces`): name of the source, put in `_source` tag
+- `source_name` (default = `%{namespace}.%{pod}.%{container}`): `_sourceName` template
+- `source_category` (default = `%{namespace}/%{pod_name}`): `_sourceCategory` template
+- `source_category_prefix` (default = `kubernetes/`): prefix added before each `_sourceCategory` value
+- `source_category_replace_dash` (default = `/`): character which all dashes (`-`) are being replaced to
 
 ### Filtering section
 
 **NOTE**: The filtering is done on the resource level attributes.
 
-- `exclude` (default = empty): a mapping of field names to exclusion regexes
+- `exclude` (default = `{}`): a mapping of field names to exclusion regexes
   for those particular fields. Whenever a value under particular field matches
   a corresponding regex, the processed entry is dropped.
 
@@ -28,24 +28,34 @@ It has certain expectations on the label names used by `k8sprocessor` which migh
   an entry for `_SYSTEMD_UNIT`) then whenever the processed record contains
   `_HOSTNAME` attribute it will be added to the resulting record under `host` key.
 
-### Keys section (must match `k8sprocessor` config)
+### Keys section
 
-- `annotation_prefix` (default = "pod_annotation_"): prefix which allows to find given annotation; 
+The following keys must match resource attributes.
+In most cases the keys should be the same like in [k8sprocessor](../k8sprocessor/README.md#extract-section) config:
+
+- `annotation_prefix` (default = `k8s.pod.annotation.`): prefix which allows to find given annotation;
 it is used for including/excluding pods, among other attributes
-- `pod_template_hash_key` (default = "pod_labels_pod-template-hash"): attribute where pod template 
+- `pod_template_hash_key` (default = `k8s.pod.label.pod-template-hash`): attribute where pod template
 hash is found (used for `pod` extraction)
-- `pod_name_key` (default = "pod_name"): attribute where name portion of the pod is stored 
-during enrichment
-- `namespace_key` (default = "namespace"): attribute where namespace name is found
-- `pod_key` (default = "pod"): attribute where pod full name is found
-- `container_key` (default = "container"): attribute where container name is found
-- `source_host_key` (default = "source_host"): attribute where source host is found
+- `namespace_key` (default = `k8s.namespace.name`): attribute where namespace name is found
+- `pod_key` (default = `k8s.pod.name`): attribute where pod full name is found
+- `container_key` (default = `k8s.container.name`): attribute where container name is found
+- `source_host_key` (default = `k8s.pod.hostname`): attribute where source host is found
+
+The following key is going to be created:
+
+- `pod_name_key` (default = `k8s.pod.pod_name`): attribute where name portion of the pod is stored
+during enrichment. Please consider following examples:
+
+  - for a daemonset pod `dset-otelcol-sumo-xa314` it's going to be `dset-otelcol-sumo`
+  - for a deployment pod `dep-otelcol-sumo-75675f5861-qasd2` it's going to be `dep-otelcol-sumo`
+  - for a statefulset pod `st-otelcol-sumo-0` it's going to be `st-otelcol-sumo`
 
 ### Name translation and template keys
 
-The key names provided as `namespace`, `pod`, `pod_name`, `container` in templates for `source_category` 
-or `source_name`are replaced with the key name provided in `namespace_key`, `pod_key`, 
-`pod_name_key`, `container_key` respectively. 
+The key names provided as `namespace`, `pod`, `pod_name`, `container` in templates for `source_category`
+or `source_name`are replaced with the key name provided in `namespace_key`, `pod_key`,
+`pod_name_key`, `container_key` respectively.
 
 For example, when default template for `source_category` is being used (`%{namespace}/%{pod_name}`) and
 `namespace_key=k8s.namespace.name`, the resource has attributes:

--- a/pkg/processor/sourceprocessor/config_test.go
+++ b/pkg/processor/sourceprocessor/config_test.go
@@ -65,7 +65,7 @@ func TestLoadConfig(t *testing.T) {
 		ContainerKey:       "container",
 		NamespaceKey:       "namespace",
 		PodKey:             "pod",
-		PodIDKey:           "pod_id",
+		PodIDKey:           "k8s.pod.uid",
 		PodNameKey:         "pod_name",
 		PodTemplateHashKey: "pod_labels_pod-template-hash",
 		SourceHostKey:      "source_host",

--- a/pkg/processor/sourceprocessor/factory.go
+++ b/pkg/processor/sourceprocessor/factory.go
@@ -35,14 +35,14 @@ const (
 	defaultSourceCategoryPrefix      = "kubernetes/"
 	defaultSourceCategoryReplaceDash = "/"
 
-	defaultAnnotationPrefix   = "pod_annotation_"
-	defaultContainerKey       = "container"
-	defaultNamespaceKey       = "namespace"
-	defaultPodIDKey           = "pod_id"
-	defaultPodKey             = "pod"
-	defaultPodNameKey         = "pod_name"
-	defaultPodTemplateHashKey = "pod_labels_pod-template-hash"
-	defaultSourceHostKey      = "source_host"
+	defaultAnnotationPrefix   = "k8s.pod.annotation."
+	defaultContainerKey       = "k8s.container.name"
+	defaultNamespaceKey       = "k8s.namespace.name"
+	defaultPodIDKey           = "k8s.pod.uid"
+	defaultPodKey             = "k8s.pod.name"
+	defaultPodNameKey         = "k8s.pod.pod_name"
+	defaultPodTemplateHashKey = "k8s.pod.label.pod-template-hash"
+	defaultSourceHostKey      = "k8s.pod.hostname"
 )
 
 var processorCapabilities = consumer.Capabilities{MutatesData: true}

--- a/pkg/processor/sourceprocessor/source_processor_test.go
+++ b/pkg/processor/sourceprocessor/source_processor_test.go
@@ -29,6 +29,13 @@ func createConfig() *Config {
 	config.Collector = "foocollector"
 	config.SourceCategoryPrefix = "prefix/"
 	config.SourceCategoryReplaceDash = "#"
+	config.PodNameKey = "pod_name"
+	config.PodKey = "pod"
+	config.NamespaceKey = "namespace"
+	config.ContainerKey = "container"
+	config.PodTemplateHashKey = "pod_labels_pod-template-hash"
+	config.AnnotationPrefix = "pod_annotation_"
+	config.PodIDKey = "pod_id"
 	return config
 }
 
@@ -67,23 +74,23 @@ var (
 	}
 
 	k8sNewLabels = map[string]string{
-		"k8s.namespace.name":               "namespace-1",
-		"k8s.pod.id":                       "pod-1234",
-		"k8s.pod.name":                     "pod-5db86d8867-sdqlj",
-		"k8s.pod.labels.pod-template-hash": "5db86d8867",
-		"k8s.container.name":               "container-1",
+		"k8s.namespace.name":              "namespace-1",
+		"k8s.pod.id":                      "pod-1234",
+		"k8s.pod.name":                    "pod-5db86d8867-sdqlj",
+		"k8s.pod.label.pod-template-hash": "5db86d8867",
+		"k8s.container.name":              "container-1",
 	}
 
 	mergedK8sNewLabelsWithMeta = map[string]string{
-		"k8s.namespace.name":               "namespace-1",
-		"k8s.pod.id":                       "pod-1234",
-		"k8s.pod.name":                     "pod-5db86d8867-sdqlj",
-		"k8s.pod.labels.pod-template-hash": "5db86d8867",
-		"k8s.container.name":               "container-1",
-		"k8s.pod.pod_name":                 "pod",
-		"_sourceName":                      "namespace-1.pod-5db86d8867-sdqlj.container-1",
-		"_sourceCategory":                  "prefix/namespace#1/pod",
-		"_collector":                       "foocollector",
+		"k8s.namespace.name":              "namespace-1",
+		"k8s.pod.id":                      "pod-1234",
+		"k8s.pod.name":                    "pod-5db86d8867-sdqlj",
+		"k8s.pod.label.pod-template-hash": "5db86d8867",
+		"k8s.container.name":              "container-1",
+		"k8s.pod.pod_name":                "pod",
+		"_sourceName":                     "namespace-1.pod-5db86d8867-sdqlj.container-1",
+		"_sourceCategory":                 "prefix/namespace#1/pod",
+		"_collector":                      "foocollector",
 	}
 
 	limitedLabels = map[string]string{
@@ -170,7 +177,7 @@ func TestTraceSourceProcessorNewTaxonomy(t *testing.T) {
 	config.PodIDKey = "k8s.pod.id"
 	config.PodNameKey = "k8s.pod.pod_name"
 	config.PodKey = "k8s.pod.name"
-	config.PodTemplateHashKey = "k8s.pod.labels.pod-template-hash"
+	config.PodTemplateHashKey = "k8s.pod.label.pod-template-hash"
 	config.ContainerKey = "k8s.container.name"
 
 	rtp := newSourceProcessor(config)


### PR DESCRIPTION
docs(sourceprocessor): clarify pod_name behavior 
refactor(sourceprocessor)!: change default key names to fit k8s and this repo convention

change defaukt keys to be compatible with k8sprocessor