### PR TITLE
fix(sumologicexporter): escape newlines for Graphite metrics

### DIFF
--- a/pkg/exporter/sumologicexporter/graphite_formatter.go
+++ b/pkg/exporter/sumologicexporter/graphite_formatter.go
@@ -41,9 +41,13 @@ func newGraphiteFormatter(template string) (graphiteFormatter, error) {
 
 	sf := newSourceFormat(r, template)
 
+	replacementChar := `_`
+	// replace characters with special meaning in the Graphite transport format
+	// Note: \r is technically ok, but it's safer to replace anyway
+	replacer := strings.NewReplacer(`.`, replacementChar, ` `, replacementChar, "\n", replacementChar, "\r", replacementChar)
 	return graphiteFormatter{
 		template: sf,
-		replacer: strings.NewReplacer(`.`, `_`, ` `, `_`),
+		replacer: replacer,
 	}, nil
 }
 

--- a/pkg/exporter/sumologicexporter/graphite_formatter_test.go
+++ b/pkg/exporter/sumologicexporter/graphite_formatter_test.go
@@ -47,6 +47,30 @@ func TestGraphiteFormat(t *testing.T) {
 	assert.Equal(t, expected, result)
 }
 
+func TestGraphiteMetricInvalidCharactersInName(t *testing.T) {
+	gf, err := newGraphiteFormatter("%{_metric_}")
+	require.NoError(t, err)
+
+	fs := fieldsFromMap(map[string]string{})
+
+	result := gf.format(fs, " .\n\r")
+	expected := `____`
+	assert.Equal(t, expected, result)
+}
+
+func TestGraphiteFieldInvalidCharactersInValue(t *testing.T) {
+	gf, err := newGraphiteFormatter("%{_metric_}.%{key}")
+	require.NoError(t, err)
+
+	fs := fieldsFromMap(map[string]string{
+		"key": " .\n\r",
+	})
+
+	result := gf.format(fs, "metric")
+	expected := `metric.____`
+	assert.Equal(t, expected, result)
+}
+
 func TestGraphiteMetricDataTypeIntGauge(t *testing.T) {
 	gf, err := newGraphiteFormatter("%{cluster}.%{namespace}.%{pod}.%{_metric_}")
 	require.NoError(t, err)


### PR DESCRIPTION
Unfortunately Graphite doesn't have a proper spec for what is and isn't allowed in a metric path. For now I've explicitly disallowed newlines, which definitely aren't. I've tested some special characters with the Sumo backend itself, and it seems to accept them just fine, so I don't think we should be any different here.

As a point of reference, carbon-relay-ng has three different validation modes for this: https://github.com/grafana/carbon-relay-ng/blob/master/docs/validation.md#message-validation