### PR TITLE
sourceprocessor: don't try to add host for systemd related records

### DIFF
--- a/pkg/processor/sourceprocessor/README.md
+++ b/pkg/processor/sourceprocessor/README.md
@@ -22,12 +22,6 @@ It has certain expectations on the label names used by `k8sprocessor` which migh
   for those particular fields. Whenever a value under particular field matches
   a corresponding regex, the processed entry is dropped.
 
-  **NOTE**:
-
-  When systemd related filtering is taking place (`exclude` contains
-  an entry for `_SYSTEMD_UNIT`) then whenever the processed record contains
-  `_HOSTNAME` attribute it will be added to the resulting record under `host` key.
-
 ### Keys section (must match `k8sprocessor` config)
 
 - `annotation_prefix` (default = "pod_annotation_"): prefix which allows to find given annotation; 


### PR DESCRIPTION
Instead of relying on this behavior, use e.g. attributes processor in the pipeline.