### PR TITLE
fix(sourceprocessor): fix source_host_key feature

### DIFF
--- a/pkg/processor/sourceprocessor/attribute_filler.go
+++ b/pkg/processor/sourceprocessor/attribute_filler.go
@@ -42,12 +42,12 @@ type attributeFiller struct {
 	labels          []string
 }
 
-func createSourceHostFiller() attributeFiller {
+func createSourceHostFiller(sourceHostAttrName string) attributeFiller {
 	return attributeFiller{
 		name:            sourceHostKey,
-		compiledFormat:  "",
+		compiledFormat:  "%s",
 		dashReplacement: "",
-		labels:          make([]string, 0),
+		labels:          []string{sourceHostAttrName},
 		prefix:          "",
 	}
 }

--- a/pkg/processor/sourceprocessor/source_processor.go
+++ b/pkg/processor/sourceprocessor/source_processor.go
@@ -134,7 +134,7 @@ func newSourceProcessor(cfg *Config) *sourceProcessor {
 		collector:            cfg.Collector,
 		keys:                 keys,
 		source:               cfg.Source,
-		sourceHostFiller:     createSourceHostFiller(),
+		sourceHostFiller:     createSourceHostFiller(cfg.SourceHostKey),
 		sourceCategoryFiller: createSourceCategoryFiller(cfg, keys),
 		sourceNameFiller:     createSourceNameFiller(cfg, keys),
 		exclude:              exclude,


### PR DESCRIPTION
It seems that using `source_host_key` in source processor didn't work at all.

This PR adds the missing functionality and some tests for that.