### PR TITLE
fix: specify otelcol's binary name

### DIFF
--- a/otelcolbuilder/.otelcol-builder.yaml
+++ b/otelcolbuilder/.otelcol-builder.yaml
@@ -1,4 +1,5 @@
 dist:
+  name: otelcol-sumo
   description: Sumo Logic OpenTelemetry Collector distribution
 
   # the module name for the new distribution, following Go mod conventions. Optional, but recommended.


### PR DESCRIPTION
This name for instance is used in help.