### PR TITLE
fix: fix modules so that they are importable

### DIFF
--- a/pkg/exporter/sumologicexporter/go.mod
+++ b/pkg/exporter/sumologicexporter/go.mod
@@ -3,7 +3,7 @@ module github.com/SumoLogic/sumologic-otel-collector/pkg/exporter/sumologicexpor
 go 1.17
 
 require (
-	github.com/SumoLogic/sumologic-otel-collector/pkg/extension/sumologicextension v0.40.0
+	github.com/SumoLogic/sumologic-otel-collector/pkg/extension/sumologicextension v0.0.43-beta.0
 	github.com/klauspost/compress v1.13.6
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector v0.40.0

--- a/pkg/extension/sumologicextension/go.mod
+++ b/pkg/extension/sumologicextension/go.mod
@@ -41,7 +41,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
-
-replace github.com/SumoLogic/sumologic-otel-collector/exporter/sumologicexporter => ../../exporter/sumologicexporter
-
-replace github.com/SumoLogic/sumologic-otel-collector/pkg/extension/sumologicextension => ./


### PR DESCRIPTION
With this change our plugins (including sumologicexporter and sumologicextension) will be importable. 

I've created https://github.com/SumoLogic/sumologic-otel-collector/issues/372 in order to figure out how to keep the dependency in sync.