### PR TITLE
fix: add match glob pattern to git describe

### DIFF
--- a/otelcolbuilder/Makefile
+++ b/otelcolbuilder/Makefile
@@ -2,7 +2,7 @@ BINARY_NAME ?= otelcol-sumo
 BUILDER_VERSION ?= 0.40.0
 BUILDER_REPO ?= github.com/open-telemetry/opentelemetry-collector
 BUILDER_BIN_PATH ?= $(HOME)/bin/opentelemetry-collector-builder
-VERSION ?= "$(shell git describe --tags --abbrev=10)"
+VERSION ?= "$(shell git describe --tags --abbrev=10 --match "v[0-9]*")"
 GO ?= go
 OS ?= $(shell uname -s | tr A-Z a-z)
 


### PR DESCRIPTION
Due to [recent changes in tags that are being pushed to this repo](https://github.com/SumoLogic/sumologic-otel-collector/pull/370) we need to be more specific w.r.t to the tags that we can match when calling `git describe` to get the version string that we embed in the binary.

This is to prevent getting a version string like:

```
pkg/processor/metricfrequencyprocessor/v0.0.44-beta.0-1-geb02b42d1d
```