### PR TITLE
fix(sumologicexporter): fix batching logs from different files

### DIFF
--- a/pkg/exporter/sumologicexporter/exporter.go
+++ b/pkg/exporter/sumologicexporter/exporter.go
@@ -282,7 +282,7 @@ func (se *sumologicexporter) pushLogsData(ctx context.Context, ld pdata.Logs) er
 				}
 
 				// If metadata differs from currently buffered, flush the buffer
-				if currentMetadata.string() != previousMetadata.string() && previousMetadata.string() != "" {
+				if !currentMetadata.equals(previousMetadata) && !previousMetadata.isEmpty() {
 					var dropped []logPair
 					dropped, err = sdr.sendLogs(ctx, previousMetadata)
 					if err != nil {
@@ -397,7 +397,7 @@ func (se *sumologicexporter) pushMetricsData(ctx context.Context, md pdata.Metri
 				}
 
 				// If metadata differs from currently buffered, flush the buffer
-				if currentMetadata.string() != previousMetadata.string() && previousMetadata.string() != "" {
+				if !currentMetadata.equals(previousMetadata) && !previousMetadata.isEmpty() {
 					var dropped []metricPair
 					dropped, err = sdr.sendMetrics(ctx, previousMetadata)
 					if err != nil {

--- a/pkg/exporter/sumologicexporter/fields.go
+++ b/pkg/exporter/sumologicexporter/fields.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/google/go-cmp/cmp"
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
@@ -33,6 +34,14 @@ func newFields(attrMap pdata.AttributeMap) fields {
 		orig:     attrMap,
 		replacer: strings.NewReplacer(",", "_", "=", ":", "\n", "_"),
 	}
+}
+
+func (f fields) isEmpty() bool {
+	return f.orig.Len() == 0
+}
+
+func (f fields) equals(other fields) bool {
+	return cmp.Equal(f.orig.AsRaw(), other.orig.AsRaw())
 }
 
 // string returns fields as ordered key=value string with `, ` as separator

--- a/pkg/exporter/sumologicexporter/go.mod
+++ b/pkg/exporter/sumologicexporter/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
+	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect


### PR DESCRIPTION
The `fields.string()` method is not good for comparisons because it ignores the `_sourceName` attribute.

Refs: SUMO-187202