### PR TITLE
feat(sourceprocessor)!: allow templating of source host field

### DIFF
--- a/pkg/processor/sourceprocessor/README.md
+++ b/pkg/processor/sourceprocessor/README.md
@@ -13,6 +13,10 @@ processors:
     # default: ""
     collector: <collector>
 
+    # Template for source host, put in `_sourceHost` tag.
+    # default: "%{k8s.pod.hostname}"
+    source_host: <source_host>
+
     # Template for source name, put in `_sourceName` tag.
     # default: "%{k8s.namespace.name}.%{k8s.pod.name}.%{k8s.container.name}"
     source_name: <source_name>
@@ -55,10 +59,6 @@ processors:
     # default: "k8s.pod.label.pod-template-hash"
     pod_template_has_key: <pod_template_hash_key>
 
-    # Name of the attribute that contains the source host.
-    # default: "k8s.pod.hostname"
-    source_host_key: <source_host_key>
-
     # See "Container-level pod annotations" section below
     container_annotations:
       # Specifies whether container-level annotations are enabled.
@@ -73,7 +73,7 @@ processors:
 
 ## Source templates
 
-You can specify a template with an attribute for `source_category`, `source_name`, using `%{attr_name}`.
+You can specify a template with an attribute for `source_category`, `source_host`, `source_name`, using `%{attr_name}`.
 
 For example, when there is an attribute `my_attr`: `my_value`, `metrics/%{my_attr}`
 will be expanded to `metrics/my_value`.
@@ -125,7 +125,7 @@ The following [Kubernetes annotations][k8s_annotations_doc] can be used on pods:
 - `sumologic.com/sourceCategory` - overrides `source_category` config option
 - `sumologic.com/sourceCategoryPrefix` - overrides `source_category_prefix` config option
 - `sumologic.com/sourceCategoryReplaceDash` - overrides `source_category_replace_dash` config option
-- `sumologic.com/sourceHost` - overrides `source_host_key` config option;
+- `sumologic.com/sourceHost` - overrides `source_host` config option;
   the value of this annotation will be set as the value of the `_sourceHost` resource attribute
 - `sumologic.com/sourceName` - overrides `source_name` config option;
   the value of this annotation will be set as the value of the `_sourceName` resource attribute
@@ -169,7 +169,6 @@ setting the following annotations on the pod:
 
 will make the logs from `container-name-1` be tagged with source category `first_source-category`
 and logs from `container-name-2` be tagged with source category `another/source-category`.
-
 
 If there is more than one prefix defined in `container_annotations.prefixes`,
 they are checked in the order they are defined in. If an annotation is found for one prefix,

--- a/pkg/processor/sourceprocessor/attribute_filler.go
+++ b/pkg/processor/sourceprocessor/attribute_filler.go
@@ -42,7 +42,7 @@ type attributeFiller struct {
 	labels          []string
 }
 
-func extractFormat(format string, name string, keys sourceKeys) attributeFiller {
+func extractFormat(format string, name string) attributeFiller {
 	labels := make([]string, 0)
 	matches := formatRegex.FindAllStringSubmatch(format, -1)
 	for _, matchset := range matches {
@@ -59,20 +59,20 @@ func extractFormat(format string, name string, keys sourceKeys) attributeFiller 
 	}
 }
 
-func createSourceHostFiller(cfg *Config, keys sourceKeys) attributeFiller {
-	filler := extractFormat(cfg.SourceHost, sourceHostKey, keys)
+func createSourceHostFiller(cfg *Config) attributeFiller {
+	filler := extractFormat(cfg.SourceHost, sourceHostKey)
 	return filler
 }
 
-func createSourceNameFiller(cfg *Config, keys sourceKeys) attributeFiller {
-	filler := extractFormat(cfg.SourceName, sourceNameKey, keys)
+func createSourceNameFiller(cfg *Config) attributeFiller {
+	filler := extractFormat(cfg.SourceName, sourceNameKey)
 	return filler
 }
 
-func (f *attributeFiller) fillResourceOrUseAnnotation(atts *pdata.AttributeMap, annotationKey string, keys sourceKeys) bool {
+func (f *attributeFiller) fillResourceOrUseAnnotation(atts *pdata.AttributeMap, annotationKey string) bool {
 	val, found := atts.Get(annotationKey)
 	if found {
-		annotationFiller := extractFormat(val.StringVal(), f.name, keys)
+		annotationFiller := extractFormat(val.StringVal(), f.name)
 		annotationFiller.dashReplacement = f.dashReplacement
 		annotationFiller.compiledFormat = f.prefix + annotationFiller.compiledFormat
 		return annotationFiller.fillAttributes(atts)

--- a/pkg/processor/sourceprocessor/attribute_filler.go
+++ b/pkg/processor/sourceprocessor/attribute_filler.go
@@ -42,16 +42,6 @@ type attributeFiller struct {
 	labels          []string
 }
 
-func createSourceHostFiller(sourceHostAttrName string) attributeFiller {
-	return attributeFiller{
-		name:            sourceHostKey,
-		compiledFormat:  "%s",
-		dashReplacement: "",
-		labels:          []string{sourceHostAttrName},
-		prefix:          "",
-	}
-}
-
 func extractFormat(format string, name string, keys sourceKeys) attributeFiller {
 	labels := make([]string, 0)
 	matches := formatRegex.FindAllStringSubmatch(format, -1)
@@ -67,6 +57,11 @@ func extractFormat(format string, name string, keys sourceKeys) attributeFiller 
 		labels:          labels,
 		prefix:          "",
 	}
+}
+
+func createSourceHostFiller(cfg *Config, keys sourceKeys) attributeFiller {
+	filler := extractFormat(cfg.SourceHost, sourceHostKey, keys)
+	return filler
 }
 
 func createSourceNameFiller(cfg *Config, keys sourceKeys) attributeFiller {

--- a/pkg/processor/sourceprocessor/config.go
+++ b/pkg/processor/sourceprocessor/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	*config.ProcessorSettings `mapstructure:"-"`
 
 	Collector                 string `mapstructure:"collector"`
+	SourceHost                string `mapstructure:"source_host"`
 	SourceName                string `mapstructure:"source_name"`
 	SourceCategory            string `mapstructure:"source_category"`
 	SourceCategoryPrefix      string `mapstructure:"source_category_prefix"`
@@ -38,7 +39,6 @@ type Config struct {
 	PodKey             string `mapstructure:"pod_key"`
 	PodNameKey         string `mapstructure:"pod_name_key"`
 	PodTemplateHashKey string `mapstructure:"pod_template_hash_key"`
-	SourceHostKey      string `mapstructure:"source_host_key"`
 
 	ContainerAnnotations ContainerAnnotationsConfig `mapstructure:"container_annotations"`
 }

--- a/pkg/processor/sourceprocessor/config_test.go
+++ b/pkg/processor/sourceprocessor/config_test.go
@@ -48,6 +48,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, p2, &Config{
 		ProcessorSettings:         &ps2,
 		Collector:                 "somecollector",
+		SourceHost:                "%{k8s.pod.hostname}",
 		SourceName:                "%{k8s.namespace.name}.%{k8s.pod.name}.%{k8s.container.name}/foo",
 		SourceCategory:            "%{k8s.namespace.name}/%{k8s.pod.pod_name}/bar",
 		SourceCategoryPrefix:      "kubernetes/",
@@ -64,7 +65,6 @@ func TestLoadConfig(t *testing.T) {
 		PodKey:             "k8s.pod.name",
 		PodNameKey:         "k8s.pod.pod_name",
 		PodTemplateHashKey: "pod_labels_pod-template-hash",
-		SourceHostKey:      "k8s.pod.hostname",
 
 		ContainerAnnotations: ContainerAnnotationsConfig{
 			Enabled: false,

--- a/pkg/processor/sourceprocessor/factory.go
+++ b/pkg/processor/sourceprocessor/factory.go
@@ -29,6 +29,7 @@ const (
 
 	defaultCollector = ""
 
+	defaultSourceHost                = "%{k8s.pod.hostname}"
 	defaultSourceName                = "%{k8s.namespace.name}.%{k8s.pod.name}.%{k8s.container.name}"
 	defaultSourceCategory            = "%{k8s.namespace.name}/%{k8s.pod.pod_name}"
 	defaultSourceCategoryPrefix      = "kubernetes/"
@@ -38,7 +39,6 @@ const (
 	defaultPodKey             = "k8s.pod.name"
 	defaultPodNameKey         = "k8s.pod.pod_name"
 	defaultPodTemplateHashKey = "k8s.pod.label.pod-template-hash"
-	defaultSourceHostKey      = "k8s.pod.hostname"
 )
 
 var processorCapabilities = consumer.Capabilities{MutatesData: true}
@@ -60,6 +60,7 @@ func createDefaultConfig() config.Processor {
 	return &Config{
 		ProcessorSettings:         &ps,
 		Collector:                 defaultCollector,
+		SourceHost:                defaultSourceHost,
 		SourceName:                defaultSourceName,
 		SourceCategory:            defaultSourceCategory,
 		SourceCategoryPrefix:      defaultSourceCategoryPrefix,
@@ -69,7 +70,6 @@ func createDefaultConfig() config.Processor {
 		PodKey:             defaultPodKey,
 		PodNameKey:         defaultPodNameKey,
 		PodTemplateHashKey: defaultPodTemplateHashKey,
-		SourceHostKey:      defaultSourceHostKey,
 
 		ContainerAnnotations: ContainerAnnotationsConfig{
 			Enabled: false,

--- a/pkg/processor/sourceprocessor/source_processor.go
+++ b/pkg/processor/sourceprocessor/source_processor.go
@@ -32,7 +32,6 @@ type sourceKeys struct {
 	podKey             string
 	podNameKey         string
 	podTemplateHashKey string
-	sourceHostKey      string
 }
 
 // dockerLog represents log from k8s using docker log driver send by FluentBit
@@ -89,7 +88,6 @@ func newSourceProcessor(cfg *Config) *sourceProcessor {
 		podKey:             cfg.PodKey,
 		podNameKey:         cfg.PodNameKey,
 		podTemplateHashKey: cfg.PodTemplateHashKey,
-		sourceHostKey:      cfg.SourceHostKey,
 	}
 
 	exclude := make(map[string]*regexp.Regexp)
@@ -102,7 +100,7 @@ func newSourceProcessor(cfg *Config) *sourceProcessor {
 	return &sourceProcessor{
 		collector:            cfg.Collector,
 		keys:                 keys,
-		sourceHostFiller:     createSourceHostFiller(cfg.SourceHostKey),
+		sourceHostFiller:     createSourceHostFiller(cfg, keys),
 		sourceCategoryFiller: newSourceCategoryFiller(cfg),
 		sourceNameFiller:     createSourceNameFiller(cfg, keys),
 		exclude:              exclude,

--- a/pkg/processor/sourceprocessor/source_processor.go
+++ b/pkg/processor/sourceprocessor/source_processor.go
@@ -100,9 +100,9 @@ func newSourceProcessor(cfg *Config) *sourceProcessor {
 	return &sourceProcessor{
 		collector:            cfg.Collector,
 		keys:                 keys,
-		sourceHostFiller:     createSourceHostFiller(cfg, keys),
+		sourceHostFiller:     createSourceHostFiller(cfg),
 		sourceCategoryFiller: newSourceCategoryFiller(cfg),
-		sourceNameFiller:     createSourceNameFiller(cfg, keys),
+		sourceNameFiller:     createSourceNameFiller(cfg),
 		exclude:              exclude,
 	}
 }
@@ -259,12 +259,10 @@ func (sp *sourceProcessor) processResource(res pdata.Resource) pdata.Resource {
 
 	sp.sourceHostFiller.fillResourceOrUseAnnotation(&atts,
 		sp.annotationAttribute(sourceHostSpecialAnnotation),
-		sp.keys,
 	)
 	sp.sourceCategoryFiller.fill(&atts)
 	sp.sourceNameFiller.fillResourceOrUseAnnotation(&atts,
 		sp.annotationAttribute(sourceNameSpecialAnnotation),
-		sp.keys,
 	)
 
 	return res

--- a/pkg/processor/sourceprocessor/source_processor_test.go
+++ b/pkg/processor/sourceprocessor/source_processor_test.go
@@ -179,7 +179,7 @@ func TestLogsSourceHostKey(t *testing.T) {
 	t.Run("works using existing resource attribute", func(t *testing.T) {
 		config := NewFactory().CreateDefaultConfig().(*Config)
 		config.SourceName = "will-it-work-%{_HOSTNAME}"
-		config.SourceHostKey = "_HOSTNAME"
+		config.SourceHost = "%{_HOSTNAME}"
 
 		pLogs := newLogsDataWithLogs(resourceAttrs, logAttrs)
 
@@ -211,7 +211,7 @@ func TestLogsSourceHostKey(t *testing.T) {
 	t.Run("does not work using record attribute", func(t *testing.T) {
 		config := NewFactory().CreateDefaultConfig().(*Config)
 		config.SourceName = "will-it-work-%{_CMDLINE}"
-		config.SourceHostKey = "_CMDLINE"
+		config.SourceHost = "%{_CMDLINE}"
 
 		pLogs := newLogsDataWithLogs(resourceAttrs, logAttrs)
 

--- a/pkg/processor/sourceprocessor/testdata/config.yaml
+++ b/pkg/processor/sourceprocessor/testdata/config.yaml
@@ -7,6 +7,7 @@ processors:
   # The following specifies a non-trivial source
   source/2:
     collector: "somecollector"
+    source_host: "%{k8s.pod.hostname}"
     source_name: "%{k8s.namespace.name}.%{k8s.pod.name}.%{k8s.container.name}/foo"
     source_category: "%{k8s.namespace.name}/%{k8s.pod.pod_name}/bar"
     source_category_prefix: "kubernetes/"
@@ -22,7 +23,6 @@ processors:
     pod_template_hash_key: "pod_labels_pod-template-hash"
     pod_name_key: "k8s.pod.pod_name"
     pod_key: "k8s.pod.name"
-    source_host_key: "k8s.pod.hostname"
 
 exporters:
   nop:


### PR DESCRIPTION
This change replaces `source_host_key` configuration option with `source_host` option.
This is for consistency, to allow templating of source host field in the same way that source name and source category fields can be templated.

BREAKING CHANGE: `source_host_key` option is removed in favor of `source_host` option.
To upgrade, take the value of `source_host_key`, surround it with `'%{` and `}'`, and put it in `source_host` option.
For example: `source_host_key: k8s.pod.hostname` should be changed to `source_host: '%{k8s.pod.hostname}'`