### PR TITLE
fix(sumologicexporter): do not send attributes in both json body and headers during attribute translations

### DIFF
--- a/pkg/exporter/sumologicexporter/sender_test.go
+++ b/pkg/exporter/sumologicexporter/sender_test.go
@@ -274,7 +274,7 @@ func TestSendLogs(t *testing.T) {
 		},
 	})
 
-	test.s.logBuffer = exampleTwoLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
 	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "value", "key2": "value2"}))
 	assert.NoError(t, err)
@@ -294,7 +294,7 @@ func TestSendLogsMultitype(t *testing.T) {
 		},
 	})
 
-	test.s.logBuffer = exampleMultitypeLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleMultitypeLogs())
 
 	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "value", "key2": "value2"}))
 	assert.NoError(t, err)
@@ -314,7 +314,7 @@ func TestSendLogsSplit(t *testing.T) {
 		},
 	})
 	test.s.config.MaxRequestBodySize = 10
-	test.s.logBuffer = exampleTwoLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
 	_, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.NoError(t, err)
@@ -336,7 +336,7 @@ func TestSendLogsSplitFailedOne(t *testing.T) {
 	})
 	test.s.config.MaxRequestBodySize = 10
 	test.s.config.LogFormat = TextFormat
-	test.s.logBuffer = exampleTwoLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
 	dropped, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, "error during sending data: 500 Internal Server Error")
@@ -362,7 +362,7 @@ func TestSendLogsSplitFailedAll(t *testing.T) {
 	})
 	test.s.config.MaxRequestBodySize = 10
 	test.s.config.LogFormat = TextFormat
-	test.s.logBuffer = exampleTwoLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
 	dropped, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(
@@ -388,7 +388,7 @@ func TestSendLogsJson(t *testing.T) {
 		},
 	})
 	test.s.config.LogFormat = JSONFormat
-	test.s.logBuffer = exampleTwoLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
 	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key": "value"}))
 	assert.NoError(t, err)
@@ -409,7 +409,7 @@ func TestSendLogsJsonMultitype(t *testing.T) {
 		},
 	})
 	test.s.config.LogFormat = JSONFormat
-	test.s.logBuffer = exampleMultitypeLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleMultitypeLogs())
 
 	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key": "value"}))
 	assert.NoError(t, err)
@@ -430,7 +430,7 @@ func TestSendLogsJsonSplit(t *testing.T) {
 	})
 	test.s.config.LogFormat = JSONFormat
 	test.s.config.MaxRequestBodySize = 10
-	test.s.logBuffer = exampleTwoLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
 	_, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.NoError(t, err)
@@ -453,7 +453,7 @@ func TestSendLogsJsonSplitFailedOne(t *testing.T) {
 	})
 	test.s.config.LogFormat = JSONFormat
 	test.s.config.MaxRequestBodySize = 10
-	test.s.logBuffer = exampleTwoLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
 	dropped, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, "error during sending data: 500 Internal Server Error")
@@ -479,7 +479,7 @@ func TestSendLogsJsonSplitFailedAll(t *testing.T) {
 	})
 	test.s.config.LogFormat = JSONFormat
 	test.s.config.MaxRequestBodySize = 10
-	test.s.logBuffer = exampleTwoLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
 	dropped, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(
@@ -498,7 +498,7 @@ func TestSendLogsUnexpectedFormat(t *testing.T) {
 		},
 	})
 	test.s.config.LogFormat = "dummy"
-	logs := exampleTwoLogs()
+	logs := logRecordsToLogPair(exampleTwoLogs())
 	test.s.logBuffer = logs
 
 	dropped, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
@@ -518,7 +518,7 @@ func TestSendLogsOTLP(t *testing.T) {
 		},
 	})
 
-	test.s.logBuffer = exampleTwoLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 	test.s.config.LogFormat = "otlp"
 
 	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "value", "key2": "value2"}))
@@ -536,7 +536,7 @@ func TestOverrideSourceName(t *testing.T) {
 		})
 
 		test.s.sources.name = getTestSourceFormat(t, "Test source name/%{key1}")
-		test.s.logBuffer = exampleLog()
+		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
 		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 		assert.NoError(t, err)
@@ -562,7 +562,7 @@ func TestOverrideSourceName(t *testing.T) {
 		})
 
 		test.s.sources.name = getTestSourceFormat(t, "Test source name/%{key1}")
-		test.s.logBuffer = exampleLog()
+		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
 		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 		assert.NoError(t, err)
@@ -580,7 +580,7 @@ func TestOverrideSourceCategory(t *testing.T) {
 		})
 
 		test.s.sources.category = getTestSourceFormat(t, "Test source category/%{key1}")
-		test.s.logBuffer = exampleLog()
+		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
 		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 		assert.NoError(t, err)
@@ -604,7 +604,7 @@ func TestOverrideSourceCategory(t *testing.T) {
 		})
 
 		test.s.sources.category = getTestSourceFormat(t, "Test source category/%{key1}")
-		test.s.logBuffer = exampleLog()
+		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
 		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 		assert.NoError(t, err)
@@ -620,7 +620,7 @@ func TestOverrideSourceHost(t *testing.T) {
 		})
 
 		test.s.sources.host = getTestSourceFormat(t, "Test source host/%{key1}")
-		test.s.logBuffer = exampleLog()
+		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
 		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 		assert.NoError(t, err)
@@ -644,7 +644,7 @@ func TestOverrideSourceHost(t *testing.T) {
 		})
 
 		test.s.sources.host = getTestSourceFormat(t, "Test source host/%{key1}")
-		test.s.logBuffer = exampleLog()
+		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
 		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 		assert.NoError(t, err)
@@ -655,13 +655,13 @@ func TestLogsBuffer(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){})
 
 	assert.Equal(t, test.s.countLogs(), 0)
-	logs := exampleTwoLogs()
+	logs := logRecordsToLogPair(exampleTwoLogs())
 
 	droppedLogs, err := test.s.batchLog(context.Background(), logs[0], newFields(pdata.NewAttributeMap()))
 	require.NoError(t, err)
 	assert.Nil(t, droppedLogs)
 	assert.Equal(t, 1, test.s.countLogs())
-	assert.Equal(t, []pdata.LogRecord{logs[0]}, test.s.logBuffer)
+	assert.Equal(t, []logPair{logs[0]}, test.s.logBuffer)
 
 	droppedLogs, err = test.s.batchLog(context.Background(), logs[1], newFields(pdata.NewAttributeMap()))
 	require.NoError(t, err)
@@ -671,14 +671,14 @@ func TestLogsBuffer(t *testing.T) {
 
 	test.s.cleanLogsBuffer()
 	assert.Equal(t, 0, test.s.countLogs())
-	assert.Equal(t, []pdata.LogRecord{}, test.s.logBuffer)
+	assert.Equal(t, []logPair{}, test.s.logBuffer)
 }
 
 func TestInvalidEndpoint(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){})
 
 	test.s.config.HTTPClientSettings.Endpoint = ":"
-	test.s.logBuffer = exampleLog()
+	test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
 	_, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, `parse ":": missing protocol scheme`)
@@ -688,7 +688,7 @@ func TestInvalidPostRequest(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){})
 
 	test.s.config.HTTPClientSettings.Endpoint = ""
-	test.s.logBuffer = exampleLog()
+	test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
 	_, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, `Post "": unsupported protocol scheme ""`)
@@ -698,7 +698,7 @@ func TestLogsBufferOverflow(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){})
 
 	test.s.config.HTTPClientSettings.Endpoint = ":"
-	log := exampleLog()
+	log := logRecordsToLogPair(exampleLog())
 	flds := newFields(pdata.NewAttributeMap())
 
 	for test.s.countLogs() < maxBufferSize-1 {


### PR DESCRIPTION
If metadata_attributes are configured and json attribute is being used, both names before and after translation should be added to metadata_attributes for proper behavior

adding attributes name before translation to metadata_attributes ensures that they will be send as fields
adding attributes name after translation to metadata_attributes ensures that they won't be send in json body