### PR TITLE
WIP: fix(k8sprocessor): add service attributes immediately after endpoints are created

### DIFF
--- a/pkg/processor/k8sprocessor/kube/fake_owner.go
+++ b/pkg/processor/k8sprocessor/kube/fake_owner.go
@@ -95,8 +95,12 @@ func (op *fakeOwnerCache) Start() {}
 func (op *fakeOwnerCache) Stop() {}
 
 // GetServices fetches list of services for a given pod
-func (op *fakeOwnerCache) GetServices(pod *api_v1.Pod) []string {
+func (op *fakeOwnerCache) GetServices(podName string) []string {
 	return []string{"foo", "bar"}
+}
+
+func (op *fakeOwnerCache) GetPodUpdateChan() <-chan *Pod {
+	return make(<-chan *Pod)
 }
 
 // GetNamespace returns a namespace
@@ -111,13 +115,13 @@ func (op *fakeOwnerCache) GetNamespace(pod *api_v1.Pod) *api_v1.Namespace {
 }
 
 // GetOwners fetches deep tree of owners for a given pod
-func (op *fakeOwnerCache) GetOwners(pod *api_v1.Pod) []*ObjectOwner {
+func (op *fakeOwnerCache) GetOwners(or OwnerReferencer) []*ObjectOwner {
 	objectOwners := []*ObjectOwner{}
 
 	visited := map[types.UID]bool{}
 	queue := []types.UID{}
 
-	for _, or := range pod.OwnerReferences {
+	for _, or := range or.GetOwnerReferences() {
 		if _, uidVisited := visited[or.UID]; !uidVisited {
 			queue = append(queue, or.UID)
 			visited[or.UID] = true

--- a/pkg/processor/k8sprocessor/kube/informer.go
+++ b/pkg/processor/k8sprocessor/kube/informer.go
@@ -59,7 +59,6 @@ func informerListFuncWithSelectors(client kubernetes.Interface, namespace string
 		opts.FieldSelector = fs.String()
 		return client.CoreV1().Pods(namespace).List(context.Background(), opts)
 	}
-
 }
 
 func informerWatchFuncWithSelectors(client kubernetes.Interface, namespace string, ls labels.Selector, fs fields.Selector) cache.WatchFunc {

--- a/pkg/processor/k8sprocessor/kube/kube.go
+++ b/pkg/processor/k8sprocessor/kube/kube.go
@@ -89,8 +89,6 @@ type Pod struct {
 	Attributes map[string]string
 	StartTime  *metav1.Time
 	Ignore     bool
-
-	DeletedAt time.Time
 }
 
 type deleteRequest struct {


### PR DESCRIPTION
Do not merge - treat this PR as RFC :)

This PR highlights problems in k8sprocessor but doesn't solve all of them.

* It's not trivial to resolve the problem of not immediately updating pod ownership (assigning replicaset/statefulset/service etc owners to pods). The problem lies in the separate update mechanism for pods and for the rest of k8s objects. When we receive an update for pod, we fill its attributes and only when subsequently its owner object update comes in then we fill it in the cache and the subsequent update (or resync on which we rely - which happens [every 5 min](https://github.com/SumoLogic/sumologic-otel-collector/blob/ba870d20af6a79cda98c1a888ce18e77af60468b/pkg/processor/k8sprocessor/kube/informer.go#L51)) will make the pod contain the owner info.
The attempt to solve it in this PR does a somewhat good job of feeding back service information to the client but it doesn't do it in a thread safe manner. It would require even more locking/channels etc to make `Attributes` access thread safe which might not be worth the hussle.

* There's a data race introduced in the service feedback notification loop test (and not only) - where accessing `Pod`'s `Attributes` is done from multiple goroutines without proper locking/etc.

  ```
  ==================
  WARNING: DATA RACE
  Write at 0x00c000138450 by goroutine 193:
    runtime.mapassign_faststr()
        /Users/pmalek/.gvm/gos/go1.17.6/src/runtime/map_faststr.go:202 +0x0
    github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sprocessor/kube.(*WatchClient).OwnerFeedbackLoop()
        /Users/pmalek/code/opentelemetry/sumologic-otel-collector/pkg/processor/k8sprocessor/kube/client.go:150 +0x371
    github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sprocessor/kube.New·dwrap·2()
        /Users/pmalek/code/opentelemetry/sumologic-otel-collector/pkg/processor/k8sprocessor/kube/client.go:106 +0x47
  
  Previous read at 0x00c000138450 by goroutine 164:
    reflect.maplen()
        /Users/pmalek/.gvm/gos/go1.17.6/src/runtime/map.go:1360 +0x0
    reflect.Value.Len()
        /Users/pmalek/.gvm/gos/go1.17.6/src/reflect/value.go:1509 +0x268
    reflect.deepValueEqual()
        /Users/pmalek/.gvm/gos/go1.17.6/src/reflect/deepequal.go:132 +0xe26
    reflect.DeepEqual()
        /Users/pmalek/.gvm/gos/go1.17.6/src/reflect/deepequal.go:218 +0x404
    github.com/stretchr/testify/assert.ObjectsAreEqual()
        /Users/pmalek/.gvm/pkgsets/go1.17.6/global/pkg/mod/github.com/stretchr/testify@v1.7.0/assert/assertions.go:65 +0x184
    github.com/stretchr/testify/assert.ObjectsAreEqualValues()
        /Users/pmalek/.gvm/pkgsets/go1.17.6/global/pkg/mod/github.com/stretchr/testify@v1.7.0/assert/assertions.go:81 +0x79
    github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sprocessor/kube.Test_PodIsAnnotatedWithOwnershipInfoImmediatelyAfterOwnersAreCreated.func3()
        /Users/pmalek/code/opentelemetry/sumologic-otel-collector/pkg/processor/k8sprocessor/kube/client_test.go:1182 +0x24c
    github.com/stretchr/testify/assert.Eventually.func1()
        /Users/pmalek/.gvm/pkgsets/go1.17.6/global/pkg/mod/github.com/stretchr/testify@v1.7.0/assert/assertions.go:1655 +0x39
  
  Goroutine 193 (running) created at:
    github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sprocessor/kube.New()
        /Users/pmalek/code/opentelemetry/sumologic-otel-collector/pkg/processor/k8sprocessor/kube/client.go:106 +0x877
    github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sprocessor/kube.Test_PodIsAnnotatedWithOwnershipInfoImmediatelyAfterOwnersAreCreated()
        /Users/pmalek/code/opentelemetry/sumologic-otel-collector/pkg/processor/k8sprocessor/kube/client_test.go:983 +0x404
    testing.tRunner()
        /Users/pmalek/.gvm/gos/go1.17.6/src/testing/testing.go:1259 +0x22f
    testing.(*T).Run·dwrap·21()
        /Users/pmalek/.gvm/gos/go1.17.6/src/testing/testing.go:1306 +0x47
  
  Goroutine 164 (finished) created at:
    github.com/stretchr/testify/assert.Eventually()
        /Users/pmalek/.gvm/pkgsets/go1.17.6/global/pkg/mod/github.com/stretchr/testify@v1.7.0/assert/assertions.go:1655 +0x3b7
    github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sprocessor/kube.Test_PodIsAnnotatedWithOwnershipInfoImmediatelyAfterOwnersAreCreated()
        /Users/pmalek/code/opentelemetry/sumologic-otel-collector/pkg/processor/k8sprocessor/kube/client_test.go:1172 +0x104c
    testing.tRunner()
        /Users/pmalek/.gvm/gos/go1.17.6/src/testing/testing.go:1259 +0x22f
    testing.(*T).Run·dwrap·21()
        /Users/pmalek/.gvm/gos/go1.17.6/src/testing/testing.go:1306 +0x47
  ==================
      testing.go:1152: race detected during execution of test
  --- FAIL: Test_PodIsAnnotatedWithOwnershipInfoImmediatelyAfterOwnersAreCreated (0.02s)
  ```