### PR TITLE
chore(ci): bump golangci-lint to 1.45.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOLANGCI_LINT_VERSION ?= v1.44.2
+GOLANGCI_LINT_VERSION ?= v1.45.2
 
 all: markdownlint yamllint
 


### PR DESCRIPTION
Related release: https://github.com/golangci/golangci-lint/releases/tag/v1.45.2