### PR TITLE
fix(k8sprocessor): do not include empty service label

### DIFF
--- a/pkg/processor/k8sprocessor/kube/client.go
+++ b/pkg/processor/k8sprocessor/kube/client.go
@@ -319,7 +319,9 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) map[string]string {
 		}
 
 		if c.Rules.ServiceName {
-			tags[c.Rules.Tags.ServiceName] = strings.Join(c.op.GetServices(pod), c.delimiter)
+			if services := c.op.GetServices(pod); len(services) > 0 {
+				tags[c.Rules.Tags.ServiceName] = strings.Join(services, c.delimiter)
+			}
 		}
 
 	}


### PR DESCRIPTION
When there's no services found for a pod, do not include an empty service label.