### PR TITLE
fix(sumoexporter): Prometheus newline sanitization

### DIFF
--- a/pkg/exporter/sumologicexporter/prometheus_formatter.go
+++ b/pkg/exporter/sumologicexporter/prometheus_formatter.go
@@ -49,7 +49,9 @@ func newPrometheusFormatter() (prometheusFormatter, error) {
 
 	return prometheusFormatter{
 		sanitNameRegex: sanitNameRegex,
-		replacer:       strings.NewReplacer(`\`, `\\`, `"`, `\"`),
+		// `\`, `"` and `\n` should be escaped, everything else should be left as-is
+		// see: https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#line-format
+		replacer: strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`),
 	}, nil
 }
 
@@ -92,9 +94,9 @@ func (f *prometheusFormatter) sanitizeKey(s string) string {
 // sanitizeKey returns sanitized value string performing the following substitutions:
 // `/` -> `//`
 // `"` -> `\"`
-// `\n` -> `\n`
+// "\n" -> `\n`
 func (f *prometheusFormatter) sanitizeValue(s string) string {
-	return strings.ReplaceAll(f.replacer.Replace(s), `\\n`, `\n`)
+	return f.replacer.Replace(s)
 }
 
 // doubleLine builds metric based on the given arguments where value is float64

--- a/pkg/exporter/sumologicexporter/prometheus_formatter_test.go
+++ b/pkg/exporter/sumologicexporter/prometheus_formatter_test.go
@@ -26,8 +26,8 @@ func TestSanitizeKey(t *testing.T) {
 	f, err := newPrometheusFormatter()
 	require.NoError(t, err)
 
-	key := "&^*123-abc-ABC!./?_:"
-	expected := "___123-abc-ABC_./__:"
+	key := "&^*123-abc-ABC!./?_:\n\r"
+	expected := "___123-abc-ABC_./__:__"
 	assert.Equal(t, expected, f.sanitizeKey(key))
 }
 
@@ -35,8 +35,10 @@ func TestSanitizeValue(t *testing.T) {
 	f, err := newPrometheusFormatter()
 	require.NoError(t, err)
 
-	value := `&^*123-abc-ABC!?./"\\n`
-	expected := `&^*123-abc-ABC!?./\"\\\n`
+	// `\`, `"` and `\n` should be escaped, everything else should be left as-is
+	// see: https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#line-format
+	value := `&^*123-abc-ABC!?./"\` + "\n\r"
+	expected := `&^*123-abc-ABC!?./\"\\\n` + "\r"
 	assert.Equal(t, expected, f.sanitizeValue(value))
 }
 


### PR DESCRIPTION
Newlines weren't correctly escaped in Prometheus metric names and label values.