### PR TITLE
fix(ci): install gon by curl not via broken brew tap

### DIFF
--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -142,10 +142,18 @@ jobs:
           # The password used to import the PKCS12 file.
           p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
 
-      - name: Install gon via HomeBrew for code signing and app notarization
+      # NOTE: gon's brew tap (as many others) has stopped working for some reason.
+      # Related issue: https://github.com/mitchellh/gon/issues/56
+      # - name: Install gon via HomeBrew for code signing and app notarization
+      #   run: |
+      #     brew tap mitchellh/gon
+      #     brew install mitchellh/gon/gon
+
+      - name: Install gon for code signing and app notarization
         run: |
-          brew tap mitchellh/gon
-          brew install mitchellh/gon/gon
+          curl -Lo gon.dmg https://github.com/mitchellh/gon/releases/download/v0.2.3/gon_macos.dmg
+          sudo hdiutil attach gon.dmg
+          cp /Volumes/gon/gon "$HOME/bin"
 
       - name: Sign the mac binaries with Gon
         env:


### PR DESCRIPTION
Example of a failed CI run: https://github.com/SumoLogic/sumologic-otel-collector/runs/5625676154?check_suite_focus=true