### PR TITLE
feat(sumologicexporter): add debug log with request headers

### DIFF
--- a/pkg/exporter/sumologicexporter/exporter.go
+++ b/pkg/exporter/sumologicexporter/exporter.go
@@ -258,6 +258,7 @@ func (se *sumologicexporter) pushLogsData(ctx context.Context, ld pdata.Logs) er
 		return consumererror.NewLogs(fmt.Errorf("failed to initialize compressor: %w", err), ld)
 	}
 	sdr := newSender(
+		se.logger,
 		se.config,
 		se.client,
 		se.filter,
@@ -377,6 +378,7 @@ func (se *sumologicexporter) pushMetricsData(ctx context.Context, md pdata.Metri
 		return consumererror.NewMetrics(fmt.Errorf("failed to initialize compressor: %w", err), md)
 	}
 	sdr := newSender(
+		se.logger,
 		se.config,
 		se.client,
 		se.filter,
@@ -478,6 +480,7 @@ func (se *sumologicexporter) pushTracesData(ctx context.Context, td pdata.Traces
 		return consumererror.NewTraces(fmt.Errorf("failed to initialize compressor: %w", err), td)
 	}
 	sdr := newSender(
+		se.logger,
 		se.config,
 		se.client,
 		se.filter,

--- a/pkg/exporter/sumologicexporter/sender_test.go
+++ b/pkg/exporter/sumologicexporter/sender_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/model/otlp"
 	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/zap"
 )
 
 type senderTest struct {
@@ -77,10 +78,14 @@ func prepareSenderTest(t *testing.T, cb []func(w http.ResponseWriter, req *http.
 	gf, err := newGraphiteFormatter(cfg.GraphiteTemplate)
 	require.NoError(t, err)
 
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
 	return &senderTest{
 		reqCounter: &reqCounter,
 		srv:        testServer,
 		s: newSender(
+			logger,
 			cfg,
 			&http.Client{
 				Timeout: cfg.HTTPClientSettings.Timeout,
@@ -134,10 +139,14 @@ func prepareOTLPSenderTest(t *testing.T, cb []func(w http.ResponseWriter, req *h
 	gf, err := newGraphiteFormatter(cfg.GraphiteTemplate)
 	require.NoError(t, err)
 
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
 	return &senderTest{
 		reqCounter: &reqCounter,
 		srv:        testServer,
 		s: newSender(
+			logger,
 			cfg,
 			&http.Client{
 				Timeout: cfg.HTTPClientSettings.Timeout,


### PR DESCRIPTION
exemplar log entry:

```
2021-12-17T11:45:09.037Z        debug   sumologicexporter@v0.40.0/sender.go:154 Sending data    {"kind": "exporter", "name": "sumologic/containers", "headers": {"Content-Encoding":["gzip"],"Content-Type":["application/x-www-form-urlencoded"],"X-Sumo-Category":["kubernetes/sumologic/collection/sumologic/otelcol/logs"],"X-Sumo-Client":["otelcol"],"X-Sumo-Fields":["_collector=pmalek-kubernetes-vagrant-2, container=otelcol, host=sumologic-kubernetes-collection, k8s.container.id=bb0f1137b251ddae622df6d54161204a4b27275d635715b25232320bbdf1967a, k8s.pod.id=8a1767d5-f4a2-410f-ac77-4a3465222e8f, k8s.pod.pod_name=collection-sumologic-otelcol-logs, namespace=sumologic, namespace_labels_kubernetes.io/metadata.name=sumologic, node=sumologic-kubernetes-collection, pod=collection-sumologic-otelcol-logs-0, pod_labels_app=collection-sumologic-otelcol-logs, pod_labels_chart=sumologic-2.4.0-alpha.1, pod_labels_controller-revision-hash=collection-sumologic-otelcol-logs-95455644, pod_labels_heritage=Helm, pod_labels_release=collection, pod_labels_statefulset.kubernetes.io/pod-name=collection-sumologic-otelcol-logs-0, service=collection-sumologic-fluentd-logs_collection-sumologic-fluentd-logs-headless, statefulset=collection-sumologic-otelcol-logs"],"X-Sumo-Host":["collection-sumologic-otelcol-logs-0"],"X-Sumo-Name":["sumologic.collection-sumologic-otelcol-logs-0.otelcol"]}}
```