### PR TITLE
feat(routingprocessor): add routing on all signals

### DIFF
--- a/otelcolbuilder/.otelcol-builder.yaml
+++ b/otelcolbuilder/.otelcol-builder.yaml
@@ -100,9 +100,12 @@ replaces:
   # https://github.com/pmalek-sumo/opentelemetry-collector-contrib/commit/11de2c03d3dbbde2e73b8a816318a2515c843985
   - github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor => github.com/SumoLogic/opentelemetry-collector-contrib/processor/filterprocessor 11de2c03d3dbbde2e73b8a816318a2515c843985
 
-  # Use features from branch https://github.com/sumologic/opentelemetry-collector-contrib/tree/v0.36.0-feat-routingprocessor-route-on-resource-attributes
+  # Use features from branch:
+  # https://github.com/SumoLogic/opentelemetry-collector-contrib/tree/v0.36.0-routingprocessor-allow-routing-on-all-signals
   # This replacement should be removed when all the features from the branch are upstreamed.
-  - github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor => github.com/SumoLogic/opentelemetry-collector-contrib/processor/routingprocessor e4d0740a3729724df5b4864d43f4931185e41d47
+  # One PR addressing the above can be found here:
+  # * https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5694
+  - github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor => github.com/SumoLogic/opentelemetry-collector-contrib/processor/routingprocessor 9c497458a97b5b6772915da177df6f8f5b67e1e2
 
   # TODO: remove this when fluentforwardreceiver support for complex object is accepted, merged and released upstream
   # PR: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5676

--- a/otelcolbuilder/cmd/collector_config_test.go
+++ b/otelcolbuilder/cmd/collector_config_test.go
@@ -63,6 +63,10 @@ func TestBuiltCollectorWithConfigurationFiles(t *testing.T) {
 			name:       "filelog with sumologicexporter with persistent queue enabled",
 			configFile: "testdata/filelog_sumologicexporter_with_persistent_queue_enabled.yaml",
 		},
+		{
+			name:       "telegrafreceiver with routingprocessor",
+			configFile: "testdata/telegrafreceiver_routingprocessor.yaml",
+		},
 	}
 
 	for _, tc := range testcases {

--- a/otelcolbuilder/cmd/testdata/telegrafreceiver_routingprocessor.yaml
+++ b/otelcolbuilder/cmd/testdata/telegrafreceiver_routingprocessor.yaml
@@ -1,0 +1,52 @@
+receivers:
+  telegraf:
+    separate_field: false
+    agent_config: |
+      [agent]
+        interval = "1s"
+        flush_interval = "1s"
+        debug = true
+      [[inputs.cpu]]
+        percpu = true
+        totalcpu = true
+      [[inputs.disk]]
+      [[inputs.net]]
+        interfaces = ["eth*", "en*", "lo*"]
+        ignore_protocol_stats = true
+      [[inputs.netstat]]
+      [[inputs.diskio]]
+      [[inputs.mem]]
+
+processors:
+  resource:
+    attributes:
+    - key: _sourceHost
+      from_attribute: host
+      action: insert
+  routing:
+    default_exporters:
+    - sumologic/1
+    attribute_source: resource
+    from_attribute: _sourceHost
+    table:
+    - value: localhost
+      exporters:
+      - sumologic/2
+
+exporters:
+  sumologic/1:
+    endpoint: http://dummy.endpoint.com:8888/api
+  sumologic/2:
+    endpoint: http://dummy.endpoint.com:8888/api/v2
+
+service:
+  pipelines:
+    metrics:
+      receivers:
+      - telegraf
+      processors:
+      - resource
+      - routing
+      exporters:
+      - sumologic/1
+      - sumologic/2


### PR DESCRIPTION
related branch: https://github.com/SumoLogic/opentelemetry-collector-contrib/tree/v0.36.0-routingprocessor-allow-routing-on-all-signals