### PR TITLE
feat: add alternative pod client implementation

### DIFF
--- a/pkg/processor/k8sprocessor/pod_association.go
+++ b/pkg/processor/k8sprocessor/pod_association.go
@@ -95,7 +95,10 @@ func extractPodID(ctx context.Context, attrs pdata.AttributeMap, associations []
 			}
 
 			if pod.StringVal() == "" || namespace.StringVal() != "" {
-				return asso.Name, kube.PodIdentifier(fmt.Sprintf("%s.%s", pod.StringVal(), namespace.StringVal()))
+				// This is the key format informers use by default
+				// See: https://pkg.go.dev/k8s.io/client-go/tools/cache#MetaNamespaceKeyFunc
+				// TODO: Make this dependency explicit somehow
+				return asso.Name, kube.PodIdentifier(fmt.Sprintf("%s/%s", pod.StringVal(), namespace.StringVal()))
 			}
 		}
 	}


### PR DESCRIPTION
This is a sketch of an alternative implementation of WatchClient, which is completely synchronous and doesn't cache any values aside from what informers do. In principle, this trades CPU for memory, but in limited testing this implementation has performed around 10% better than the current one, while also being significantly simpler. We can even add a cache to it later if need be, and it should be easier to manage given that we can always recompute the values on demand.

This implementation is missing two features at the moment:
* Tracking the size of the cache. There's no way to check the size cheaply using the Store interface. We could use a separate variable for this or just let `observability.go` do it on its own.
* Grace period for deleted pods. I'd like to use https://pkg.go.dev/k8s.io/client-go/tools/cache#ExpirationCache, but it has some properties that aren't ideal for us, like lazy expiration, no indices, and a single key function. Maybe we can take https://pkg.go.dev/k8s.io/client-go/tools/cache#ExpirationPolicy and make our own?