### PR TITLE
chore(deps): bump telegraf to 1.20.4-sumo-1

### DIFF
--- a/otelcolbuilder/.otelcol-builder.yaml
+++ b/otelcolbuilder/.otelcol-builder.yaml
@@ -110,7 +110,7 @@ replaces:
 
   # ----------------------------------------------------------------------------
   # Needed for telegrafreceiver
-  - github.com/influxdata/telegraf => github.com/SumoLogic/telegraf v1.20.4-sumo-0
+  - github.com/influxdata/telegraf => github.com/SumoLogic/telegraf v1.20.4-sumo-1
 
   # TODO: remove this when:
   # - regexp log filtering is released upstream:


### PR DESCRIPTION
Related tag: https://github.com/SumoLogic/telegraf/releases/tag/v1.20.4-sumo-1

Includes https://github.com/SumoLogic/telegraf/commit/7efb4e4c9205c64f4e2988552ac764f1c5cd5b9e which bumps to:

* `github.com/opencontainers/image-spec@v1.0.2`
* `github.com/containerd/containerd@v1.5.8`

which was mentioned by dependabot in security review 