### PR TITLE
refactor(sumologicextension): refactor credentialsstore

### DIFF
--- a/pkg/extension/sumologicextension/config.go
+++ b/pkg/extension/sumologicextension/config.go
@@ -30,7 +30,7 @@ type Config struct {
 	// Credentials contains Access Key and Access ID for Sumo Logic service.
 	// Please refer to https://help.sumologic.com/Manage/Security/Access-Keys
 	// for detailed instructions how to obtain them.
-	Credentials credentials `mapstructure:",squash"`
+	Credentials accessCredentials `mapstructure:",squash"`
 
 	// CollectorName is the name under which collector will be registered.
 	// Please note that registering a collector under a name which is already
@@ -77,7 +77,7 @@ type Config struct {
 	BackOff backOffConfig `mapstructure:"backoff"`
 }
 
-type credentials struct {
+type accessCredentials struct {
 	AccessID  string `mapstructure:"access_id"`
 	AccessKey string `mapstructure:"access_key"`
 }

--- a/pkg/extension/sumologicextension/credentials/credentialsstore_localfs_test.go
+++ b/pkg/extension/sumologicextension/credentials/credentialsstore_localfs_test.go
@@ -12,16 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sumologicextension
+package credentials
 
 import (
 	"os"
 	"testing"
 
-	"github.com/SumoLogic/sumologic-otel-collector/pkg/extension/sumologicextension/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	"github.com/SumoLogic/sumologic-otel-collector/pkg/extension/sumologicextension/api"
 )
 
 func TestCredentialsStoreLocalFs(t *testing.T) {
@@ -42,7 +43,7 @@ func TestCredentialsStoreLocalFs(t *testing.T) {
 		},
 	}
 
-	sut := localFsCredentialsStore{
+	sut := LocalFsStore{
 		collectorCredentialsDirectory: dir,
 		logger:                        zap.NewNop(),
 	}

--- a/pkg/extension/sumologicextension/credentials/encrypt.go
+++ b/pkg/extension/sumologicextension/credentials/encrypt.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sumologicextension
+package credentials
 
 import (
 	"crypto/aes"
@@ -24,8 +24,8 @@ import (
 	"io"
 )
 
-// hash returns an md5 hashed string of provided key and an error.
-func hash(key string) (string, error) {
+// Hash returns an md5 hashed string of provided key and an error.
+func Hash(key string) (string, error) {
 	hasher := md5.New()
 	if _, err := hasher.Write([]byte(key)); err != nil {
 		return "", err
@@ -35,7 +35,7 @@ func hash(key string) (string, error) {
 
 // encrypt encrypts provided byte slice with AES using the passphrase
 func encrypt(data []byte, passphrase string) ([]byte, error) {
-	h, err := hash(passphrase)
+	h, err := Hash(passphrase)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func encrypt(data []byte, passphrase string) ([]byte, error) {
 
 // decrypt decrypts provided byte slice with AES using the passphrase.
 func decrypt(data []byte, passphrase string) ([]byte, error) {
-	h, err := hash(passphrase)
+	h, err := Hash(passphrase)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/extension/sumologicextension/credentials/store.go
+++ b/pkg/extension/sumologicextension/credentials/store.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sumologicextension
+package credentials
 
 import (
 	"github.com/SumoLogic/sumologic-otel-collector/pkg/extension/sumologicextension/api"
@@ -34,8 +34,8 @@ type CollectorCredentials struct {
 	ApiBaseUrl string `json:"apiBaseUrl"`
 }
 
-// CredentialsStore is an interface to get collector authentication data
-type CredentialsStore interface {
+// Store is an interface to get collector authentication data
+type Store interface {
 	// Check checks if collector credentials exist under the specified key.
 	Check(key string) bool
 

--- a/pkg/extension/sumologicextension/factory.go
+++ b/pkg/extension/sumologicextension/factory.go
@@ -16,13 +16,13 @@ package sumologicextension
 
 import (
 	"context"
-	"os"
-	"path"
 
 	"github.com/cenkalti/backoff"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/extension/extensionhelper"
+
+	"github.com/SumoLogic/sumologic-otel-collector/pkg/extension/sumologicextension/credentials"
 )
 
 const (
@@ -41,11 +41,10 @@ func NewFactory() component.ExtensionFactory {
 }
 
 func createDefaultConfig() config.Extension {
-	homePath, err := os.UserHomeDir()
+	defaultCredsPath, err := credentials.GetDefaultCollectorCredentialsDirectory()
 	if err != nil {
 		return nil
 	}
-	defaultCredsPath := path.Join(homePath, collectorCredentialsDirectory)
 
 	return &Config{
 		ExtensionSettings:             config.NewExtensionSettings(config.NewComponentID(typeStr)),

--- a/pkg/extension/sumologicextension/factory_test.go
+++ b/pkg/extension/sumologicextension/factory_test.go
@@ -26,13 +26,15 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
+
+	"github.com/SumoLogic/sumologic-otel-collector/pkg/extension/sumologicextension/credentials"
 )
 
 func TestFactory_CreateDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig()
 	homePath, err := os.UserHomeDir()
 	require.NoError(t, err)
-	defaultCredsPath := path.Join(homePath, collectorCredentialsDirectory)
+	defaultCredsPath := path.Join(homePath, credentials.DefaultCollectorCredentialsDirectory)
 	assert.Equal(t, &Config{
 		ExtensionSettings:             config.NewExtensionSettings(config.NewComponentID(typeStr)),
 		HeartBeatInterval:             DefaultHeartbeatInterval,


### PR DESCRIPTION
Refactor sumologicextension's credentialsstore so that it's put in a separate package.

This way it's more separated from the extension's code. And will be easier to reason about and easier to extend.