### PR TITLE
refactor(sumologicexporter): don't change attributes in place when translating

### DIFF
--- a/pkg/exporter/sumologicexporter/exporter.go
+++ b/pkg/exporter/sumologicexporter/exporter.go
@@ -301,7 +301,7 @@ func (se *sumologicexporter) pushLogsData(ctx context.Context, ld pdata.Logs) er
 				currentMetadata = sdr.filter.filterIn(attributes)
 
 				if se.config.TranslateAttributes {
-					currentMetadata.orig = translateAttributes(currentMetadata.orig)
+					currentMetadata.translateAttributes()
 				}
 
 				// If metadata differs from currently buffered, flush the buffer
@@ -393,7 +393,7 @@ func (se *sumologicexporter) pushMetricsData(ctx context.Context, md pdata.Metri
 
 		if se.config.TranslateAttributes {
 			attributes = translateAttributes(attributes)
-			currentMetadata.orig = translateAttributes(currentMetadata.orig)
+			currentMetadata.translateAttributes()
 		}
 
 		// iterate over InstrumentationLibraryMetrics

--- a/pkg/exporter/sumologicexporter/exporter_test.go
+++ b/pkg/exporter/sumologicexporter/exporter_test.go
@@ -46,6 +46,18 @@ func LogRecordsToLogs(records []pdata.LogRecord) pdata.Logs {
 	return logs
 }
 
+func logRecordsToLogPair(records []pdata.LogRecord) []logPair {
+	logs := make([]logPair, len(records))
+	for num, record := range records {
+		logs[num] = logPair{
+			log:        record,
+			attributes: record.Attributes(),
+		}
+	}
+
+	return logs
+}
+
 type exporterTest struct {
 	srv *httptest.Server
 	exp *sumologicexporter
@@ -503,7 +515,8 @@ func TestPushJSONLogsWithAttributeTranslation(t *testing.T) {
 		func(w http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			var regex string
-			regex += `{"InstanceType":"wizard","host":"harry-potter","log":"Example log","timestamp":\d{13}}`
+			// Mind that host attribute is not being send in log body
+			regex += `{"InstanceType":"wizard","log":"Example log","timestamp":\d{13}}`
 			assert.Regexp(t, regex, body)
 
 			assert.Equal(t, "host=harry-potter", req.Header.Get("X-Sumo-Fields"))

--- a/pkg/exporter/sumologicexporter/fields.go
+++ b/pkg/exporter/sumologicexporter/fields.go
@@ -58,3 +58,8 @@ func (f fields) string() string {
 func (f fields) sanitizeField(fld string) string {
 	return f.replacer.Replace(fld)
 }
+
+// translateAttributes translates fields to sumo format
+func (f *fields) translateAttributes() {
+	f.orig = translateAttributes(f.orig)
+}

--- a/pkg/exporter/sumologicexporter/sender.go
+++ b/pkg/exporter/sumologicexporter/sender.go
@@ -49,8 +49,15 @@ type metricPair struct {
 	metric     pdata.Metric
 }
 
+// logPair keeps information about logRecord and attributes,
+// where attributes are record and resource attributes
+type logPair struct {
+	attributes pdata.AttributeMap
+	log        pdata.LogRecord
+}
+
 type sender struct {
-	logBuffer           []pdata.LogRecord
+	logBuffer           []logPair
 	metricBuffer        []metricPair
 	config              *Config
 	client              *http.Client
@@ -181,17 +188,18 @@ func (s *sender) logToText(record pdata.LogRecord) string {
 }
 
 // logToJSON converts LogRecord to a json line, returns it and error eventually
-func (s *sender) logToJSON(record pdata.LogRecord) (string, error) {
-	attrs := pdata.NewAttributeMap()
-	record.Attributes().CopyTo(attrs)
+func (s *sender) logToJSON(record logPair) (string, error) {
+	data := s.filter.filterOut(record.attributes)
 	if s.jsonLogsConfig.AddTimestamp {
-		addJSONTimestamp(attrs, s.jsonLogsConfig.TimestampKey, record.Timestamp())
+		addJSONTimestamp(data.orig, s.jsonLogsConfig.TimestampKey, record.log.Timestamp())
 	}
 
-	data := s.filter.filterOut(attrs)
+	if s.config.TranslateAttributes {
+		data.translateAttributes()
+	}
 
 	// Only append the body when it's not empty to prevent sending 'null' log.
-	if body := record.Body(); !isEmptyAttributeValue(body) {
+	if body := record.log.Body(); !isEmptyAttributeValue(body) {
 		data.orig.Upsert(s.jsonLogsConfig.LogKey, body)
 	}
 
@@ -231,7 +239,7 @@ func isEmptyAttributeValue(att pdata.AttributeValue) bool {
 // sendLogs sends log records from the logBuffer formatted according
 // to configured LogFormat and as the result of execution
 // returns array of records which has not been sent correctly and error
-func (s *sender) sendLogs(ctx context.Context, flds fields) ([]pdata.LogRecord, error) {
+func (s *sender) sendLogs(ctx context.Context, flds fields) ([]logPair, error) {
 
 	// Follow different execution path for OTLP format
 	if s.config.LogFormat == OTLPLogFormat {
@@ -241,8 +249,8 @@ func (s *sender) sendLogs(ctx context.Context, flds fields) ([]pdata.LogRecord, 
 	var (
 		body           strings.Builder
 		errs           []error
-		droppedRecords []pdata.LogRecord
-		currentRecords []pdata.LogRecord
+		droppedRecords []logPair
+		currentRecords []logPair
 	)
 
 	for _, record := range s.logBuffer {
@@ -251,7 +259,7 @@ func (s *sender) sendLogs(ctx context.Context, flds fields) ([]pdata.LogRecord, 
 
 		switch s.config.LogFormat {
 		case TextFormat:
-			formattedLine = s.logToText(record)
+			formattedLine = s.logToText(record.log)
 		case JSONFormat:
 			formattedLine, err = s.logToJSON(record)
 		default:
@@ -303,7 +311,7 @@ func (s *sender) sendLogs(ctx context.Context, flds fields) ([]pdata.LogRecord, 
 // sendLogs sends log records from the logBuffer in OTLP format and as a result
 // it returns an array of records which has not been sent correctly and an error.
 // TODO: add support for HTTP limits
-func (s *sender) sendOTLPLogs(ctx context.Context, flds fields) ([]pdata.LogRecord, error) {
+func (s *sender) sendOTLPLogs(ctx context.Context, flds fields) ([]logPair, error) {
 	ld := pdata.NewLogs()
 	rl := ld.ResourceLogs().AppendEmpty()
 	ill := rl.InstrumentationLibraryLogs().AppendEmpty()
@@ -311,7 +319,10 @@ func (s *sender) sendOTLPLogs(ctx context.Context, flds fields) ([]pdata.LogReco
 	logs.EnsureCapacity(len(s.logBuffer))
 	for _, record := range s.logBuffer {
 		log := logs.AppendEmpty()
-		record.CopyTo(log)
+		record.log.CopyTo(log)
+		log.Attributes().Clear()
+		log.Attributes().EnsureCapacity(record.attributes.Len())
+		record.attributes.CopyTo(log.Attributes())
 
 		// Clear timestamp if required
 		if s.config.ClearLogsTimestamp {
@@ -505,7 +516,7 @@ func (s *sender) cleanLogsBuffer() {
 
 // batchLog adds log to the logBuffer and flushes them if logBuffer is full to avoid overflow
 // returns list of log records which were not sent successfully
-func (s *sender) batchLog(ctx context.Context, log pdata.LogRecord, metadata fields) ([]pdata.LogRecord, error) {
+func (s *sender) batchLog(ctx context.Context, log logPair, metadata fields) ([]logPair, error) {
 	s.logBuffer = append(s.logBuffer, log)
 
 	if s.countLogs() >= maxBufferSize {

--- a/pkg/exporter/sumologicexporter/sender_test.go
+++ b/pkg/exporter/sumologicexporter/sender_test.go
@@ -279,7 +279,7 @@ func TestSendLogs(t *testing.T) {
 		},
 	})
 
-	test.s.logBuffer = exampleTwoLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
 	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "value", "key2": "value2"}))
 	assert.NoError(t, err)
@@ -299,7 +299,7 @@ func TestSendLogsMultitype(t *testing.T) {
 		},
 	})
 
-	test.s.logBuffer = exampleMultitypeLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleMultitypeLogs())
 
 	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "value", "key2": "value2"}))
 	assert.NoError(t, err)
@@ -319,7 +319,7 @@ func TestSendLogsSplit(t *testing.T) {
 		},
 	})
 	test.s.config.MaxRequestBodySize = 10
-	test.s.logBuffer = exampleTwoLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
 	_, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.NoError(t, err)
@@ -341,7 +341,7 @@ func TestSendLogsSplitFailedOne(t *testing.T) {
 	})
 	test.s.config.MaxRequestBodySize = 10
 	test.s.config.LogFormat = TextFormat
-	test.s.logBuffer = exampleTwoLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
 	dropped, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, "error during sending data: 500 Internal Server Error")
@@ -367,7 +367,7 @@ func TestSendLogsSplitFailedAll(t *testing.T) {
 	})
 	test.s.config.MaxRequestBodySize = 10
 	test.s.config.LogFormat = TextFormat
-	test.s.logBuffer = exampleTwoLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
 	dropped, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(
@@ -457,7 +457,7 @@ func TestSendLogsJsonConfig(t *testing.T) {
 			}, tc.configOpts...)
 
 			test.s.config.LogFormat = JSONFormat
-			test.s.logBuffer = exampleTwoLogs()
+			test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
 			_, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 			assert.NoError(t, err)
@@ -483,7 +483,7 @@ func TestSendLogsJson(t *testing.T) {
 		},
 	})
 	test.s.config.LogFormat = JSONFormat
-	test.s.logBuffer = exampleTwoLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
 	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key": "value"}))
 	assert.NoError(t, err)
@@ -507,7 +507,7 @@ func TestSendLogsJsonMultitype(t *testing.T) {
 		},
 	})
 	test.s.config.LogFormat = JSONFormat
-	test.s.logBuffer = exampleMultitypeLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleMultitypeLogs())
 
 	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key": "value"}))
 	assert.NoError(t, err)
@@ -532,7 +532,7 @@ func TestSendLogsJsonSplit(t *testing.T) {
 	})
 	test.s.config.LogFormat = JSONFormat
 	test.s.config.MaxRequestBodySize = 10
-	test.s.logBuffer = exampleTwoLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
 	_, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.NoError(t, err)
@@ -561,7 +561,7 @@ func TestSendLogsJsonSplitFailedOne(t *testing.T) {
 	})
 	test.s.config.LogFormat = JSONFormat
 	test.s.config.MaxRequestBodySize = 10
-	test.s.logBuffer = exampleTwoLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
 	dropped, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, "error during sending data: 500 Internal Server Error")
@@ -593,7 +593,7 @@ func TestSendLogsJsonSplitFailedAll(t *testing.T) {
 	})
 	test.s.config.LogFormat = JSONFormat
 	test.s.config.MaxRequestBodySize = 10
-	test.s.logBuffer = exampleTwoLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
 	dropped, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(
@@ -612,7 +612,7 @@ func TestSendLogsUnexpectedFormat(t *testing.T) {
 		},
 	})
 	test.s.config.LogFormat = "dummy"
-	logs := exampleTwoLogs()
+	logs := logRecordsToLogPair(exampleTwoLogs())
 	test.s.logBuffer = logs
 
 	dropped, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
@@ -632,7 +632,7 @@ func TestSendLogsOTLP(t *testing.T) {
 		},
 	})
 
-	test.s.logBuffer = exampleTwoLogs()
+	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 	test.s.config.LogFormat = "otlp"
 
 	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "value", "key2": "value2"}))
@@ -650,7 +650,7 @@ func TestOverrideSourceName(t *testing.T) {
 		})
 
 		test.s.sources.name = getTestSourceFormat(t, "Test source name/%{key1}")
-		test.s.logBuffer = exampleLog()
+		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
 		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 		assert.NoError(t, err)
@@ -668,7 +668,7 @@ func TestOverrideSourceName(t *testing.T) {
 		})
 
 		test.s.sources.name = getTestSourceFormat(t, "Test source name/%{key1}")
-		test.s.logBuffer = exampleLog()
+		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
 		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 		assert.NoError(t, err)
@@ -694,7 +694,7 @@ func TestOverrideSourceName(t *testing.T) {
 		})
 
 		test.s.sources.name = getTestSourceFormat(t, "Test source name/%{key1}")
-		test.s.logBuffer = exampleLog()
+		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
 		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 		assert.NoError(t, err)
@@ -712,7 +712,7 @@ func TestOverrideSourceCategory(t *testing.T) {
 		})
 
 		test.s.sources.category = getTestSourceFormat(t, "Test source category/%{key1}")
-		test.s.logBuffer = exampleLog()
+		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
 		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 		assert.NoError(t, err)
@@ -728,7 +728,7 @@ func TestOverrideSourceCategory(t *testing.T) {
 		})
 
 		test.s.sources.category = getTestSourceFormat(t, "Test source category/%{key1}")
-		test.s.logBuffer = exampleLog()
+		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
 		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 		assert.NoError(t, err)
@@ -754,7 +754,7 @@ func TestOverrideSourceCategory(t *testing.T) {
 		})
 
 		test.s.sources.category = getTestSourceFormat(t, "Test source category/%{key1}")
-		test.s.logBuffer = exampleLog()
+		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
 		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 		assert.NoError(t, err)
@@ -770,7 +770,7 @@ func TestOverrideSourceHost(t *testing.T) {
 		})
 
 		test.s.sources.host = getTestSourceFormat(t, "Test source host/%{key1}")
-		test.s.logBuffer = exampleLog()
+		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
 		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 		assert.NoError(t, err)
@@ -786,7 +786,7 @@ func TestOverrideSourceHost(t *testing.T) {
 		})
 
 		test.s.sources.host = getTestSourceFormat(t, "Test source host/%{key1}")
-		test.s.logBuffer = exampleLog()
+		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
 		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 		assert.NoError(t, err)
@@ -812,7 +812,7 @@ func TestOverrideSourceHost(t *testing.T) {
 		})
 
 		test.s.sources.host = getTestSourceFormat(t, "Test source host/%{key1}")
-		test.s.logBuffer = exampleLog()
+		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
 		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 		assert.NoError(t, err)
@@ -869,7 +869,7 @@ func TestLogsDontSendSourceFieldsInXSumoFieldsHeader(t *testing.T) {
 		test.s.sources.name = getTestSourceFormat(t, "Test source name/%{key1}/%{_sourceName}")
 		test.s.sources.host = getTestSourceFormat(t, "Test source host/%{key1}")
 		test.s.sources.category = getTestSourceFormat(t, "Test source category/%{key1}")
-		test.s.logBuffer = exampleLog()
+		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
 		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(
 			map[string]string{
@@ -888,13 +888,13 @@ func TestLogsBuffer(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){})
 
 	assert.Equal(t, test.s.countLogs(), 0)
-	logs := exampleTwoLogs()
+	logs := logRecordsToLogPair(exampleTwoLogs())
 
 	droppedLogs, err := test.s.batchLog(context.Background(), logs[0], newFields(pdata.NewAttributeMap()))
 	require.NoError(t, err)
 	assert.Nil(t, droppedLogs)
 	assert.Equal(t, 1, test.s.countLogs())
-	assert.Equal(t, []pdata.LogRecord{logs[0]}, test.s.logBuffer)
+	assert.Equal(t, []logPair{logs[0]}, test.s.logBuffer)
 
 	droppedLogs, err = test.s.batchLog(context.Background(), logs[1], newFields(pdata.NewAttributeMap()))
 	require.NoError(t, err)
@@ -904,14 +904,14 @@ func TestLogsBuffer(t *testing.T) {
 
 	test.s.cleanLogsBuffer()
 	assert.Equal(t, 0, test.s.countLogs())
-	assert.Equal(t, []pdata.LogRecord{}, test.s.logBuffer)
+	assert.Equal(t, []logPair{}, test.s.logBuffer)
 }
 
 func TestInvalidEndpoint(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){})
 
 	test.s.config.HTTPClientSettings.Endpoint = ":"
-	test.s.logBuffer = exampleLog()
+	test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
 	_, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, `parse ":": missing protocol scheme`)
@@ -921,7 +921,7 @@ func TestInvalidPostRequest(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){})
 
 	test.s.config.HTTPClientSettings.Endpoint = ""
-	test.s.logBuffer = exampleLog()
+	test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
 	_, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, `Post "": unsupported protocol scheme ""`)
@@ -931,7 +931,7 @@ func TestLogsBufferOverflow(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){})
 
 	test.s.config.HTTPClientSettings.Endpoint = ":"
-	log := exampleLog()
+	log := logRecordsToLogPair(exampleLog())
 	flds := newFields(pdata.NewAttributeMap())
 
 	for test.s.countLogs() < maxBufferSize-1 {


### PR DESCRIPTION
- Stop rewriting structures in place
- Fix duplicating translated metadata in X-Sumo-Fields and Json format