### PR TITLE
feat(k8sprocessor): only enable owner informers when configured

### DIFF
--- a/pkg/processor/k8sprocessor/kube/client.go
+++ b/pkg/processor/k8sprocessor/kube/client.go
@@ -100,7 +100,7 @@ func New(
 			newOwnerProviderFunc = newOwnerProvider
 		}
 
-		c.op, err = newOwnerProviderFunc(logger, c.kc, labelSelector, fieldSelector, c.Filters.Namespace)
+		c.op, err = newOwnerProviderFunc(logger, c.kc, labelSelector, fieldSelector, rules, c.Filters.Namespace)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/processor/k8sprocessor/kube/fake_owner.go
+++ b/pkg/processor/k8sprocessor/kube/fake_owner.go
@@ -35,6 +35,7 @@ func newFakeOwnerProvider(logger *zap.Logger,
 	client kubernetes.Interface,
 	labelSelector labels.Selector,
 	fieldSelector fields.Selector,
+	extractionRules ExtractionRules,
 	namespace string) (OwnerAPI, error) {
 	ownerCache := fakeOwnerCache{}
 	ownerCache.objectOwners = map[string]*ObjectOwner{}

--- a/pkg/processor/k8sprocessor/kube/owner_test.go
+++ b/pkg/processor/k8sprocessor/kube/owner_test.go
@@ -54,7 +54,21 @@ func Test_OwnerProvider_GetOwners(t *testing.T) {
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err)
 
-	op, err := newOwnerProvider(logger, c, labels.Everything(), fields.Everything(), "kube-system")
+	op, err := newOwnerProvider(
+		logger,
+		c,
+		labels.Everything(),
+		fields.Everything(),
+		ExtractionRules{
+			PodUID:             true,
+			PodName:            true,
+			StatefulSetName:    true,
+			Namespace:          true,
+			OwnerLookupEnabled: true,
+			Tags:               NewExtractionFieldTags(),
+		},
+		"kube-system",
+	)
 	require.NoError(t, err)
 
 	client := c.(*fake.Clientset)
@@ -129,7 +143,21 @@ func Test_OwnerProvider_GetServices(t *testing.T) {
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err)
 
-	op, err := newOwnerProvider(logger, c, labels.Everything(), fields.Everything(), namespace)
+	op, err := newOwnerProvider(
+		logger,
+		c,
+		labels.Everything(),
+		fields.Everything(),
+		ExtractionRules{
+			PodUID:             true,
+			PodName:            true,
+			Namespace:          true,
+			ServiceName:        true,
+			OwnerLookupEnabled: true,
+			Tags:               NewExtractionFieldTags(),
+		},
+		namespace,
+	)
 	require.NoError(t, err)
 
 	client := c.(*fake.Clientset)


### PR DESCRIPTION
It seems that k8sprocessor was enabling informers regardless whether the extraction rules for them were configured.

This caused unnecessary load on the processor and on some clusters e.g. k8s versions < 1.20 errors like:

```
E0117 09:57:48.400854       1 reflector.go:138] k8s.io/client-go@v0.22.4/tools/cache/reflector.go:167: Failed to watch *v1.CronJob: failed to list *v1.CronJob: the server could not find the requested resource
```

because the client was configured to watch event on resource that didn't exist on the cluster.

This PR addresses that. 