### PR TITLE
refactor(k8sprocessor): apply fieldalignment suggestions

### DIFF
--- a/pkg/processor/k8sprocessor/kube/kube.go
+++ b/pkg/processor/k8sprocessor/kube/kube.go
@@ -82,23 +82,21 @@ type APIClientsetProvider func(config k8sconfig.APIConfig) (kubernetes.Interface
 
 // Pod represents a kubernetes pod.
 type Pod struct {
+	Attributes map[string]string
+	StartTime  *metav1.Time
 	Name       string
 	Namespace  string
 	Address    string
 	PodUID     string
-	Attributes map[string]string
-	StartTime  *metav1.Time
 	Ignore     bool
-
-	DeletedAt time.Time
 }
 
 type deleteRequest struct {
+	ts time.Time
 	// id is identifier (IP address or Pod UID) of pod to remove from pods map
 	id PodIdentifier
 	// name contains name of pod to remove from pods map
 	podName string
-	ts      time.Time
 }
 
 // Filters is used to instruct the client on how to filter out k8s pods.
@@ -202,13 +200,13 @@ func NewExtractionFieldTags() ExtractionFieldTags {
 // FieldExtractionRule is used to specify which fields to extract from pod fields
 // and inject into spans as attributes.
 type FieldExtractionRule struct {
+	// Regex is a regular expression used to extract a sub-part of a field value.
+	// Full value is extracted when no regexp is provided.
+	Regex *regexp.Regexp
 	// Name is used to as the Span tag name.
 	Name string
 	// Key is used to lookup k8s pod fields.
 	Key string
-	// Regex is a regular expression used to extract a sub-part of a field value.
-	// Full value is extracted when no regexp is provided.
-	Regex *regexp.Regexp
 }
 
 // Associations represent a list of rules for Pod metadata associations with resources

--- a/pkg/processor/k8sprocessor/kube/owner.go
+++ b/pkg/processor/k8sprocessor/kube/owner.go
@@ -43,10 +43,10 @@ type OwnerProvider func(
 // ObjectOwner keeps single entry
 type ObjectOwner struct {
 	UID       types.UID
-	ownerUIDs []types.UID
 	namespace string
 	kind      string
 	name      string
+	ownerUIDs []types.UID
 }
 
 // OwnerAPI describes functions that could allow retrieving owner info


### PR DESCRIPTION
The following have been addressed here:

```
pkg/processor/k8sprocessor/kube/kube.go:84:10: struct with 112 pointer bytes could be 96
pkg/processor/k8sprocessor/kube/kube.go:96:20: struct with 56 pointer bytes could be 48
pkg/processor/k8sprocessor/kube/kube.go:204:26: struct with 40 pointer bytes could be 32
pkg/processor/k8sprocessor/kube/owner.go:44:18: struct with 80 pointer bytes could be 72
```
