### PR TITLE
fix(ci): fix pulling tag for dev and release builds

### DIFF
--- a/ci/build-push-multiplatform.sh
+++ b/ci/build-push-multiplatform.sh
@@ -75,17 +75,19 @@ function build_push() {
 
     echo "Building tag: ${TAG}"
     if [[ "${PUSH}" == true ]]; then
-        # load flag is needed so that docker loads this image
-        # for subsequent steps on github actions
         docker buildx build \
             --push \
             --file "${DOCKERFILE}" \
             --build-arg BUILD_TAG="${BUILD_TAG}" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             --platform="${PLATFORM}" \
-            --load \
             --tag "${TAG}" \
             .
+
+        # This is needed on CI because the above build command does not include
+        # --load flag, which is forbidded to be used together with --push, hence
+        # the docker pull.
+        docker pull "${TAG}"
 
         echo "Tagging: ${LATEST_TAG}"
         docker tag "${TAG}" "${LATEST_TAG}"


### PR DESCRIPTION
It seems that we cannot use `--pull` and `--load` as arguments to `docker buildx build` at the same time:

https://github.com/SumoLogic/sumologic-otel-collector/runs/3879996838?check_suite_focus=true

```
docker buildx build --push --file Dockerfile --build-arg BUILD_TAG=0.0.35-beta.0 --build-arg BUILDKIT_INLINE_CACHE=1 --platform=linux/arm64 --load --tag public.ecr.aws/a4t4y2n3/sumologic-otel-collector:0.0.35-beta.0-arm64 .
Building tag: public.ecr.aws/a4t4y2n3/sumologic-otel-collector:0.0.35-beta.0-arm64
error: push and load may not be set together at the moment
```