### PR TITLE
Revert "chore(deps): bump tj-actions/changed-files from 11 to 12 (#360)"

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Check if test related files changed
         id: changed-files
-        uses: tj-actions/changed-files@v12
+        uses: tj-actions/changed-files@v11
         with:
           files: |
             pkg/
@@ -130,7 +130,7 @@ jobs:
 
       - name: Check if files changed that need linting
         id: changed-files
-        uses: tj-actions/changed-files@v12
+        uses: tj-actions/changed-files@v11
         with:
           files: |
             otelcolbuilder/cmd/
@@ -195,7 +195,7 @@ jobs:
 
       - name: Check if build related files changed
         id: changed-files
-        uses: tj-actions/changed-files@v12
+        uses: tj-actions/changed-files@v11
         with:
           files: |
             otelcolbuilder/.otelcol-builder.yaml
@@ -273,7 +273,7 @@ jobs:
 
       - name: Check if build related files changed
         id: changed-files
-        uses: tj-actions/changed-files@v12
+        uses: tj-actions/changed-files@v11
         with:
           files: |
             otelcolbuilder/.otelcol-builder.yaml


### PR DESCRIPTION
This reverts commit 8c7fc3c19090bcd7a54d7d4a047530d472a2aa55.

Seems this has caused the issue of not buildable container: here's a CI run with tj-actions reverted to v11 which passed: https://github.com/SumoLogic/sumologic-otel-collector/runs/4550802501?check_suite_focus=true

For completeness here's a failed CI run: https://github.com/SumoLogic/sumologic-otel-collector/runs/4550599183?check_suite_focus=true