### PR TITLE
fix(k8sprocessor): parse IP out of net.Addr to correctly tag k8s.pod.ip

### DIFF
--- a/pkg/processor/k8sprocessor/pod_association.go
+++ b/pkg/processor/k8sprocessor/pod_association.go
@@ -107,6 +107,14 @@ func getConnectionIP(ctx context.Context) kube.PodIdentifier {
 	if c.Addr == nil {
 		return ""
 	}
+	switch addr := c.Addr.(type) {
+	case *net.UDPAddr:
+		return kube.PodIdentifier(addr.IP.String())
+	case *net.TCPAddr:
+		return kube.PodIdentifier(addr.IP.String())
+	case *net.IPAddr:
+		return kube.PodIdentifier(addr.IP.String())
+	}
 	return kube.PodIdentifier(c.Addr.String())
 }
 

--- a/pkg/processor/k8sprocessor/processor_test.go
+++ b/pkg/processor/k8sprocessor/processor_test.go
@@ -311,29 +311,40 @@ func withPodAndNamespace(pod string, namespace string) generateResourceFunc {
 }
 
 func TestIPDetectionFromContext(t *testing.T) {
-	m := newMultiTest(t, NewFactory().CreateDefaultConfig(), nil)
-
-	addr, err := net.ResolveIPAddr("ip", "1.1.1.1")
-	require.NoError(t, err)
-	ctx := client.NewContext(context.Background(),
-		client.Info{
+	addresses := []net.Addr{
+		&net.IPAddr{
+			IP: net.IPv4(1, 1, 1, 1),
+		},
+		&net.TCPAddr{
+			IP:   net.IPv4(1, 1, 1, 1),
+			Port: 3200,
+		},
+		&net.UDPAddr{
+			IP:   net.IPv4(1, 1, 1, 1),
+			Port: 3200,
+		},
+	}
+	for _, addr := range addresses {
+		m := newMultiTest(t, NewFactory().CreateDefaultConfig(), nil)
+		ctx := client.NewContext(context.Background(), client.Info{
 			Addr: addr,
 		})
-	m.testConsume(
-		ctx,
-		generateTraces(),
-		generateMetrics(),
-		generateLogs(),
-		func(err error) {
-			assert.NoError(t, err)
-		})
+		m.testConsume(
+			ctx,
+			generateTraces(),
+			generateMetrics(),
+			generateLogs(),
+			func(err error) {
+				assert.NoError(t, err)
+			})
 
-	m.assertBatchesLen(1)
-	m.assertResourceObjectLen(0)
-	m.assertResource(0, func(r pdata.Resource) {
-		require.Greater(t, r.Attributes().Len(), 0)
-		assertResourceHasStringAttribute(t, r, "k8s.pod.ip", "1.1.1.1")
-	})
+		m.assertBatchesLen(1)
+		m.assertResourceObjectLen(0)
+		m.assertResource(0, func(r pdata.Resource) {
+			require.Greater(t, r.Attributes().Len(), 0)
+			assertResourceHasStringAttribute(t, r, "k8s.pod.ip", "1.1.1.1")
+		})
+	}
 }
 
 func TestNilBatch(t *testing.T) {


### PR DESCRIPTION
Backports https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/7077.
