### PR TITLE
fix(sumologicexporter): fix attribute translation for otlp logs

### DIFF
--- a/pkg/exporter/sumologicexporter/sender.go
+++ b/pkg/exporter/sumologicexporter/sender.go
@@ -322,7 +322,12 @@ func (s *sender) sendOTLPLogs(ctx context.Context, flds fields) ([]logPair, erro
 		record.log.CopyTo(log)
 		log.Attributes().Clear()
 		log.Attributes().EnsureCapacity(record.attributes.Len())
-		record.attributes.CopyTo(log.Attributes())
+
+		if s.config.TranslateAttributes {
+			translateAttributes(record.attributes).CopyTo(log.Attributes())
+		} else {
+			record.attributes.CopyTo(log.Attributes())
+		}
 
 		// Clear timestamp if required
 		if s.config.ClearLogsTimestamp {


### PR DESCRIPTION
This PR additionally cleans up the tests around attribute translation so that each format has its own test with subtests (similar boilerplate makes it easier to compare across formats the effect of translation).