### PR TITLE
feat(sumologicextension): add api base URL to credentials file path hash

### DIFF
--- a/pkg/extension/sumologicextension/extension.go
+++ b/pkg/extension/sumologicextension/extension.go
@@ -118,7 +118,12 @@ func newSumologicExtension(conf *Config, logger *zap.Logger) (*SumologicExtensio
 }
 
 func createHashKey(conf *Config) string {
-	return fmt.Sprintf("%s%s%s", conf.CollectorName, conf.Credentials.AccessID, conf.Credentials.AccessKey)
+	return fmt.Sprintf("%s%s%s%s",
+		conf.CollectorName,
+		conf.Credentials.AccessID,
+		conf.Credentials.AccessKey,
+		strings.TrimSuffix(conf.ApiBaseUrl, "/"),
+	)
 }
 
 func (se *SumologicExtension) validateCredenials(


### PR DESCRIPTION
With this PR users will be able to use multiple `sumologicextension`s with the same collector names, access key and access ID and with different api base URLs.

Without this PR the local credentials files would overwrite themselves because api base URL would not be taken into account when creating the credentials file's name.