### PR TITLE
fix(telegrafreceiver): shutdown Telegraf agent gracefully

### DIFF
--- a/otelcolbuilder/.otelcol-builder.yaml
+++ b/otelcolbuilder/.otelcol-builder.yaml
@@ -141,7 +141,7 @@ replaces:
 
   # ----------------------------------------------------------------------------
   # Needed for telegrafreceiver
-  - github.com/influxdata/telegraf => github.com/SumoLogic/telegraf v1.21.3-sumo-0
+  - github.com/influxdata/telegraf => github.com/SumoLogic/telegraf v1.21.3-sumo-1
 
   # TODO: remove this when:
   # - regexp log filtering is released upstream:

--- a/pkg/receiver/telegrafreceiver/go.mod
+++ b/pkg/receiver/telegrafreceiver/go.mod
@@ -276,4 +276,4 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
-replace github.com/influxdata/telegraf => github.com/sumologic/telegraf v1.21.3-sumo-0
+replace github.com/influxdata/telegraf => github.com/sumologic/telegraf v1.21.3-sumo-1

--- a/pkg/receiver/telegrafreceiver/go.sum
+++ b/pkg/receiver/telegrafreceiver/go.sum
@@ -1535,8 +1535,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/sumologic/telegraf v1.21.3-sumo-0 h1:efWQq7hkrWXhSg4aphi3qnXQmtSWfX5YjVt6GAwKdSA=
-github.com/sumologic/telegraf v1.21.3-sumo-0/go.mod h1:63aSA3wT04MSgH69nNEAlDbrVPJhEQ1Djwc+2QFMEtU=
+github.com/sumologic/telegraf v1.21.3-sumo-1 h1:fskH4qYA0meQHtI+b3/s0bH92LJ+XOu/3xfN2L9e2nM=
+github.com/sumologic/telegraf v1.21.3-sumo-1/go.mod h1:63aSA3wT04MSgH69nNEAlDbrVPJhEQ1Djwc+2QFMEtU=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=

--- a/pkg/receiver/telegrafreceiver/receiver_test.go
+++ b/pkg/receiver/telegrafreceiver/receiver_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/receiver/telegrafreceiver/receiver_test.go
+++ b/pkg/receiver/telegrafreceiver/receiver_test.go
@@ -1,0 +1,44 @@
+// Copyright 2021, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telegrafreceiver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+)
+
+func createTestConfig() *Config {
+	config := createDefaultConfig().(*Config)
+	config.AgentConfig = `
+[agent]
+	interval = "2s"
+	flush_interval = "3s"
+[[inputs.mem]]
+	`
+	return config
+}
+
+func TestStartShutdown(t *testing.T) {
+	ctx := context.Background()
+	cfg := createTestConfig()
+	receiver, err := createMetricsReceiver(ctx, componenttest.NewNopReceiverCreateSettings(), cfg, consumertest.NewNop())
+	require.NoError(t, err)
+	require.NoError(t, receiver.Start(ctx, componenttest.NewNopHost()))
+	require.NoError(t, receiver.Shutdown(ctx))
+}


### PR DESCRIPTION
It was possible to create panics in Telegraf agent by closing the channel before the input plugin is done closing. We fix this in two ways:
1. let Telegraf agent close the channel on its own, and wait for it to do so before shutting down the receiver
2. upgrade to a new Telegraf version where the http plugin closes more gracefully, see the change here: https://github.com/SumoLogic/telegraf/pull/36

We also add a simple test for receiver start and shutdown.