### PR TITLE
fix(sumologicexporter): escape \r in Carbon metrics

### DIFF
--- a/pkg/exporter/sumologicexporter/carbon_formatter.go
+++ b/pkg/exporter/sumologicexporter/carbon_formatter.go
@@ -60,7 +60,7 @@ func carbon2TagString(record metricPair) string {
 
 // sanitizeCarbonString replaces problematic characters with underscore
 func sanitizeCarbonString(text string) string {
-	return strings.NewReplacer(" ", "_", "=", ":", "\n", "_").Replace(text)
+	return strings.NewReplacer(" ", "_", "=", ":", "\n", "_", "\r", "_").Replace(text)
 }
 
 // carbon2NumberRecord converts NumberDataPoint to carbon2 metric string

--- a/pkg/exporter/sumologicexporter/carbon_formatter_test.go
+++ b/pkg/exporter/sumologicexporter/carbon_formatter_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/model/pdata"
 )
 
 func TestCarbon2TagString(t *testing.T) {
@@ -36,6 +37,21 @@ func TestCarbon2TagString(t *testing.T) {
 	metric = exampleDoubleGaugeMetric()
 	data = carbon2TagString(metric)
 	assert.Equal(t, "foo=bar metric=gauge_metric_name_double_test", data)
+}
+
+func TestCarbon2InvalidCharacters(t *testing.T) {
+	metric := pdata.NewMetric()
+
+	attributes := pdata.NewAttributeMap()
+	attributes.InsertString("= \n\r", "= \n\r")
+	metric.SetName("= \n\r")
+
+	metricPair := metricPair{
+		metric:     metric,
+		attributes: attributes,
+	}
+	data := carbon2TagString(metricPair)
+	assert.Equal(t, ":___=:___ metric=:___", data)
 }
 
 func TestCarbonMetricDataTypeIntGauge(t *testing.T) {


### PR DESCRIPTION
We've already been escaping \n here, as we should. I added \r and a test for this behaviour.