### PR TITLE
fix(sumologicexporter): don't remove fields after sending data

### DIFF
--- a/pkg/exporter/sumologicexporter/fields.go
+++ b/pkg/exporter/sumologicexporter/fields.go
@@ -39,6 +39,12 @@ func newFields(attrMap pdata.AttributeMap) fields {
 func (f fields) string() string {
 	returnValue := make([]string, 0, f.orig.Len())
 	f.orig.Range(func(k string, v pdata.AttributeValue) bool {
+		// Don't add source related attributes to fields as they are handled separately
+		// and are added to the payload either as special HTTP headers or as resources
+		// attributes.
+		if k == attributeKeySourceCategory || k == attributeKeySourceHost || k == attributeKeySourceName {
+			return true
+		}
 		sv := v.AsString()
 
 		// Skip empty field

--- a/pkg/exporter/sumologicexporter/sender.go
+++ b/pkg/exporter/sumologicexporter/sender.go
@@ -627,17 +627,14 @@ func addSourcesHeaders(req *http.Request, sources sourceFormats, flds fields) {
 	if sources.host.isSet() {
 		req.Header.Add(headerHost, sources.host.format(flds))
 	}
-	flds.orig.Delete(attributeKeySourceHost)
 
 	if sources.name.isSet() {
 		req.Header.Add(headerName, sources.name.format(flds))
 	}
-	flds.orig.Delete(attributeKeySourceName)
 
 	if sources.category.isSet() {
 		req.Header.Add(headerCategory, sources.category.format(flds))
 	}
-	flds.orig.Delete(attributeKeySourceCategory)
 }
 
 func addLogsHeaders(req *http.Request, lf LogFormatType, flds fields) {
@@ -647,7 +644,10 @@ func addLogsHeaders(req *http.Request, lf LogFormatType, flds fields) {
 	default:
 		req.Header.Add(headerContentType, contentTypeLogs)
 	}
-	req.Header.Add(headerFields, flds.string())
+
+	if fieldsStr := flds.string(); fieldsStr != "" {
+		req.Header.Add(headerFields, fieldsStr)
+	}
 }
 
 func addMetricsHeaders(req *http.Request, mf MetricFormatType) error {

--- a/pkg/exporter/sumologicexporter/sender_test.go
+++ b/pkg/exporter/sumologicexporter/sender_test.go
@@ -307,7 +307,6 @@ func TestSendTrace(t *testing.T) {
 
 	err = test.s.sendTraces(context.Background(), td, fieldsFromMap(map[string]string{}))
 	assert.NoError(t, err)
-
 }
 
 func TestSendLogs(t *testing.T) {
@@ -386,6 +385,7 @@ func TestSendLogsSplit(t *testing.T) {
 
 	assert.EqualValues(t, 2, *test.reqCounter)
 }
+
 func TestSendLogsSplitFailedOne(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
 		func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
When a payload gets split due to `max_request_body_size` we shouldn't remove source related fields as they will be used by other requests yet to be sent.

This causes `undefined` source category, name and host being set.