### PR TITLE
fix(k8sprocessor): delete pod entries for all corresponding IDs

### DIFF
--- a/pkg/processor/k8sprocessor/client_test.go
+++ b/pkg/processor/k8sprocessor/client_test.go
@@ -15,6 +15,8 @@
 package k8sprocessor
 
 import (
+	"time"
+
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -52,6 +54,8 @@ func newFakeClient(
 	_ kube.InformerProvider,
 	_ kube.OwnerProvider,
 	_ string,
+	_ time.Duration,
+	_ time.Duration,
 ) (kube.Client, error) {
 	cs := fake.NewSimpleClientset()
 

--- a/pkg/processor/k8sprocessor/kube/client_test.go
+++ b/pkg/processor/k8sprocessor/kube/client_test.go
@@ -88,12 +88,38 @@ func podAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj interfac
 }
 
 func TestDefaultClientset(t *testing.T) {
-	c, err := New(zap.NewNop(), k8sconfig.APIConfig{}, ExtractionRules{}, Filters{}, []Association{}, Excludes{}, nil, nil, nil, "", 30*time.Second, DefaultPodDeleteGracePeriod)
+	c, err := New(
+		zap.NewNop(),
+		k8sconfig.APIConfig{},
+		ExtractionRules{},
+		Filters{},
+		[]Association{},
+		Excludes{},
+		nil,
+		nil,
+		nil,
+		"",
+		30*time.Second,
+		DefaultPodDeleteGracePeriod,
+	)
 	assert.Error(t, err)
 	assert.Equal(t, "invalid authType for kubernetes: ", err.Error())
 	assert.Nil(t, c)
 
-	c, err = New(zap.NewNop(), k8sconfig.APIConfig{}, ExtractionRules{}, Filters{}, []Association{}, Excludes{}, newFakeAPIClientset, nil, nil, "", 30*time.Second, DefaultPodDeleteGracePeriod)
+	c, err = New(
+		zap.NewNop(),
+		k8sconfig.APIConfig{},
+		ExtractionRules{},
+		Filters{},
+		[]Association{},
+		Excludes{},
+		newFakeAPIClientset,
+		nil,
+		nil,
+		"",
+		30*time.Second,
+		DefaultPodDeleteGracePeriod,
+	)
 	assert.NoError(t, err)
 	assert.NotNil(t, c)
 }
@@ -147,7 +173,20 @@ func TestConstructorErrors(t *testing.T) {
 			gotAPIConfig = c
 			return nil, fmt.Errorf("error creating k8s client")
 		}
-		c, err := New(zap.NewNop(), apiCfg, er, ff, []Association{}, Excludes{}, clientProvider, NewFakeInformer, newFakeOwnerProvider, "", 30*time.Second, DefaultPodDeleteGracePeriod)
+		c, err := New(
+			zap.NewNop(),
+			apiCfg,
+			er,
+			ff,
+			[]Association{},
+			Excludes{},
+			clientProvider,
+			NewFakeInformer,
+			newFakeOwnerProvider,
+			"",
+			30*time.Second,
+			DefaultPodDeleteGracePeriod,
+		)
 		assert.Nil(t, c)
 		assert.Error(t, err)
 		assert.Equal(t, err.Error(), "error creating k8s client")
@@ -652,19 +691,21 @@ func TestExtractionRules(t *testing.T) {
 		{
 			name: "labels",
 			rules: ExtractionRules{
-				Annotations: []FieldExtractionRule{{
-					Name: "a1",
-					Key:  "annotation1",
+				Annotations: []FieldExtractionRule{
+					{
+						Name: "a1",
+						Key:  "annotation1",
+					},
 				},
-				},
-				Labels: []FieldExtractionRule{{
-					Name: "l1",
-					Key:  "label1",
-				}, {
-					Name:  "l2",
-					Key:   "label2",
-					Regex: regexp.MustCompile(`k5=(?P<value>[^\s]+)`),
-				},
+				Labels: []FieldExtractionRule{
+					{
+						Name: "l1",
+						Key:  "label1",
+					}, {
+						Name:  "l2",
+						Key:   "label2",
+						Regex: regexp.MustCompile(`k5=(?P<value>[^\s]+)`),
+					},
 				},
 			},
 			attributes: map[string]string{
@@ -678,20 +719,23 @@ func TestExtractionRules(t *testing.T) {
 			rules: ExtractionRules{
 				OwnerLookupEnabled: true,
 				Tags:               NewExtractionFieldTags(),
-				Annotations: []FieldExtractionRule{{
-					Name: "k8s.pod.annotation.%s",
-					Key:  "*",
+				Annotations: []FieldExtractionRule{
+					{
+						Name: "k8s.pod.annotation.%s",
+						Key:  "*",
+					},
 				},
+				Labels: []FieldExtractionRule{
+					{
+						Name: "k8s.pod.label.%s",
+						Key:  "*",
+					},
 				},
-				Labels: []FieldExtractionRule{{
-					Name: "k8s.pod.label.%s",
-					Key:  "*",
-				},
-				},
-				NamespaceLabels: []FieldExtractionRule{{
-					Name: "namespace_labels_%s",
-					Key:  "*",
-				},
+				NamespaceLabels: []FieldExtractionRule{
+					{
+						Name: "namespace_labels_%s",
+						Key:  "*",
+					},
 				},
 			},
 			attributes: map[string]string{
@@ -732,51 +776,52 @@ func TestFilters(t *testing.T) {
 		filters Filters
 		labels  string
 		fields  string
-	}{{
-		name:    "no-filters",
-		filters: Filters{},
-	}, {
-		name: "namespace",
-		filters: Filters{
-			Namespace: "default",
-		},
-	}, {
-		name: "node",
-		filters: Filters{
-			Node: "ec2-test",
-		},
-		fields: "spec.nodeName=ec2-test",
-	}, {
-		name: "labels-and-fields",
-		filters: Filters{
-			Labels: []FieldFilter{
-				{
-					Key:   "k1",
-					Value: "v1",
-					Op:    selection.Equals,
+	}{
+		{
+			name:    "no-filters",
+			filters: Filters{},
+		}, {
+			name: "namespace",
+			filters: Filters{
+				Namespace: "default",
+			},
+		}, {
+			name: "node",
+			filters: Filters{
+				Node: "ec2-test",
+			},
+			fields: "spec.nodeName=ec2-test",
+		}, {
+			name: "labels-and-fields",
+			filters: Filters{
+				Labels: []FieldFilter{
+					{
+						Key:   "k1",
+						Value: "v1",
+						Op:    selection.Equals,
+					},
+					{
+						Key:   "k2",
+						Value: "v2",
+						Op:    selection.NotEquals,
+					},
 				},
-				{
-					Key:   "k2",
-					Value: "v2",
-					Op:    selection.NotEquals,
+				Fields: []FieldFilter{
+					{
+						Key:   "k1",
+						Value: "v1",
+						Op:    selection.Equals,
+					},
+					{
+						Key:   "k2",
+						Value: "v2",
+						Op:    selection.NotEquals,
+					},
 				},
 			},
-			Fields: []FieldFilter{
-				{
-					Key:   "k1",
-					Value: "v1",
-					Op:    selection.Equals,
-				},
-				{
-					Key:   "k2",
-					Value: "v2",
-					Op:    selection.NotEquals,
-				},
-			},
+			labels: "k1=v1,k2!=v2",
+			fields: "k1=v1,k2!=v2",
 		},
-		labels: "k1=v1,k2!=v2",
-		fields: "k1=v1,k2!=v2",
-	},
 	}
 
 	for _, tc := range testCases {
@@ -788,88 +833,88 @@ func TestFilters(t *testing.T) {
 			assert.Equal(t, tc.fields, inf.fieldSelector.String())
 		})
 	}
-
 }
 
 func TestPodIgnorePatterns(t *testing.T) {
 	testCases := []struct {
 		ignore bool
 		pod    api_v1.Pod
-	}{{
-		ignore: false,
-		pod:    api_v1.Pod{},
-	}, {
-		ignore: true,
-		pod: api_v1.Pod{
-			Spec: api_v1.PodSpec{
-				HostNetwork: true,
+	}{
+		{
+			ignore: false,
+			pod:    api_v1.Pod{},
+		}, {
+			ignore: true,
+			pod: api_v1.Pod{
+				Spec: api_v1.PodSpec{
+					HostNetwork: true,
+				},
 			},
-		},
-	}, {
-		ignore: true,
-		pod: api_v1.Pod{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Annotations: map[string]string{
-					"opentelemetry.io/k8s-processor/ignore": "True ",
+		}, {
+			ignore: true,
+			pod: api_v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Annotations: map[string]string{
+						"opentelemetry.io/k8s-processor/ignore": "True ",
+					},
+				},
+			},
+		}, {
+			ignore: true,
+			pod: api_v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Annotations: map[string]string{
+						"opentelemetry.io/k8s-processor/ignore": "true",
+					},
+				},
+			},
+		}, {
+			ignore: false,
+			pod: api_v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Annotations: map[string]string{
+						"opentelemetry.io/k8s-processor/ignore": "false",
+					},
+				},
+			},
+		}, {
+			ignore: false,
+			pod: api_v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Annotations: map[string]string{
+						"opentelemetry.io/k8s-processor/ignore": "",
+					},
+				},
+			},
+		}, {
+			ignore: true,
+			pod: api_v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: "jaeger-agent",
+				},
+			},
+		}, {
+			ignore: true,
+			pod: api_v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: "jaeger-collector",
+				},
+			},
+		}, {
+			ignore: true,
+			pod: api_v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: "jaeger-agent-b2zdv",
+				},
+			},
+		}, {
+			ignore: false,
+			pod: api_v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: "test-pod-name",
 				},
 			},
 		},
-	}, {
-		ignore: true,
-		pod: api_v1.Pod{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Annotations: map[string]string{
-					"opentelemetry.io/k8s-processor/ignore": "true",
-				},
-			},
-		},
-	}, {
-		ignore: false,
-		pod: api_v1.Pod{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Annotations: map[string]string{
-					"opentelemetry.io/k8s-processor/ignore": "false",
-				},
-			},
-		},
-	}, {
-		ignore: false,
-		pod: api_v1.Pod{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Annotations: map[string]string{
-					"opentelemetry.io/k8s-processor/ignore": "",
-				},
-			},
-		},
-	}, {
-		ignore: true,
-		pod: api_v1.Pod{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Name: "jaeger-agent",
-			},
-		},
-	}, {
-		ignore: true,
-		pod: api_v1.Pod{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Name: "jaeger-collector",
-			},
-		},
-	}, {
-		ignore: true,
-		pod: api_v1.Pod{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Name: "jaeger-agent-b2zdv",
-			},
-		},
-	}, {
-		ignore: false,
-		pod: api_v1.Pod{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Name: "test-pod-name",
-			},
-		},
-	},
 	}
 
 	c, _ := newTestClient(t)
@@ -1074,7 +1119,20 @@ func newTestClientWithRulesAndFilters(t *testing.T, e ExtractionRules, f Filters
 			{Name: regexp.MustCompile(`jaeger-collector`)},
 		},
 	}
-	c, err := New(logger, k8sconfig.APIConfig{}, e, f, []Association{}, exclude, newFakeAPIClientset, NewFakeInformer, newFakeOwnerProvider, "_", 30*time.Second, DefaultPodDeleteGracePeriod)
+	c, err := New(
+		logger,
+		k8sconfig.APIConfig{},
+		e,
+		f,
+		[]Association{},
+		exclude,
+		newFakeAPIClientset,
+		NewFakeInformer,
+		newFakeOwnerProvider,
+		"_",
+		30*time.Second,
+		DefaultPodDeleteGracePeriod,
+	)
 	require.NoError(t, err)
 	return c.(*WatchClient), logs
 }

--- a/pkg/processor/k8sprocessor/kube/client_test.go
+++ b/pkg/processor/k8sprocessor/kube/client_test.go
@@ -15,6 +15,7 @@
 package kube
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -28,6 +29,7 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 	api_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -83,16 +85,15 @@ func podAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj interfac
 	assert.Equal(t, got.Address, "2.2.2.2")
 	assert.Equal(t, got.Name, "podC")
 	assert.Equal(t, got.PodUID, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
-
 }
 
 func TestDefaultClientset(t *testing.T) {
-	c, err := New(zap.NewNop(), k8sconfig.APIConfig{}, ExtractionRules{}, Filters{}, []Association{}, Excludes{}, nil, nil, nil, "")
+	c, err := New(zap.NewNop(), k8sconfig.APIConfig{}, ExtractionRules{}, Filters{}, []Association{}, Excludes{}, nil, nil, nil, "", 30*time.Second, DefaultPodDeleteGracePeriod)
 	assert.Error(t, err)
 	assert.Equal(t, "invalid authType for kubernetes: ", err.Error())
 	assert.Nil(t, c)
 
-	c, err = New(zap.NewNop(), k8sconfig.APIConfig{}, ExtractionRules{}, Filters{}, []Association{}, Excludes{}, newFakeAPIClientset, nil, nil, "")
+	c, err = New(zap.NewNop(), k8sconfig.APIConfig{}, ExtractionRules{}, Filters{}, []Association{}, Excludes{}, newFakeAPIClientset, nil, nil, "", 30*time.Second, DefaultPodDeleteGracePeriod)
 	assert.NoError(t, err)
 	assert.NotNil(t, c)
 }
@@ -109,6 +110,8 @@ func TestBadFilters(t *testing.T) {
 		NewFakeInformer,
 		newFakeOwnerProvider,
 		"",
+		30*time.Second,
+		DefaultPodDeleteGracePeriod,
 	)
 	assert.Error(t, err)
 	assert.Nil(t, c)
@@ -144,7 +147,7 @@ func TestConstructorErrors(t *testing.T) {
 			gotAPIConfig = c
 			return nil, fmt.Errorf("error creating k8s client")
 		}
-		c, err := New(zap.NewNop(), apiCfg, er, ff, []Association{}, Excludes{}, clientProvider, NewFakeInformer, newFakeOwnerProvider, "")
+		c, err := New(zap.NewNop(), apiCfg, er, ff, []Association{}, Excludes{}, clientProvider, NewFakeInformer, newFakeOwnerProvider, "", 30*time.Second, DefaultPodDeleteGracePeriod)
 		assert.Nil(t, c)
 		assert.Error(t, err)
 		assert.Equal(t, err.Error(), "error creating k8s client")
@@ -966,6 +969,102 @@ func Test_selectorsFromFilters(t *testing.T) {
 	}
 }
 
+func Test_PodsGetAddedAndDeletedFromCache(t *testing.T) {
+	const (
+		namespace = "kube-system"
+	)
+
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+	client, err := New(
+		logger,
+		k8sconfig.APIConfig{},
+		ExtractionRules{
+			ContainerID:        true,
+			ContainerImage:     true,
+			ContainerName:      true,
+			PodUID:             true,
+			PodName:            true,
+			StartTime:          true,
+			Namespace:          true,
+			NodeName:           false,
+			OwnerLookupEnabled: true,
+			Tags:               NewExtractionFieldTags(),
+		},
+		Filters{},
+		[]Association{},
+		Excludes{},
+		newFakeAPIClientset,
+		newSharedInformer,
+		newOwnerProvider,
+		"_",
+		10*time.Millisecond,
+		10*time.Millisecond,
+	)
+	require.NoError(t, err)
+
+	c := client.(*WatchClient)
+
+	ch := waitForWatchToBeEstablished(c.kc.(*fake.Clientset), "pods")
+	go func() {
+		c.Start()
+	}()
+	defer c.Stop()
+	<-ch
+
+	eventuallyNPodsInCache := func(t *testing.T, n int) {
+		assert.Eventually(t, func() bool {
+			c.m.RLock()
+			l := len(c.Pods)
+			c.m.RUnlock()
+			return l == n
+		}, 5*time.Second, 10*time.Millisecond)
+	}
+
+	t.Run("pod with IP", func(t *testing.T) {
+		pod := &api_v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-pod",
+				Namespace: namespace,
+				UID:       "f15f0585-a0bc-43a3-96e4-dd2eace75392",
+			},
+			Status: api_v1.PodStatus{
+				PodIP: "10.0.0.1",
+			},
+		}
+
+		_, err = c.kc.CoreV1().Pods(namespace).
+			Create(context.Background(), pod, metav1.CreateOptions{})
+		require.NoError(t, err)
+		eventuallyNPodsInCache(t, 3)
+
+		err = c.kc.CoreV1().Pods(namespace).
+			Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
+		require.NoError(t, err)
+		eventuallyNPodsInCache(t, 0)
+	})
+
+	t.Run("pod without an IP", func(t *testing.T) {
+		pod := &api_v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-pod",
+				Namespace: namespace,
+				UID:       "f15f0585-a0bc-43a3-96e4-dd2eace75392",
+			},
+		}
+
+		_, err = c.kc.CoreV1().Pods(namespace).
+			Create(context.Background(), pod, metav1.CreateOptions{})
+		require.NoError(t, err)
+		eventuallyNPodsInCache(t, 2)
+
+		err = c.kc.CoreV1().Pods(namespace).
+			Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
+		require.NoError(t, err)
+		eventuallyNPodsInCache(t, 0)
+	})
+}
+
 func newTestClientWithRulesAndFilters(t *testing.T, e ExtractionRules, f Filters) (*WatchClient, *observer.ObservedLogs) {
 	observedLogger, logs := observer.New(zapcore.WarnLevel)
 	logger := zap.New(observedLogger)
@@ -975,7 +1074,7 @@ func newTestClientWithRulesAndFilters(t *testing.T, e ExtractionRules, f Filters
 			{Name: regexp.MustCompile(`jaeger-collector`)},
 		},
 	}
-	c, err := New(logger, k8sconfig.APIConfig{}, e, f, []Association{}, exclude, newFakeAPIClientset, NewFakeInformer, newFakeOwnerProvider, "_")
+	c, err := New(logger, k8sconfig.APIConfig{}, e, f, []Association{}, exclude, newFakeAPIClientset, NewFakeInformer, newFakeOwnerProvider, "_", 30*time.Second, DefaultPodDeleteGracePeriod)
 	require.NoError(t, err)
 	return c.(*WatchClient), logs
 }

--- a/pkg/processor/k8sprocessor/kube/kube.go
+++ b/pkg/processor/k8sprocessor/kube/kube.go
@@ -50,8 +50,8 @@ const (
 // PodIdentifier is a custom type to represent IP Address or Pod UID
 type PodIdentifier string
 
-var (
-	defaultPodDeleteGracePeriod = time.Second * 120
+const (
+	DefaultPodDeleteGracePeriod = time.Second * 120
 	watchSyncPeriod             = time.Minute * 5
 )
 
@@ -74,6 +74,8 @@ type ClientProvider func(
 	InformerProvider,
 	OwnerProvider,
 	string,
+	time.Duration,
+	time.Duration,
 ) (Client, error)
 
 // APIClientsetProvider defines a func type that initializes and return a new kubernetes
@@ -89,6 +91,14 @@ type Pod struct {
 	Address    string
 	PodUID     string
 	Ignore     bool
+}
+
+func (p Pod) GetName() string {
+	return p.Name
+}
+
+func (p Pod) GetNamespace() string {
+	return p.Namespace
 }
 
 type deleteRequest struct {

--- a/pkg/processor/k8sprocessor/kube/owner_test.go
+++ b/pkg/processor/k8sprocessor/kube/owner_test.go
@@ -30,7 +30,7 @@ import (
 // Related issue: https://github.com/kubernetes/kubernetes/issues/95372
 func waitForWatchToBeEstablished(client *fake.Clientset, resource string) <-chan struct{} {
 	ch := make(chan struct{})
-	client.PrependWatchReactor("*", func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
+	client.PrependWatchReactor(resource, func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
 		ns := action.GetNamespace()
 
@@ -39,7 +39,7 @@ func waitForWatchToBeEstablished(client *fake.Clientset, resource string) <-chan
 			return false, nil, err
 		}
 
-		if action.GetVerb() == "watch" && gvr.String() == resource {
+		if action.GetVerb() == "watch" {
 			close(ch)
 		}
 		return true, watch, nil
@@ -58,7 +58,7 @@ func Test_OwnerProvider_GetOwners(t *testing.T) {
 	require.NoError(t, err)
 
 	client := c.(*fake.Clientset)
-	ch := waitForWatchToBeEstablished(client, "apps/v1, Resource=statefulsets")
+	ch := waitForWatchToBeEstablished(client, "statefulsets")
 
 	op.Start()
 	t.Cleanup(func() {
@@ -133,7 +133,7 @@ func Test_OwnerProvider_GetServices(t *testing.T) {
 	require.NoError(t, err)
 
 	client := c.(*fake.Clientset)
-	ch := waitForWatchToBeEstablished(client, "/v1, Resource=endpoints")
+	ch := waitForWatchToBeEstablished(client, "endpoints")
 
 	op.Start()
 	t.Cleanup(func() {

--- a/pkg/processor/k8sprocessor/processor.go
+++ b/pkg/processor/k8sprocessor/processor.go
@@ -59,7 +59,7 @@ func (kp *kubernetesprocessor) initKubeClient(logger *zap.Logger, kubeClient kub
 			nil,
 			nil,
 			kp.delimiter,
-			30 * time.Second,
+			30*time.Second,
 			kube.DefaultPodDeleteGracePeriod,
 		)
 		if err != nil {
@@ -116,7 +116,6 @@ func (kp *kubernetesprocessor) ProcessLogs(ctx context.Context, ld pdata.Logs) (
 
 // processResource adds Pod metadata tags to resource based on pod association configuration
 func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pdata.Resource) {
-
 	podIdentifierKey, podIdentifierValue := extractPodID(ctx, resource.Attributes(), kp.podAssociations)
 	if podIdentifierValue == "" {
 		return

--- a/pkg/processor/k8sprocessor/processor.go
+++ b/pkg/processor/k8sprocessor/processor.go
@@ -16,6 +16,7 @@ package k8sprocessor
 
 import (
 	"context"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/model/pdata"
@@ -47,7 +48,20 @@ func (kp *kubernetesprocessor) initKubeClient(logger *zap.Logger, kubeClient kub
 		kubeClient = kube.New
 	}
 	if !kp.passthroughMode {
-		kc, err := kubeClient(logger, kp.apiConfig, kp.rules, kp.filters, kp.podAssociations, kp.podIgnore, nil, nil, nil, kp.delimiter)
+		kc, err := kubeClient(
+			logger,
+			kp.apiConfig,
+			kp.rules,
+			kp.filters,
+			kp.podAssociations,
+			kp.podIgnore,
+			nil,
+			nil,
+			nil,
+			kp.delimiter,
+			30 * time.Second,
+			kube.DefaultPodDeleteGracePeriod,
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/processor/k8sprocessor/processor_test.go
+++ b/pkg/processor/k8sprocessor/processor_test.go
@@ -235,6 +235,8 @@ func TestProcessorBadClientProvider(t *testing.T) {
 		_ kube.InformerProvider,
 		_ kube.OwnerProvider,
 		_ string,
+		_ time.Duration,
+		_ time.Duration,
 	) (kube.Client, error) {
 		return nil, fmt.Errorf("bad client error")
 	}
@@ -856,7 +858,6 @@ func TestMetricsProcessorHostname(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestMetricsProcessorHostnameWithPodAssociation(t *testing.T) {
@@ -932,7 +933,6 @@ func TestMetricsProcessorHostnameWithPodAssociation(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestPassthroughStart(t *testing.T) {


### PR DESCRIPTION
There was a "memory leak" in `k8sprocessor` caused by not deleting a pod from cache in `forgetPod` under the following ID:

```go
fmt.Sprintf("%s.%s", p.GetName(), p.GetNamespace())
```

This PR fixes it and adds test to ensure this. In order to do so delete interval and grace period (both use in the delete loop) needed to be made configurable (not to wait 30s + 120s in tests).