### PR TITLE
chore: bump go version to 1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   golang:
     docker:
-      - image: cimg/go:1.17
+      - image: cimg/go:1.18
   machine:
     machine:
       image: ubuntu-1604:201903-01

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,14 +8,14 @@ linters-settings:
     check-blank: true
 
   gosimple:
-    go: "1.17"
+    go: "1.18"
 
   maligned:
     # print struct with more effective memory layout or not, false by default
     suggest-new: true
 
   unused:
-    go: "1.17"
+    go: "1.18"
 
   lll:
     # max line length, lines longer will be reported. Default is 120.

--- a/pkg/Makefile.Common
+++ b/pkg/Makefile.Common
@@ -16,4 +16,4 @@ lint:
 
 .PHONY: mod-download-all
 mod-download-all:
-	go mod download all && go mod tidy -compat=1.17
+	go mod download all && go mod tidy -compat=1.18

--- a/pkg/test/timestamp_test.go
+++ b/pkg/test/timestamp_test.go
@@ -1,5 +1,5 @@
-//go:build go1.17
-// +build go1.17
+//go:build go1.18
+// +build go1.18
 
 package sumologic_tests
 


### PR DESCRIPTION
Update to go 1.18 missed a few things. This PR updates the remaining go 1.17 config to 1.18