### PR TITLE
docs(sourceprocessor): remove `source` configuration option

### DIFF
--- a/pkg/processor/sourceprocessor/README.md
+++ b/pkg/processor/sourceprocessor/README.md
@@ -1,6 +1,6 @@
 # Source Processor
 
-The `sourceprocessor` adds `_source` and other tags related to Sumo Logic metadata taxonomy.
+The `sourceprocessor` adds `_sourceName` and other tags related to Sumo Logic metadata taxonomy.
 
 It leverages data tagged by `k8sprocessor` and must be after it in the processing chain.
 It has certain expectations on the label names used by `k8sprocessor` which might be configured below.
@@ -8,7 +8,6 @@ It has certain expectations on the label names used by `k8sprocessor` which migh
 ## Config
 
 - `collector` (default = ``): name of the collector, put in `_collector` tag
-- `source` (default = `traces`): name of the source, put in `_source` tag
 - `source_name` (default = `%{namespace}.%{pod}.%{container}`): `_sourceName` template
 - `source_category` (default = `%{namespace}/%{pod_name}`): `_sourceCategory` template
 - `source_category_prefix` (default = `kubernetes/`): prefix added before each `_sourceCategory` value

--- a/pkg/processor/sourceprocessor/config.go
+++ b/pkg/processor/sourceprocessor/config.go
@@ -23,7 +23,6 @@ type Config struct {
 	*config.ProcessorSettings `mapstructure:"-"`
 
 	Collector                 string `mapstructure:"collector"`
-	Source                    string `mapstructure:"source"`
 	SourceName                string `mapstructure:"source_name"`
 	SourceCategory            string `mapstructure:"source_category"`
 	SourceCategoryPrefix      string `mapstructure:"source_category_prefix"`

--- a/pkg/processor/sourceprocessor/config_test.go
+++ b/pkg/processor/sourceprocessor/config_test.go
@@ -48,7 +48,6 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, p2, &Config{
 		ProcessorSettings:         &ps2,
 		Collector:                 "somecollector",
-		Source:                    "tracesource",
 		SourceName:                "%{namespace}.%{pod}.%{container}/foo",
 		SourceCategory:            "%{namespace}/%{pod_name}/bar",
 		SourceCategoryPrefix:      "kubernetes/",

--- a/pkg/processor/sourceprocessor/factory.go
+++ b/pkg/processor/sourceprocessor/factory.go
@@ -27,7 +27,6 @@ const (
 	// The value of "type" key in configuration.
 	typeStr = "source"
 
-	defaultSource    = "traces"
 	defaultCollector = ""
 
 	defaultSourceName                = "%{namespace}.%{pod}.%{container}"
@@ -63,7 +62,6 @@ func createDefaultConfig() config.Processor {
 	ps := config.NewProcessorSettings(config.NewID(typeStr))
 	return &Config{
 		ProcessorSettings:         &ps,
-		Source:                    defaultSource,
 		Collector:                 defaultCollector,
 		SourceName:                defaultSourceName,
 		SourceCategory:            defaultSourceCategory,

--- a/pkg/processor/sourceprocessor/source_processor.go
+++ b/pkg/processor/sourceprocessor/source_processor.go
@@ -66,7 +66,6 @@ type dockerLog struct {
 
 type sourceProcessor struct {
 	collector            string
-	source               string
 	sourceCategoryFiller attributeFiller
 	sourceNameFiller     attributeFiller
 	sourceHostFiller     attributeFiller
@@ -126,7 +125,6 @@ func newSourceProcessor(cfg *Config) *sourceProcessor {
 	return &sourceProcessor{
 		collector:            cfg.Collector,
 		keys:                 keys,
-		source:               cfg.Source,
 		sourceHostFiller:     createSourceHostFiller(cfg.SourceHostKey),
 		sourceCategoryFiller: createSourceCategoryFiller(cfg, keys),
 		sourceNameFiller:     createSourceNameFiller(cfg, keys),

--- a/pkg/processor/sourceprocessor/testdata/config.yaml
+++ b/pkg/processor/sourceprocessor/testdata/config.yaml
@@ -7,7 +7,6 @@ processors:
   # The following specifies a non-trivial source
   source/2:
     collector: "somecollector"
-    source: "tracesource"
     source_name: "%{namespace}.%{pod}.%{container}/foo"
     source_category: "%{namespace}/%{pod_name}/bar"
     source_category_prefix: "kubernetes/"


### PR DESCRIPTION
It doesn't do anything.

Contrary to what the docs claim, the `_source` tag is not set by the Source processor.