### PR TITLE
ci: unify github actions cache names to prevent eviction

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -83,9 +83,9 @@ jobs:
             /home/runner/.cache/go-build
             /Users/runner/go/pkg/mod
             /Users/runner/Library/Caches/go-build
-          key: ${{matrix.arch_os}}-go-pkg-${{matrix.go}}-${{ hashFiles('**/go.sum') }}
+          key: ${{matrix.arch_os}}-go-${{matrix.go}}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{matrix.arch_os}}-go-pkg-${{matrix.go}}-
+            ${{matrix.arch_os}}-go-${{matrix.go}}-
 
       - name: Run tests
         run: make gotest
@@ -112,9 +112,9 @@ jobs:
           path: |
             /home/runner/go/pkg/mod
             /home/runner/.cache/go-build
-          key: ${{matrix.arch_os}}-go-lint-${{matrix.go}}-${{ hashFiles('**/go.sum') }}
+          key: ${{matrix.arch_os}}-go-${{matrix.go}}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{matrix.arch_os}}-go-lint-${{matrix.go}}-
+            ${{matrix.arch_os}}-go-${{matrix.go}}-
 
       - name: Install golangci-lint
         run: make install-golangci-lint


### PR DESCRIPTION
It seems that we're hitting the cache size limit of 5GB [1] since upon rebuilding the project the caches are not being used every time even though their IDs stay the same. 

Example of CI run not hitting the cache: https://github.com/SumoLogic/sumologic-otel-collector/pull/300/checks?check_run_id=3859067401

This PR tries to address that by using only one cache name instead of 3 separate ones for tests, lints and builds separately.

[1]: https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy