### PR TITLE
feat(sumologicextension): re-register collector on HTTP Unauthorized

### DIFF
--- a/pkg/exporter/sumologicexporter/exporter.go
+++ b/pkg/exporter/sumologicexporter/exporter.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sync"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -39,7 +40,9 @@ const (
 
 type sumologicexporter struct {
 	sources             sourceFormats
+	configLock          sync.RWMutex
 	config              *Config
+	host                component.Host
 	logger              *zap.Logger
 	client              *http.Client
 	filter              filter
@@ -257,6 +260,8 @@ func (se *sumologicexporter) pushLogsData(ctx context.Context, ld pdata.Logs) er
 	if err != nil {
 		return consumererror.NewLogs(fmt.Errorf("failed to initialize compressor: %w", err), ld)
 	}
+
+	se.configLock.RLock()
 	sdr := newSender(
 		se.logger,
 		se.config,
@@ -343,6 +348,7 @@ func (se *sumologicexporter) pushLogsData(ctx context.Context, ld pdata.Logs) er
 		errs = append(errs, err)
 	}
 
+	se.configLock.RUnlock()
 	if len(droppedRecords) > 0 {
 		// Move all dropped records to Logs
 		droppedLogs := pdata.NewLogs()
@@ -355,6 +361,7 @@ func (se *sumologicexporter) pushLogsData(ctx context.Context, ld pdata.Logs) er
 			lp.log.CopyTo(logs.AppendEmpty())
 		}
 
+		se.handleUnauthorizedErrors(ctx, errs...)
 		return consumererror.NewLogs(multierr.Combine(errs...), droppedLogs)
 	}
 
@@ -377,6 +384,8 @@ func (se *sumologicexporter) pushMetricsData(ctx context.Context, md pdata.Metri
 	if err != nil {
 		return consumererror.NewMetrics(fmt.Errorf("failed to initialize compressor: %w", err), md)
 	}
+
+	se.configLock.RLock()
 	sdr := newSender(
 		se.logger,
 		se.config,
@@ -454,6 +463,7 @@ func (se *sumologicexporter) pushMetricsData(ctx context.Context, md pdata.Metri
 		errs = append(errs, err)
 	}
 
+	se.configLock.RUnlock()
 	if len(droppedRecords) > 0 {
 		// Move all dropped records to Metrics
 		droppedMetrics := pdata.NewMetrics()
@@ -467,10 +477,29 @@ func (se *sumologicexporter) pushMetricsData(ctx context.Context, md pdata.Metri
 			record.metric.CopyTo(ilms.AppendEmpty().Metrics().AppendEmpty())
 		}
 
+		se.handleUnauthorizedErrors(ctx, errs...)
 		return consumererror.NewMetrics(multierr.Combine(errs...), droppedMetrics)
 	}
 
 	return nil
+}
+
+// handleUnauthorizedErrors checks if any of the provided errors is an unauthorized error.
+// In which case it triggers exporter reconfiguration which in turn takes the credentials
+// from sumologicextension which at this point should already detect the problem with
+// authorization (via heartbeats) and prepare new collector credentials to be available.
+func (se *sumologicexporter) handleUnauthorizedErrors(ctx context.Context, errs ...error) {
+	for _, err := range errs {
+		if errors.Is(err, errUnauthorized) {
+			se.logger.Warn("Received unauthorized status code, triggering reconfiguration")
+			if errC := se.configure(ctx); errC != nil {
+				se.logger.Error("Error configuring the exporter with new credentials", zap.Error(err))
+			} else {
+				// It's enough to successfully reconfigure the exporter just once.
+				return
+			}
+		}
+	}
 }
 
 func (se *sumologicexporter) pushTracesData(ctx context.Context, td pdata.Traces) error {
@@ -479,6 +508,8 @@ func (se *sumologicexporter) pushTracesData(ctx context.Context, td pdata.Traces
 	if err != nil {
 		return consumererror.NewTraces(fmt.Errorf("failed to initialize compressor: %w", err), td)
 	}
+
+	se.configLock.RLock()
 	sdr := newSender(
 		se.logger,
 		se.config,
@@ -493,6 +524,8 @@ func (se *sumologicexporter) pushTracesData(ctx context.Context, td pdata.Traces
 		se.dataUrlTraces,
 	)
 	err = sdr.sendTraces(ctx, td, currentMetadata)
+	se.configLock.RUnlock()
+	se.handleUnauthorizedErrors(ctx, err)
 	if err != nil {
 		return err
 	}
@@ -501,6 +534,14 @@ func (se *sumologicexporter) pushTracesData(ctx context.Context, td pdata.Traces
 }
 
 func (se *sumologicexporter) start(ctx context.Context, host component.Host) error {
+	se.host = host
+	return se.configure(ctx)
+}
+
+func (se *sumologicexporter) configure(ctx context.Context) error {
+	se.configLock.Lock()
+	defer se.configLock.Unlock()
+
 	var (
 		ext          *sumologicextension.SumologicExtension
 		foundSumoExt bool
@@ -508,7 +549,7 @@ func (se *sumologicexporter) start(ctx context.Context, host component.Host) err
 
 	httpSettings := se.config.HTTPClientSettings
 
-	for _, e := range host.GetExtensions() {
+	for _, e := range se.host.GetExtensions() {
 		v, ok := e.(*sumologicextension.SumologicExtension)
 		if ok && httpSettings.Auth.AuthenticatorID == v.ComponentID() {
 			ext = v
@@ -558,7 +599,7 @@ func (se *sumologicexporter) start(ctx context.Context, host component.Host) err
 		return fmt.Errorf("no auth extension and no endpoint specified")
 	}
 
-	client, err := httpSettings.ToClient(host.GetExtensions(), component.TelemetrySettings{})
+	client, err := httpSettings.ToClient(se.host.GetExtensions(), component.TelemetrySettings{})
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP Client: %w", err)
 	}


### PR DESCRIPTION
This PR addresses the problem of Sumo API returning 401 during collector's runtime in which case data stops being sent due to collector not being able to get authorized.

With this PR the collector will detect that (via 401 returned on heartbeat request), trigger re-registration and then `sumologicexporter` will reconfigure as well if it detects 401 in response to sending data.

Exemplar log from re-registration process:


```
2022-02-22T14:42:25.378+0100    debug   sumologicexporter@v0.44.0/sender.go:156 Sending data    {"kind": "exporter", "name": "sumologic/1", "pipeline": "metrics", "headers": {"Content-Encoding":["gzip"],"Content-Type":["application/x-protobuf"],"X-Sumo-Client":["otelcol"],"X-Sumo-Host":["pmalek_source_host"],"X-Sumo-Name":["pmalek_source_name"]}}
2022-02-22T14:42:25.565+0100    debug   sumologicextension@v0.44.0/extension.go:540     Heartbeat sent  {"kind": "extension", "name": "sumologic", "collector_name": "pmalek_my_custom_collector_reg_030", "collector_id": "000000000123123C"}
2022-02-22T14:42:30.371+0100    debug   sumologicexporter@v0.44.0/sender.go:156 Sending data    {"kind": "exporter", "name": "sumologic/1", "pipeline": "metrics", "headers": {"Content-Encoding":["gzip"],"Content-Type":["application/x-protobuf"],"X-Sumo-Client":["otelcol"],"X-Sumo-Host":["pmalek_source_host"],"X-Sumo-Name":["pmalek_source_name"]}}
2022-02-22T14:42:30.569+0100    warn    sumologicextension@v0.44.0/extension.go:517     Heartbeat request unauthorized, re-registering the collector    {"kind": "extension", "name": "sumologic", "collector_name": "pmalek_my_custom_collector_reg_030", "collector_id": "000000000123123C"}
2022-02-22T14:42:30.570+0100    info    sumologicextension@v0.44.0/extension.go:380     Calling register API    {"kind": "extension", "name": "sumologic", "collector_name": "pmalek_my_custom_collector_reg_030", "collector_id": "000000000123123C", "URL": "https://sumologic.com/api/v1/collector/register"}
2022-02-22T14:42:30.913+0100    info    sumologicextension@v0.44.0/extension.go:465     Collector registration finished successfully    {"kind": "extension", "name": "sumologic", "collector_name": "pmalek_my_custom_collector_reg_030", "collector_id": "0000000001231232"}
2022-02-22T14:42:30.914+0100    info    credentials/credentialsstore_localfs.go:199     Collector registration credentials stored locally       {"kind": "extension", "name": "sumologic", "path": "/Users/pmalek/.sumologic-otel-collector/11111111111111111111111111111111111111111111111111111111111111111"}
2022-02-22T14:42:35.372+0100    debug   sumologicexporter@v0.44.0/sender.go:156 Sending data    {"kind": "exporter", "name": "sumologic/1", "pipeline": "metrics", "headers": {"Content-Encoding":["gzip"],"Content-Type":["application/x-protobuf"],"X-Sumo-Client":["otelcol"],"X-Sumo-Host":["pmalek_source_host"],"X-Sumo-Name":["pmalek_source_name"]}}
```