### PR TITLE
Add missing interface method for configauth.ClientAuthenticator

### DIFF
--- a/pkg/extension/sumologicextension/extension.go
+++ b/pkg/extension/sumologicextension/extension.go
@@ -33,7 +33,9 @@ import (
 	"github.com/google/uuid"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/configauth"
 	"go.uber.org/zap"
+	grpccredentials "google.golang.org/grpc/credentials"
 
 	"github.com/SumoLogic/sumologic-otel-collector/pkg/extension/sumologicextension/api"
 )
@@ -72,6 +74,11 @@ const (
 const (
 	DefaultHeartbeatInterval = 15 * time.Second
 )
+
+var errGRPCNotSupported = fmt.Errorf("gRPC is not supported by sumologicextension")
+
+// SumologicExtension implements ClientAuthenticator
+var _ configauth.ClientAuthenticator = (*SumologicExtension)(nil)
 
 func newSumologicExtension(conf *Config, logger *zap.Logger) (*SumologicExtension, error) {
 	if conf.Credentials.AccessID == "" || conf.Credentials.AccessKey == "" {
@@ -484,6 +491,10 @@ func (se *SumologicExtension) RoundTripper(base http.RoundTripper) (http.RoundTr
 		collectorCredentialKey: se.registrationInfo.CollectorCredentialKey,
 		base:                   base,
 	}, nil
+}
+
+func (se *SumologicExtension) PerRPCCredentials() (grpccredentials.PerRPCCredentials, error) {
+	return nil, errGRPCNotSupported
 }
 
 type roundTripper struct {


### PR DESCRIPTION
Before:
```
Error: cannot start exporters: failed to create HTTP Client: requested authenticator is not a client authenticator

2021/11/17 11:58:54 collector server run finished with error: cannot start exporters: failed to create HTTP Client: requested authenticator is not a client authenticator
```

After:
```
2021-11-17T12:00:40.633+0100	info	service/collector.go:132	Everything is ready. Begin running and processing data.
2021-11-17T12:00:40.876+0100	debug	sumologicextension@v0.38.0/extension.go:425	Heartbeat sent	{"kind": "extension", "name": "sumologic/otc-extension", "collector_name": "Collector_Test_Otc-ubuntu1804LTS-1637162421020", "collector_id": "0000000006530DFC"}
```