### PR TITLE
ci(check-uniform-dependencies): don't check for non-existent dependency

### DIFF
--- a/ci/check_uniform_dependencies.sh
+++ b/ci/check_uniform_dependencies.sh
@@ -33,5 +33,4 @@ function check(){
   fi
 }
 
-check "github.com/SumoLogic/opentelemetry-collector"
 check "go.opentelemetry.io/collector"


### PR DESCRIPTION
We haven't been using github.com/SumoLogic/opentelemetry-collector
since #201 (v0.0.22-beta.0).
