### PR TITLE
chore(vagrant): use IP in allowed range

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,9 @@ Vagrant.configure('2') do |config|
   config.disksize.size = '50GB'
   config.vm.box_check_update = false
   config.vm.host_name = 'sumologic-otel-collector'
-  config.vm.network :private_network, ip: "192.168.79.13"
+  # Vbox 6.1.28+ restricts host-only adapters to 192.168.56.0/21
+  # See: https://www.virtualbox.org/manual/ch06.html#network_hostonly
+  config.vm.network :private_network, ip: "192.168.56.13"
 
   config.vm.provider 'virtualbox' do |vb|
     vb.gui = false


### PR DESCRIPTION
Vbox 6.1.28 restricts the IP addresses permitted in host-only networks
to 192.168.56.0/21. This can be changed via vbox config, but we don't
care what our guest IP is, so changing that instead is simpler.

See: https://www.virtualbox.org/manual/ch06.html#network_hostonly