### PR TITLE
fix(ci): release job should store artifacts without version

### DIFF
--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Store binary as action artifact
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ steps.set_filename.outputs.filename }}
+          name: ${{matrix.arch_os}}
           path: ./otelcolbuilder/cmd/${{ steps.set_filename.outputs.filename }}
           if-no-files-found: error
 
@@ -173,14 +173,14 @@ jobs:
       - name: Store .dmg as action artifact
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ steps.set_filename.outputs.filename }}.dmg
+          name: ${{matrix.arch_os}}.dmg
           path: ./otelcolbuilder/cmd/${{ steps.set_filename.outputs.filename }}.dmg
           if-no-files-found: error
 
       - name: Store binary as action artifact
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ steps.set_filename.outputs.filename }}
+          name: ${{matrix.arch_os}}
           path: ./otelcolbuilder/cmd/${{ steps.set_filename.outputs.filename }}
           if-no-files-found: error
 


### PR DESCRIPTION
This will fix builds like this: https://github.com/SumoLogic/sumologic-otel-collector/runs/5478153020?check_suite_focus=true where CI expects an artifact without the version included in the filename.