### PR TITLE
feat(exporter/sumologic): add metrics for HTTP requests

### DIFF
--- a/pkg/exporter/sumologicexporter/README.md
+++ b/pkg/exporter/sumologicexporter/README.md
@@ -244,6 +244,22 @@ with metric name.
 If an attribute is not found, it is replaced with `undefined`.
 For example, `%{existing_attr}/%{nonexistent_attr}` becomes `value-of-existing-attr/undefined`.
 
+## Metrics
+
+The Sumo Logic Exporter exposes the following metrics:
+
+- `otelcol_exporter_requests_bytes` (`counter`) - total size of HTTP requests (in bytes)
+- `otelcol_exporter_requests_duration` (`counter`) - duration of HTTP requests (in milliseconds)
+- `otelcol_exporter_requests_records` (`counter`) - total size of HTTP requests (in number of records)
+- `otelcol_exporter_requests_sent` (`counter`) - number of HTTP requests
+
+All of the above metrics have the following dimensions:
+
+- `endpoint` - endpoint address
+- `exporter` - exporter name
+- `pipeline` - pipeline name (`logs`, `metrics` or `traces`)
+- `status_code` - HTTP response status code (`0` in case of error)
+
 ## Example Configuration
 
 ### Example with sumologicextension

--- a/pkg/exporter/sumologicexporter/go.mod
+++ b/pkg/exporter/sumologicexporter/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/go-cmp v0.5.7
 	github.com/klauspost/compress v1.15.1
 	github.com/stretchr/testify v1.7.0
+	go.opencensus.io v0.23.0
 	go.opentelemetry.io/collector v0.47.0
 	go.opentelemetry.io/collector/model v0.47.0
 	go.uber.org/multierr v1.8.0
@@ -20,6 +21,7 @@ require (
 	github.com/go-logr/logr v1.2.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/uuid v1.3.0 // indirect
@@ -32,7 +34,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/cors v1.8.2 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
-	go.opencensus.io v0.23.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.29.0 // indirect
 	go.opentelemetry.io/otel v1.4.1 // indirect
 	go.opentelemetry.io/otel/internal/metric v0.27.0 // indirect

--- a/pkg/exporter/sumologicexporter/go.sum
+++ b/pkg/exporter/sumologicexporter/go.sum
@@ -55,6 +55,7 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/pkg/exporter/sumologicexporter/internal/observability/observability.go
+++ b/pkg/exporter/sumologicexporter/internal/observability/observability.go
@@ -24,9 +24,6 @@ import (
 	"go.opencensus.io/tag"
 )
 
-// TODO: re-think if processor should register it's own telemetry views or if some other
-// mechanism should be used by the collector to discover views from all components
-
 func init() {
 	err := view.Register(
 		viewRequestsSent,

--- a/pkg/exporter/sumologicexporter/internal/observability/observability.go
+++ b/pkg/exporter/sumologicexporter/internal/observability/observability.go
@@ -31,6 +31,8 @@ func init() {
 	err := view.Register(
 		viewRequestsSent,
 		viewRequestsDuration,
+		viewRequestsBytes,
+		viewRequestsRecords,
 	)
 	if err != nil {
 		fmt.Printf("Failed to register sumologic exporter's views: %v\n", err)
@@ -38,16 +40,20 @@ func init() {
 }
 
 var (
-	mRequestsSent     = stats.Int64("sumologic/requests/sent", "Number of requests per status_code", "1")
+	mRequestsSent     = stats.Int64("sumologic/requests/sent", "Number of requests", "1")
 	mRequestsDuration = stats.Int64("sumologic/requests/duration", "Duration of HTTP requests (in milliseconds)", "0")
+	mRequestsBytes    = stats.Int64("sumologic/requests/bytes", "Duration of HTTP requests (in milliseconds)", "0")
+	mRequestsRecords  = stats.Int64("sumologic/requests/records", "Duration of HTTP requests (in milliseconds)", "0")
 	statusKey, _      = tag.NewKey("status_code")
+	addressKey, _     = tag.NewKey("address")
+	uriKey, _         = tag.NewKey("uri")
 )
 
 var viewRequestsSent = &view.View{
 	Name:        mRequestsSent.Name(),
 	Description: mRequestsSent.Description(),
 	Measure:     mRequestsSent,
-	TagKeys:     []tag.Key{statusKey},
+	TagKeys:     []tag.Key{statusKey, addressKey, uriKey},
 	Aggregation: view.Count(),
 }
 
@@ -55,24 +61,74 @@ var viewRequestsDuration = &view.View{
 	Name:        mRequestsDuration.Name(),
 	Description: mRequestsDuration.Description(),
 	Measure:     mRequestsDuration,
-	TagKeys:     []tag.Key{statusKey},
+	TagKeys:     []tag.Key{statusKey, addressKey, uriKey},
+	Aggregation: view.Sum(),
+}
+
+var viewRequestsBytes = &view.View{
+	Name:        mRequestsBytes.Name(),
+	Description: mRequestsBytes.Description(),
+	Measure:     mRequestsBytes,
+	TagKeys:     []tag.Key{statusKey, addressKey, uriKey},
+	Aggregation: view.Sum(),
+}
+
+var viewRequestsRecords = &view.View{
+	Name:        mRequestsRecords.Name(),
+	Description: mRequestsRecords.Description(),
+	Measure:     mRequestsRecords,
+	TagKeys:     []tag.Key{statusKey, addressKey, uriKey},
 	Aggregation: view.Sum(),
 }
 
 // RecordPodUpdated increments the metric that records pod update events received.
-func RecordRequestsSent(status_code int) {
-	stats.RecordWithTags(
+func RecordRequestsSent(statusCode int, address string, uri string) error {
+	return stats.RecordWithTags(
 		context.Background(),
-		[]tag.Mutator{tag.Insert(statusKey, fmt.Sprintf("%d", status_code))},
+		[]tag.Mutator{
+			tag.Insert(statusKey, fmt.Sprintf("%d", statusCode)),
+			tag.Insert(addressKey, address),
+			tag.Insert(uriKey, uri),
+		},
 		mRequestsSent.M(int64(1)),
 	)
 }
 
 // RecordPodAdded increments the metric that records pod add events receiver.
-func RecordRequestsDuration(duration time.Duration, status_code int) {
-	stats.RecordWithTags(
+func RecordRequestsDuration(duration time.Duration, statusCode int, address string, uri string) error {
+	return stats.RecordWithTags(
 		context.Background(),
-		[]tag.Mutator{tag.Insert(statusKey, fmt.Sprintf("%d", status_code))},
+		[]tag.Mutator{
+			tag.Insert(statusKey, fmt.Sprintf("%d", statusCode)),
+			tag.Insert(addressKey, address),
+			tag.Insert(uriKey, uri),
+		},
 		mRequestsDuration.M(duration.Milliseconds()),
+	)
+}
+
+// RecordPodAdded increments the metric that records pod add events receiver.
+func RecordRequestsBytes(bytes int64, statusCode int, address string, uri string) error {
+	return stats.RecordWithTags(
+		context.Background(),
+		[]tag.Mutator{
+			tag.Insert(statusKey, fmt.Sprintf("%d", statusCode)),
+			tag.Insert(addressKey, address),
+			tag.Insert(uriKey, uri),
+		},
+		mRequestsBytes.M(bytes),
+	)
+}
+
+// RecordPodAdded increments the metric that records pod add events receiver.
+func RecordRequestsRecords(records int64, statusCode int, address string, uri string) error {
+	return stats.RecordWithTags(
+		context.Background(),
+		[]tag.Mutator{
+			tag.Insert(statusKey, fmt.Sprintf("%d", statusCode)),
+			tag.Insert(addressKey, address),
+			tag.Insert(uriKey, uri),
+		},
+		mRequestsRecords.M(records),
 	)
 }

--- a/pkg/exporter/sumologicexporter/internal/observability/observability.go
+++ b/pkg/exporter/sumologicexporter/internal/observability/observability.go
@@ -1,0 +1,78 @@
+// Copyright 2022 Sumo Logic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observability
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+// TODO: re-think if processor should register it's own telemetry views or if some other
+// mechanism should be used by the collector to discover views from all components
+
+func init() {
+	err := view.Register(
+		viewRequestsSent,
+		viewRequestsDuration,
+	)
+	if err != nil {
+		fmt.Printf("Failed to register sumologic exporter's views: %v\n", err)
+	}
+}
+
+var (
+	mRequestsSent     = stats.Int64("sumologic/requests/sent", "Number of requests per status_code", "1")
+	mRequestsDuration = stats.Int64("sumologic/requests/duration", "Duration of HTTP requests (in milliseconds)", "0")
+	statusKey, _      = tag.NewKey("status_code")
+)
+
+var viewRequestsSent = &view.View{
+	Name:        mRequestsSent.Name(),
+	Description: mRequestsSent.Description(),
+	Measure:     mRequestsSent,
+	TagKeys:     []tag.Key{statusKey},
+	Aggregation: view.Count(),
+}
+
+var viewRequestsDuration = &view.View{
+	Name:        mRequestsDuration.Name(),
+	Description: mRequestsDuration.Description(),
+	Measure:     mRequestsDuration,
+	TagKeys:     []tag.Key{statusKey},
+	Aggregation: view.Sum(),
+}
+
+// RecordPodUpdated increments the metric that records pod update events received.
+func RecordRequestsSent(status_code int) {
+	stats.RecordWithTags(
+		context.Background(),
+		[]tag.Mutator{tag.Insert(statusKey, fmt.Sprintf("%d", status_code))},
+		mRequestsSent.M(int64(1)),
+	)
+}
+
+// RecordPodAdded increments the metric that records pod add events receiver.
+func RecordRequestsDuration(duration time.Duration, status_code int) {
+	stats.RecordWithTags(
+		context.Background(),
+		[]tag.Mutator{tag.Insert(statusKey, fmt.Sprintf("%d", status_code))},
+		mRequestsDuration.M(duration.Milliseconds()),
+	)
+}

--- a/pkg/exporter/sumologicexporter/internal/observability/observability.go
+++ b/pkg/exporter/sumologicexporter/internal/observability/observability.go
@@ -43,15 +43,14 @@ var (
 	mRequestsRecords  = stats.Int64("sumologic/requests/records", "Duration of HTTP requests (in milliseconds)", "0")
 
 	statusKey, _  = tag.NewKey("status_code")
-	addressKey, _ = tag.NewKey("address")
-	uriKey, _     = tag.NewKey("uri")
+	endpointKey, _ = tag.NewKey("endpoint")
 )
 
 var viewRequestsSent = &view.View{
 	Name:        mRequestsSent.Name(),
 	Description: mRequestsSent.Description(),
 	Measure:     mRequestsSent,
-	TagKeys:     []tag.Key{statusKey, addressKey, uriKey},
+	TagKeys:     []tag.Key{statusKey, endpointKey},
 	Aggregation: view.Count(),
 }
 
@@ -59,7 +58,7 @@ var viewRequestsDuration = &view.View{
 	Name:        mRequestsDuration.Name(),
 	Description: mRequestsDuration.Description(),
 	Measure:     mRequestsDuration,
-	TagKeys:     []tag.Key{statusKey, addressKey, uriKey},
+	TagKeys:     []tag.Key{statusKey, endpointKey},
 	Aggregation: view.Sum(),
 }
 
@@ -67,7 +66,7 @@ var viewRequestsBytes = &view.View{
 	Name:        mRequestsBytes.Name(),
 	Description: mRequestsBytes.Description(),
 	Measure:     mRequestsBytes,
-	TagKeys:     []tag.Key{statusKey, addressKey, uriKey},
+	TagKeys:     []tag.Key{statusKey, endpointKey},
 	Aggregation: view.Sum(),
 }
 
@@ -75,57 +74,53 @@ var viewRequestsRecords = &view.View{
 	Name:        mRequestsRecords.Name(),
 	Description: mRequestsRecords.Description(),
 	Measure:     mRequestsRecords,
-	TagKeys:     []tag.Key{statusKey, addressKey, uriKey},
+	TagKeys:     []tag.Key{statusKey, endpointKey},
 	Aggregation: view.Sum(),
 }
 
 // RecordRequestsSent increments the metric that records sent requests
-func RecordRequestsSent(statusCode int, address string, uri string) error {
+func RecordRequestsSent(statusCode int, endpoint string) error {
 	return stats.RecordWithTags(
 		context.Background(),
 		[]tag.Mutator{
 			tag.Insert(statusKey, fmt.Sprintf("%d", statusCode)),
-			tag.Insert(addressKey, address),
-			tag.Insert(uriKey, uri),
+			tag.Insert(endpointKey, endpoint),
 		},
 		mRequestsSent.M(int64(1)),
 	)
 }
 
 // RecordRequestsDuration update metric which records request duration
-func RecordRequestsDuration(duration time.Duration, statusCode int, address string, uri string) error {
+func RecordRequestsDuration(duration time.Duration, statusCode int, endpoint string) error {
 	return stats.RecordWithTags(
 		context.Background(),
 		[]tag.Mutator{
 			tag.Insert(statusKey, fmt.Sprintf("%d", statusCode)),
-			tag.Insert(addressKey, address),
-			tag.Insert(uriKey, uri),
+			tag.Insert(endpointKey, endpoint),
 		},
 		mRequestsDuration.M(duration.Milliseconds()),
 	)
 }
 
 // RecordRequestsBytes update metric which records number of send bytes
-func RecordRequestsBytes(bytes int64, statusCode int, address string, uri string) error {
+func RecordRequestsBytes(bytes int64, statusCode int, endpoint string) error {
 	return stats.RecordWithTags(
 		context.Background(),
 		[]tag.Mutator{
 			tag.Insert(statusKey, fmt.Sprintf("%d", statusCode)),
-			tag.Insert(addressKey, address),
-			tag.Insert(uriKey, uri),
+			tag.Insert(endpointKey, endpoint),
 		},
 		mRequestsBytes.M(bytes),
 	)
 }
 
 // RecordRequestsRecords update metric which records number of sent records
-func RecordRequestsRecords(records int64, statusCode int, address string, uri string) error {
+func RecordRequestsRecords(records int64, statusCode int, endpoint string) error {
 	return stats.RecordWithTags(
 		context.Background(),
 		[]tag.Mutator{
 			tag.Insert(statusKey, fmt.Sprintf("%d", statusCode)),
-			tag.Insert(addressKey, address),
-			tag.Insert(uriKey, uri),
+			tag.Insert(endpointKey, endpoint),
 		},
 		mRequestsRecords.M(records),
 	)

--- a/pkg/exporter/sumologicexporter/internal/observability/observability.go
+++ b/pkg/exporter/sumologicexporter/internal/observability/observability.go
@@ -41,9 +41,10 @@ var (
 	mRequestsDuration = stats.Int64("sumologic/requests/duration", "Duration of HTTP requests (in milliseconds)", "0")
 	mRequestsBytes    = stats.Int64("sumologic/requests/bytes", "Duration of HTTP requests (in milliseconds)", "0")
 	mRequestsRecords  = stats.Int64("sumologic/requests/records", "Duration of HTTP requests (in milliseconds)", "0")
-	statusKey, _      = tag.NewKey("status_code")
-	addressKey, _     = tag.NewKey("address")
-	uriKey, _         = tag.NewKey("uri")
+
+	statusKey, _  = tag.NewKey("status_code")
+	addressKey, _ = tag.NewKey("address")
+	uriKey, _     = tag.NewKey("uri")
 )
 
 var viewRequestsSent = &view.View{
@@ -78,7 +79,7 @@ var viewRequestsRecords = &view.View{
 	Aggregation: view.Sum(),
 }
 
-// RecordPodUpdated increments the metric that records pod update events received.
+// RecordRequestsSent increments the metric that records sent requests
 func RecordRequestsSent(statusCode int, address string, uri string) error {
 	return stats.RecordWithTags(
 		context.Background(),
@@ -91,7 +92,7 @@ func RecordRequestsSent(statusCode int, address string, uri string) error {
 	)
 }
 
-// RecordPodAdded increments the metric that records pod add events receiver.
+// RecordRequestsDuration update metric which records request duration
 func RecordRequestsDuration(duration time.Duration, statusCode int, address string, uri string) error {
 	return stats.RecordWithTags(
 		context.Background(),
@@ -104,7 +105,7 @@ func RecordRequestsDuration(duration time.Duration, statusCode int, address stri
 	)
 }
 
-// RecordPodAdded increments the metric that records pod add events receiver.
+// RecordRequestsBytes update metric which records number of send bytes
 func RecordRequestsBytes(bytes int64, statusCode int, address string, uri string) error {
 	return stats.RecordWithTags(
 		context.Background(),
@@ -117,7 +118,7 @@ func RecordRequestsBytes(bytes int64, statusCode int, address string, uri string
 	)
 }
 
-// RecordPodAdded increments the metric that records pod add events receiver.
+// RecordRequestsRecords update metric which records number of sent records
 func RecordRequestsRecords(records int64, statusCode int, address string, uri string) error {
 	return stats.RecordWithTags(
 		context.Background(),

--- a/pkg/exporter/sumologicexporter/internal/observability/observability.go
+++ b/pkg/exporter/sumologicexporter/internal/observability/observability.go
@@ -44,13 +44,14 @@ var (
 
 	statusKey, _   = tag.NewKey("status_code")
 	endpointKey, _ = tag.NewKey("endpoint")
+	pipelineKey, _ = tag.NewKey("pipeline")
 )
 
 var viewRequestsSent = &view.View{
 	Name:        mRequestsSent.Name(),
 	Description: mRequestsSent.Description(),
 	Measure:     mRequestsSent,
-	TagKeys:     []tag.Key{statusKey, endpointKey},
+	TagKeys:     []tag.Key{statusKey, endpointKey, pipelineKey},
 	Aggregation: view.Count(),
 }
 
@@ -58,7 +59,7 @@ var viewRequestsDuration = &view.View{
 	Name:        mRequestsDuration.Name(),
 	Description: mRequestsDuration.Description(),
 	Measure:     mRequestsDuration,
-	TagKeys:     []tag.Key{statusKey, endpointKey},
+	TagKeys:     []tag.Key{statusKey, endpointKey, pipelineKey},
 	Aggregation: view.Sum(),
 }
 
@@ -66,7 +67,7 @@ var viewRequestsBytes = &view.View{
 	Name:        mRequestsBytes.Name(),
 	Description: mRequestsBytes.Description(),
 	Measure:     mRequestsBytes,
-	TagKeys:     []tag.Key{statusKey, endpointKey},
+	TagKeys:     []tag.Key{statusKey, endpointKey, pipelineKey},
 	Aggregation: view.Sum(),
 }
 
@@ -74,53 +75,57 @@ var viewRequestsRecords = &view.View{
 	Name:        mRequestsRecords.Name(),
 	Description: mRequestsRecords.Description(),
 	Measure:     mRequestsRecords,
-	TagKeys:     []tag.Key{statusKey, endpointKey},
+	TagKeys:     []tag.Key{statusKey, endpointKey, pipelineKey},
 	Aggregation: view.Sum(),
 }
 
 // RecordRequestsSent increments the metric that records sent requests
-func RecordRequestsSent(statusCode int, endpoint string) error {
+func RecordRequestsSent(statusCode int, endpoint string, pipeline string) error {
 	return stats.RecordWithTags(
 		context.Background(),
 		[]tag.Mutator{
-			tag.Insert(statusKey, fmt.Sprintf("%d", statusCode)),
+			tag.Insert(statusKey, fmt.Sprint(statusCode)),
 			tag.Insert(endpointKey, endpoint),
+			tag.Insert(pipelineKey, pipeline),
 		},
 		mRequestsSent.M(int64(1)),
 	)
 }
 
 // RecordRequestsDuration update metric which records request duration
-func RecordRequestsDuration(duration time.Duration, statusCode int, endpoint string) error {
+func RecordRequestsDuration(duration time.Duration, statusCode int, endpoint string, pipeline string) error {
 	return stats.RecordWithTags(
 		context.Background(),
 		[]tag.Mutator{
-			tag.Insert(statusKey, fmt.Sprintf("%d", statusCode)),
+			tag.Insert(statusKey, fmt.Sprint(statusCode)),
 			tag.Insert(endpointKey, endpoint),
+			tag.Insert(pipelineKey, pipeline),
 		},
 		mRequestsDuration.M(duration.Milliseconds()),
 	)
 }
 
 // RecordRequestsBytes update metric which records number of send bytes
-func RecordRequestsBytes(bytes int64, statusCode int, endpoint string) error {
+func RecordRequestsBytes(bytes int64, statusCode int, endpoint string, pipeline string) error {
 	return stats.RecordWithTags(
 		context.Background(),
 		[]tag.Mutator{
-			tag.Insert(statusKey, fmt.Sprintf("%d", statusCode)),
+			tag.Insert(statusKey, fmt.Sprint(statusCode)),
 			tag.Insert(endpointKey, endpoint),
+			tag.Insert(pipelineKey, pipeline),
 		},
 		mRequestsBytes.M(bytes),
 	)
 }
 
 // RecordRequestsRecords update metric which records number of sent records
-func RecordRequestsRecords(records int64, statusCode int, endpoint string) error {
+func RecordRequestsRecords(records int64, statusCode int, endpoint string, pipeline string) error {
 	return stats.RecordWithTags(
 		context.Background(),
 		[]tag.Mutator{
-			tag.Insert(statusKey, fmt.Sprintf("%d", statusCode)),
+			tag.Insert(statusKey, fmt.Sprint(statusCode)),
 			tag.Insert(endpointKey, endpoint),
+			tag.Insert(pipelineKey, pipeline),
 		},
 		mRequestsRecords.M(records),
 	)

--- a/pkg/exporter/sumologicexporter/internal/observability/observability.go
+++ b/pkg/exporter/sumologicexporter/internal/observability/observability.go
@@ -37,21 +37,22 @@ func init() {
 }
 
 var (
-	mRequestsSent     = stats.Int64("sumologic/requests/sent", "Number of requests", "1")
-	mRequestsDuration = stats.Int64("sumologic/requests/duration", "Duration of HTTP requests (in milliseconds)", "0")
-	mRequestsBytes    = stats.Int64("sumologic/requests/bytes", "Total size of requests (in bytes)", "0")
-	mRequestsRecords  = stats.Int64("sumologic/requests/records", "Total size of requests (in number of records)", "0")
+	mRequestsSent     = stats.Int64("exporter/requests/sent", "Number of requests", "1")
+	mRequestsDuration = stats.Int64("exporter/requests/duration", "Duration of HTTP requests (in milliseconds)", "0")
+	mRequestsBytes    = stats.Int64("exporter/requests/bytes", "Total size of requests (in bytes)", "0")
+	mRequestsRecords  = stats.Int64("exporter/requests/records", "Total size of requests (in number of records)", "0")
 
 	statusKey, _   = tag.NewKey("status_code")
 	endpointKey, _ = tag.NewKey("endpoint")
 	pipelineKey, _ = tag.NewKey("pipeline")
+	exporterKey, _ = tag.NewKey("exporter")
 )
 
 var viewRequestsSent = &view.View{
 	Name:        mRequestsSent.Name(),
 	Description: mRequestsSent.Description(),
 	Measure:     mRequestsSent,
-	TagKeys:     []tag.Key{statusKey, endpointKey, pipelineKey},
+	TagKeys:     []tag.Key{statusKey, endpointKey, pipelineKey, exporterKey},
 	Aggregation: view.Count(),
 }
 
@@ -59,7 +60,7 @@ var viewRequestsDuration = &view.View{
 	Name:        mRequestsDuration.Name(),
 	Description: mRequestsDuration.Description(),
 	Measure:     mRequestsDuration,
-	TagKeys:     []tag.Key{statusKey, endpointKey, pipelineKey},
+	TagKeys:     []tag.Key{statusKey, endpointKey, pipelineKey, exporterKey},
 	Aggregation: view.Sum(),
 }
 
@@ -67,7 +68,7 @@ var viewRequestsBytes = &view.View{
 	Name:        mRequestsBytes.Name(),
 	Description: mRequestsBytes.Description(),
 	Measure:     mRequestsBytes,
-	TagKeys:     []tag.Key{statusKey, endpointKey, pipelineKey},
+	TagKeys:     []tag.Key{statusKey, endpointKey, pipelineKey, exporterKey},
 	Aggregation: view.Sum(),
 }
 
@@ -75,57 +76,61 @@ var viewRequestsRecords = &view.View{
 	Name:        mRequestsRecords.Name(),
 	Description: mRequestsRecords.Description(),
 	Measure:     mRequestsRecords,
-	TagKeys:     []tag.Key{statusKey, endpointKey, pipelineKey},
+	TagKeys:     []tag.Key{statusKey, endpointKey, pipelineKey, exporterKey},
 	Aggregation: view.Sum(),
 }
 
 // RecordRequestsSent increments the metric that records sent requests
-func RecordRequestsSent(statusCode int, endpoint string, pipeline string) error {
+func RecordRequestsSent(statusCode int, endpoint string, pipeline string, exporter string) error {
 	return stats.RecordWithTags(
 		context.Background(),
 		[]tag.Mutator{
 			tag.Insert(statusKey, fmt.Sprint(statusCode)),
 			tag.Insert(endpointKey, endpoint),
 			tag.Insert(pipelineKey, pipeline),
+			tag.Insert(exporterKey, exporter),
 		},
 		mRequestsSent.M(int64(1)),
 	)
 }
 
 // RecordRequestsDuration update metric which records request duration
-func RecordRequestsDuration(duration time.Duration, statusCode int, endpoint string, pipeline string) error {
+func RecordRequestsDuration(duration time.Duration, statusCode int, endpoint string, pipeline string, exporter string) error {
 	return stats.RecordWithTags(
 		context.Background(),
 		[]tag.Mutator{
 			tag.Insert(statusKey, fmt.Sprint(statusCode)),
 			tag.Insert(endpointKey, endpoint),
 			tag.Insert(pipelineKey, pipeline),
+			tag.Insert(exporterKey, exporter),
 		},
 		mRequestsDuration.M(duration.Milliseconds()),
 	)
 }
 
 // RecordRequestsBytes update metric which records number of send bytes
-func RecordRequestsBytes(bytes int64, statusCode int, endpoint string, pipeline string) error {
+func RecordRequestsBytes(bytes int64, statusCode int, endpoint string, pipeline string, exporter string) error {
 	return stats.RecordWithTags(
 		context.Background(),
 		[]tag.Mutator{
 			tag.Insert(statusKey, fmt.Sprint(statusCode)),
 			tag.Insert(endpointKey, endpoint),
 			tag.Insert(pipelineKey, pipeline),
+			tag.Insert(exporterKey, exporter),
 		},
 		mRequestsBytes.M(bytes),
 	)
 }
 
 // RecordRequestsRecords update metric which records number of sent records
-func RecordRequestsRecords(records int64, statusCode int, endpoint string, pipeline string) error {
+func RecordRequestsRecords(records int64, statusCode int, endpoint string, pipeline string, exporter string) error {
 	return stats.RecordWithTags(
 		context.Background(),
 		[]tag.Mutator{
 			tag.Insert(statusKey, fmt.Sprint(statusCode)),
 			tag.Insert(endpointKey, endpoint),
 			tag.Insert(pipelineKey, pipeline),
+			tag.Insert(exporterKey, exporter),
 		},
 		mRequestsRecords.M(records),
 	)

--- a/pkg/exporter/sumologicexporter/internal/observability/observability.go
+++ b/pkg/exporter/sumologicexporter/internal/observability/observability.go
@@ -39,10 +39,10 @@ func init() {
 var (
 	mRequestsSent     = stats.Int64("sumologic/requests/sent", "Number of requests", "1")
 	mRequestsDuration = stats.Int64("sumologic/requests/duration", "Duration of HTTP requests (in milliseconds)", "0")
-	mRequestsBytes    = stats.Int64("sumologic/requests/bytes", "Duration of HTTP requests (in milliseconds)", "0")
-	mRequestsRecords  = stats.Int64("sumologic/requests/records", "Duration of HTTP requests (in milliseconds)", "0")
+	mRequestsBytes    = stats.Int64("sumologic/requests/bytes", "Total size of requests (in bytes)", "0")
+	mRequestsRecords  = stats.Int64("sumologic/requests/records", "Total size of requests (in number of records)", "0")
 
-	statusKey, _  = tag.NewKey("status_code")
+	statusKey, _   = tag.NewKey("status_code")
 	endpointKey, _ = tag.NewKey("endpoint")
 )
 

--- a/pkg/exporter/sumologicexporter/internal/observability/observability_test.go
+++ b/pkg/exporter/sumologicexporter/internal/observability/observability_test.go
@@ -1,3 +1,4 @@
+
 // Copyright 2020 OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -85,8 +86,7 @@ func metricReader(chData chan []*metricdata.Metric, fail chan struct{}, count in
 func TestMetrics(t *testing.T) {
 	const (
 		statusCode = 200
-		addr       = "test_address"
-		uri        = "some/uri"
+		endpoint   = "some/uri"
 	)
 	type testCase struct {
 		name       string
@@ -127,13 +127,13 @@ func TestMetrics(t *testing.T) {
 	for _, tt := range tests {
 		switch tt.recordFunc {
 		case "sent":
-			RecordRequestsSent(statusCode, addr, uri)
+			RecordRequestsSent(statusCode, endpoint)
 		case "duration":
-			RecordRequestsDuration(tt.duration, statusCode, addr, uri)
+			RecordRequestsDuration(tt.duration, statusCode, endpoint)
 		case "bytes":
-			RecordRequestsBytes(tt.bytes, statusCode, addr, uri)
+			RecordRequestsBytes(tt.bytes, statusCode, endpoint)
 		case "records":
-			RecordRequestsRecords(tt.records, statusCode, addr, uri)
+			RecordRequestsRecords(tt.records, statusCode, endpoint)
 		}
 	}
 
@@ -160,14 +160,12 @@ func TestMetrics(t *testing.T) {
 		require.Len(t, d.TimeSeries[0].Points, 1)
 		assert.Equal(t, d.TimeSeries[0].Points[0].Value, int64(1))
 
-		require.Len(t, d.TimeSeries[0].LabelValues, 3)
+		require.Len(t, d.TimeSeries[0].LabelValues, 2)
 
 		require.True(t, d.TimeSeries[0].LabelValues[0].Present)
 		require.True(t, d.TimeSeries[0].LabelValues[1].Present)
-		require.True(t, d.TimeSeries[0].LabelValues[2].Present)
 
-		assert.Equal(t, d.TimeSeries[0].LabelValues[0].Value, "test_address")
+		assert.Equal(t, d.TimeSeries[0].LabelValues[0].Value, "some/uri")
 		assert.Equal(t, d.TimeSeries[0].LabelValues[1].Value, "200")
-		assert.Equal(t, d.TimeSeries[0].LabelValues[2].Value, "some/uri")
 	}
 }

--- a/pkg/exporter/sumologicexporter/internal/observability/observability_test.go
+++ b/pkg/exporter/sumologicexporter/internal/observability/observability_test.go
@@ -1,4 +1,3 @@
-
 // Copyright 2020 OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -87,6 +86,7 @@ func TestMetrics(t *testing.T) {
 	const (
 		statusCode = 200
 		endpoint   = "some/uri"
+		pipeline   = "metrics"
 	)
 	type testCase struct {
 		name       string
@@ -127,13 +127,13 @@ func TestMetrics(t *testing.T) {
 	for _, tt := range tests {
 		switch tt.recordFunc {
 		case "sent":
-			RecordRequestsSent(statusCode, endpoint)
+			RecordRequestsSent(statusCode, endpoint, pipeline)
 		case "duration":
-			RecordRequestsDuration(tt.duration, statusCode, endpoint)
+			RecordRequestsDuration(tt.duration, statusCode, endpoint, pipeline)
 		case "bytes":
-			RecordRequestsBytes(tt.bytes, statusCode, endpoint)
+			RecordRequestsBytes(tt.bytes, statusCode, endpoint, pipeline)
 		case "records":
-			RecordRequestsRecords(tt.records, statusCode, endpoint)
+			RecordRequestsRecords(tt.records, statusCode, endpoint, pipeline)
 		}
 	}
 
@@ -160,12 +160,14 @@ func TestMetrics(t *testing.T) {
 		require.Len(t, d.TimeSeries[0].Points, 1)
 		assert.Equal(t, d.TimeSeries[0].Points[0].Value, int64(1))
 
-		require.Len(t, d.TimeSeries[0].LabelValues, 2)
+		require.Len(t, d.TimeSeries[0].LabelValues, 3)
 
 		require.True(t, d.TimeSeries[0].LabelValues[0].Present)
 		require.True(t, d.TimeSeries[0].LabelValues[1].Present)
+		require.True(t, d.TimeSeries[0].LabelValues[2].Present)
 
 		assert.Equal(t, d.TimeSeries[0].LabelValues[0].Value, "some/uri")
-		assert.Equal(t, d.TimeSeries[0].LabelValues[1].Value, "200")
+		assert.Equal(t, d.TimeSeries[0].LabelValues[1].Value, "metrics")
+		assert.Equal(t, d.TimeSeries[0].LabelValues[2].Value, "200")
 	}
 }

--- a/pkg/exporter/sumologicexporter/internal/observability/observability_test.go
+++ b/pkg/exporter/sumologicexporter/internal/observability/observability_test.go
@@ -1,0 +1,173 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observability
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opencensus.io/metric/metricdata"
+	"go.opencensus.io/metric/metricexport"
+)
+
+type exporter struct {
+	pipe chan *metricdata.Metric
+}
+
+func newExporter() *exporter {
+	return &exporter{make(chan *metricdata.Metric)}
+}
+
+func (e *exporter) ReturnAfter(after int) chan []*metricdata.Metric {
+	ch := make(chan []*metricdata.Metric)
+	go func() {
+		received := []*metricdata.Metric{}
+		for m := range e.pipe {
+			received = append(received, m)
+			if len(received) >= after {
+				break
+			}
+		}
+		ch <- received
+	}()
+	return ch
+}
+
+func (e *exporter) ExportMetrics(ctx context.Context, data []*metricdata.Metric) error {
+	for _, m := range data {
+		e.pipe <- m
+	}
+	return nil
+}
+
+func metricReader(chData chan []*metricdata.Metric, fail chan struct{}, count int) {
+	reader := metricexport.NewReader()
+	e := newExporter()
+	ch := e.ReturnAfter(count)
+
+	// Add a manual retry mechanism in case there's a hiccup reading the
+	// metrics from producers in ReadAndExport(): we can wait for the metrics
+	// to come instead of failing because they didn't come right away.
+	for i := 0; i < 10; i++ {
+		go reader.ReadAndExport(e)
+
+		select {
+		case <-time.After(500 * time.Millisecond):
+
+		case data := <-ch:
+			chData <- data
+			return
+		}
+	}
+
+	fail <- struct{}{}
+}
+
+// NOTE:
+// This test can only be run with -count 1 because of static
+// metricproducer.GlobalManager() used in metricexport.NewReader().
+func TestMetrics(t *testing.T) {
+	const (
+		statusCode = 200
+		addr       = "test_address"
+		uri        = "some/uri"
+	)
+	type testCase struct {
+		name       string
+		bytes      int64
+		records    int64
+		recordFunc string
+		duration   time.Duration
+	}
+	tests := []testCase{
+		{
+			name:       "sumologic/requests/sent",
+			recordFunc: "sent",
+		},
+		{
+			name:       "sumologic/requests/duration",
+			recordFunc: "duration",
+			duration:   time.Millisecond,
+		},
+		{
+			name:       "sumologic/requests/bytes",
+			recordFunc: "bytes",
+			bytes:      1,
+		},
+		{
+			name:       "sumologic/requests/records",
+			recordFunc: "records",
+			records:    1,
+		},
+	}
+
+	var (
+		fail   = make(chan struct{})
+		chData = make(chan []*metricdata.Metric)
+	)
+
+	go metricReader(chData, fail, len(tests))
+
+	for _, tt := range tests {
+		switch tt.recordFunc {
+		case "sent":
+			RecordRequestsSent(statusCode, addr, uri)
+		case "duration":
+			RecordRequestsDuration(tt.duration, statusCode, addr, uri)
+		case "bytes":
+			RecordRequestsBytes(tt.bytes, statusCode, addr, uri)
+		case "records":
+			RecordRequestsRecords(tt.records, statusCode, addr, uri)
+		}
+	}
+
+	var data []*metricdata.Metric
+	select {
+	case <-fail:
+		t.Fatalf("timedout waiting for metrics to arrive")
+	case data = <-chData:
+	}
+
+	sort.Slice(tests, func(i, j int) bool {
+		return tests[i].name < tests[j].name
+	})
+
+	sort.Slice(data, func(i, j int) bool {
+		return data[i].Descriptor.Name < data[j].Descriptor.Name
+	})
+
+	for i, tt := range tests {
+		require.Len(t, data, len(tests))
+		d := data[i]
+		assert.Equal(t, d.Descriptor.Name, tt.name)
+		require.Len(t, d.TimeSeries, 1)
+		require.Len(t, d.TimeSeries[0].Points, 1)
+		assert.Equal(t, d.TimeSeries[0].Points[0].Value, int64(1))
+
+		require.Len(t, d.TimeSeries[0].LabelValues, 3)
+
+		require.True(t, d.TimeSeries[0].LabelValues[0].Present)
+		require.True(t, d.TimeSeries[0].LabelValues[1].Present)
+		require.True(t, d.TimeSeries[0].LabelValues[2].Present)
+
+		assert.Equal(t, d.TimeSeries[0].LabelValues[0].Value, "test_address")
+		assert.Equal(t, d.TimeSeries[0].LabelValues[1].Value, "200")
+		assert.Equal(t, d.TimeSeries[0].LabelValues[2].Value, "some/uri")
+	}
+}

--- a/pkg/exporter/sumologicexporter/internal/observability/observability_test.go
+++ b/pkg/exporter/sumologicexporter/internal/observability/observability_test.go
@@ -84,9 +84,13 @@ func metricReader(chData chan []*metricdata.Metric, fail chan struct{}, count in
 // metricproducer.GlobalManager() used in metricexport.NewReader().
 func TestMetrics(t *testing.T) {
 	const (
-		statusCode = 200
-		endpoint   = "some/uri"
-		pipeline   = "metrics"
+		statusCode   = 200
+		endpoint     = "some/uri"
+		pipeline     = "metrics"
+		bytesFunc    = "bytes"
+		recordsFunc  = "records"
+		durationFunc = "duration"
+		sentFunc     = "sent"
 	)
 	type testCase struct {
 		name       string
@@ -98,21 +102,21 @@ func TestMetrics(t *testing.T) {
 	tests := []testCase{
 		{
 			name:       "sumologic/requests/sent",
-			recordFunc: "sent",
+			recordFunc: sentFunc,
 		},
 		{
 			name:       "sumologic/requests/duration",
-			recordFunc: "duration",
+			recordFunc: durationFunc,
 			duration:   time.Millisecond,
 		},
 		{
 			name:       "sumologic/requests/bytes",
-			recordFunc: "bytes",
+			recordFunc: bytesFunc,
 			bytes:      1,
 		},
 		{
 			name:       "sumologic/requests/records",
-			recordFunc: "records",
+			recordFunc: recordsFunc,
 			records:    1,
 		},
 	}
@@ -126,14 +130,14 @@ func TestMetrics(t *testing.T) {
 
 	for _, tt := range tests {
 		switch tt.recordFunc {
-		case "sent":
-			RecordRequestsSent(statusCode, endpoint, pipeline)
-		case "duration":
-			RecordRequestsDuration(tt.duration, statusCode, endpoint, pipeline)
-		case "bytes":
-			RecordRequestsBytes(tt.bytes, statusCode, endpoint, pipeline)
-		case "records":
-			RecordRequestsRecords(tt.records, statusCode, endpoint, pipeline)
+		case sentFunc:
+			require.NoError(t, RecordRequestsSent(statusCode, endpoint, pipeline))
+		case durationFunc:
+			require.NoError(t, RecordRequestsDuration(tt.duration, statusCode, endpoint, pipeline))
+		case bytesFunc:
+			require.NoError(t, RecordRequestsBytes(tt.bytes, statusCode, endpoint, pipeline))
+		case recordsFunc:
+			require.NoError(t, RecordRequestsRecords(tt.records, statusCode, endpoint, pipeline))
 		}
 	}
 

--- a/pkg/exporter/sumologicexporter/internal/observability/observability_test.go
+++ b/pkg/exporter/sumologicexporter/internal/observability/observability_test.go
@@ -94,6 +94,7 @@ func TestMetrics(t *testing.T) {
 		statusCode   = 200
 		endpoint     = "some/uri"
 		pipeline     = "metrics"
+		exporter     = "sumologic/my-name"
 		bytesFunc    = "bytes"
 		recordsFunc  = "records"
 		durationFunc = "duration"
@@ -108,21 +109,21 @@ func TestMetrics(t *testing.T) {
 	}
 	tests := []testCase{
 		{
-			name:       "sumologic/requests/sent",
+			name:       "exporter/requests/sent",
 			recordFunc: sentFunc,
 		},
 		{
-			name:       "sumologic/requests/duration",
+			name:       "exporter/requests/duration",
 			recordFunc: durationFunc,
 			duration:   time.Millisecond,
 		},
 		{
-			name:       "sumologic/requests/bytes",
+			name:       "exporter/requests/bytes",
 			recordFunc: bytesFunc,
 			bytes:      1,
 		},
 		{
-			name:       "sumologic/requests/records",
+			name:       "exporter/requests/records",
 			recordFunc: recordsFunc,
 			records:    1,
 		},
@@ -138,13 +139,13 @@ func TestMetrics(t *testing.T) {
 	for _, tt := range tests {
 		switch tt.recordFunc {
 		case sentFunc:
-			require.NoError(t, RecordRequestsSent(statusCode, endpoint, pipeline))
+			require.NoError(t, RecordRequestsSent(statusCode, endpoint, pipeline, exporter))
 		case durationFunc:
-			require.NoError(t, RecordRequestsDuration(tt.duration, statusCode, endpoint, pipeline))
+			require.NoError(t, RecordRequestsDuration(tt.duration, statusCode, endpoint, pipeline, exporter))
 		case bytesFunc:
-			require.NoError(t, RecordRequestsBytes(tt.bytes, statusCode, endpoint, pipeline))
+			require.NoError(t, RecordRequestsBytes(tt.bytes, statusCode, endpoint, pipeline, exporter))
 		case recordsFunc:
-			require.NoError(t, RecordRequestsRecords(tt.records, statusCode, endpoint, pipeline))
+			require.NoError(t, RecordRequestsRecords(tt.records, statusCode, endpoint, pipeline, exporter))
 		}
 	}
 
@@ -172,15 +173,17 @@ func TestMetrics(t *testing.T) {
 			require.Len(t, d.TimeSeries[0].Points, 1)
 			assert.Equal(t, d.TimeSeries[0].Points[0].Value, int64(1))
 
-			require.Len(t, d.TimeSeries[0].LabelValues, 3)
+			require.Len(t, d.TimeSeries[0].LabelValues, 4)
 
 			require.True(t, d.TimeSeries[0].LabelValues[0].Present)
 			require.True(t, d.TimeSeries[0].LabelValues[1].Present)
 			require.True(t, d.TimeSeries[0].LabelValues[2].Present)
+			require.True(t, d.TimeSeries[0].LabelValues[3].Present)
 
 			assert.Equal(t, d.TimeSeries[0].LabelValues[0].Value, "some/uri")
-			assert.Equal(t, d.TimeSeries[0].LabelValues[1].Value, "metrics")
-			assert.Equal(t, d.TimeSeries[0].LabelValues[2].Value, "200")
+			assert.Equal(t, d.TimeSeries[0].LabelValues[1].Value, "sumologic/my-name")
+			assert.Equal(t, d.TimeSeries[0].LabelValues[2].Value, "metrics")
+			assert.Equal(t, d.TimeSeries[0].LabelValues[3].Value, "200")
 		})
 	}
 }

--- a/pkg/exporter/sumologicexporter/sender.go
+++ b/pkg/exporter/sumologicexporter/sender.go
@@ -71,13 +71,13 @@ func newCountingReader(records int) *countingReader {
 	}
 }
 
-// withBytes set ups reader to read from bytes data
+// withBytes sets up reader to read from bytes data
 func (c *countingReader) withBytes(data []byte) *countingReader {
 	c.reader = bytes.NewReader(data)
 	return c
 }
 
-// withString set ups reader to read from string data
+// withString sets up reader to read from string data
 func (c *countingReader) withString(data string) *countingReader {
 	c.reader = strings.NewReader(data)
 	return c

--- a/pkg/exporter/sumologicexporter/sender.go
+++ b/pkg/exporter/sumologicexporter/sender.go
@@ -846,19 +846,19 @@ func (s *sender) recordMetrics(duration time.Duration, count int64, req *http.Re
 		statusCode = resp.StatusCode
 	}
 
-	if err := observability.RecordRequestsDuration(duration, statusCode, req.RemoteAddr, req.URL.String()); err != nil {
+	if err := observability.RecordRequestsDuration(duration, statusCode, req.URL.String()); err != nil {
 		s.logger.Debug("error for recording metric for request duration", zap.Error(err))
 	}
 
-	if err := observability.RecordRequestsBytes(req.ContentLength, statusCode, req.RemoteAddr, req.URL.String()); err != nil {
+	if err := observability.RecordRequestsBytes(req.ContentLength, statusCode, req.URL.String()); err != nil {
 		s.logger.Debug("error for recording metric for sent bytes", zap.Error(err))
 	}
 
-	if err := observability.RecordRequestsRecords(count, statusCode, req.RemoteAddr, req.URL.String()); err != nil {
+	if err := observability.RecordRequestsRecords(count, statusCode, req.URL.String()); err != nil {
 		s.logger.Debug("error for recording metric for sent records", zap.Error(err))
 	}
 
-	if err := observability.RecordRequestsSent(statusCode, req.RemoteAddr, req.URL.String()); err != nil {
+	if err := observability.RecordRequestsSent(statusCode, req.URL.String()); err != nil {
 		s.logger.Debug("error for recording metric for sent request", zap.Error(err))
 	}
 

--- a/pkg/exporter/sumologicexporter/sender.go
+++ b/pkg/exporter/sumologicexporter/sender.go
@@ -852,19 +852,21 @@ func (s *sender) recordMetrics(duration time.Duration, count int64, req *http.Re
 		statusCode = resp.StatusCode
 	}
 
-	if err := observability.RecordRequestsDuration(duration, statusCode, req.URL.String(), string(pipeline)); err != nil {
+	id := s.config.ID().String()
+
+	if err := observability.RecordRequestsDuration(duration, statusCode, req.URL.String(), string(pipeline), id); err != nil {
 		s.logger.Debug("error for recording metric for request duration", zap.Error(err))
 	}
 
-	if err := observability.RecordRequestsBytes(req.ContentLength, statusCode, req.URL.String(), string(pipeline)); err != nil {
+	if err := observability.RecordRequestsBytes(req.ContentLength, statusCode, req.URL.String(), string(pipeline), id); err != nil {
 		s.logger.Debug("error for recording metric for sent bytes", zap.Error(err))
 	}
 
-	if err := observability.RecordRequestsRecords(count, statusCode, req.URL.String(), string(pipeline)); err != nil {
+	if err := observability.RecordRequestsRecords(count, statusCode, req.URL.String(), string(pipeline), id); err != nil {
 		s.logger.Debug("error for recording metric for sent records", zap.Error(err))
 	}
 
-	if err := observability.RecordRequestsSent(statusCode, req.URL.String(), string(pipeline)); err != nil {
+	if err := observability.RecordRequestsSent(statusCode, req.URL.String(), string(pipeline), id); err != nil {
 		s.logger.Debug("error for recording metric for sent request", zap.Error(err))
 	}
 

--- a/pkg/exporter/sumologicexporter/sender.go
+++ b/pkg/exporter/sumologicexporter/sender.go
@@ -107,7 +107,7 @@ func (b *bodyBuilder) addLine(line string) error {
 }
 
 func (b *bodyBuilder) addNewLine() error {
-	_, err := b.builder.WriteString("\n")
+	err := b.builder.WriteByte('\n')
 	return err
 }
 

--- a/pkg/exporter/sumologicexporter/sender.go
+++ b/pkg/exporter/sumologicexporter/sender.go
@@ -71,11 +71,13 @@ func newCountingReader(records int) *countingReader {
 	}
 }
 
+// withBytes set ups reader to read from bytes data
 func (c *countingReader) withBytes(data []byte) *countingReader {
 	c.reader = bytes.NewReader(data)
 	return c
 }
 
+// withString set ups reader to read from string data
 func (c *countingReader) withString(data string) *countingReader {
 	c.reader = strings.NewReader(data)
 	return c
@@ -87,10 +89,12 @@ type bodyBuilder struct {
 	counter int
 }
 
+// newBodyBuilder returns empty bodyBuilder
 func newBodyBuilder() bodyBuilder {
 	return bodyBuilder{}
 }
 
+// Reset resets both counter and builder content
 func (b *bodyBuilder) Reset() {
 	b.counter = 0
 	b.builder.Reset()
@@ -106,11 +110,13 @@ func (b *bodyBuilder) addLine(line string) error {
 	return nil
 }
 
+// addNewLine adds newline to builder
 func (b *bodyBuilder) addNewLine() error {
 	err := b.builder.WriteByte('\n')
 	return err
 }
 
+// Len returns builder content length
 func (b *bodyBuilder) Len() int {
 	return b.builder.Len()
 }

--- a/pkg/exporter/sumologicexporter/sender.go
+++ b/pkg/exporter/sumologicexporter/sender.go
@@ -224,12 +224,12 @@ func (s *sender) send(ctx context.Context, pipeline PipelineType, reader *counti
 	start := time.Now()
 	resp, err := s.client.Do(req)
 	if err != nil {
-		s.recordMetrics(time.Since(start), reader.counter, req, nil)
+		s.recordMetrics(time.Since(start), reader.counter, req, nil, pipeline)
 		return err
 	}
 	defer resp.Body.Close()
 
-	s.recordMetrics(time.Since(start), reader.counter, req, resp)
+	s.recordMetrics(time.Since(start), reader.counter, req, resp, pipeline)
 
 	return s.handleReceiverResponse(resp)
 }
@@ -839,26 +839,26 @@ func (s *sender) addResourceAttributes(attrs pdata.AttributeMap, flds fields) {
 	}
 }
 
-func (s *sender) recordMetrics(duration time.Duration, count int64, req *http.Request, resp *http.Response) {
+func (s *sender) recordMetrics(duration time.Duration, count int64, req *http.Request, resp *http.Response, pipeline PipelineType) {
 	statusCode := 0
 
 	if resp != nil {
 		statusCode = resp.StatusCode
 	}
 
-	if err := observability.RecordRequestsDuration(duration, statusCode, req.URL.String()); err != nil {
+	if err := observability.RecordRequestsDuration(duration, statusCode, req.URL.String(), string(pipeline)); err != nil {
 		s.logger.Debug("error for recording metric for request duration", zap.Error(err))
 	}
 
-	if err := observability.RecordRequestsBytes(req.ContentLength, statusCode, req.URL.String()); err != nil {
+	if err := observability.RecordRequestsBytes(req.ContentLength, statusCode, req.URL.String(), string(pipeline)); err != nil {
 		s.logger.Debug("error for recording metric for sent bytes", zap.Error(err))
 	}
 
-	if err := observability.RecordRequestsRecords(count, statusCode, req.URL.String()); err != nil {
+	if err := observability.RecordRequestsRecords(count, statusCode, req.URL.String(), string(pipeline)); err != nil {
 		s.logger.Debug("error for recording metric for sent records", zap.Error(err))
 	}
 
-	if err := observability.RecordRequestsSent(statusCode, req.URL.String()); err != nil {
+	if err := observability.RecordRequestsSent(statusCode, req.URL.String(), string(pipeline)); err != nil {
 		s.logger.Debug("error for recording metric for sent request", zap.Error(err))
 	}
 

--- a/pkg/exporter/sumologicexporter/sender_test.go
+++ b/pkg/exporter/sumologicexporter/sender_test.go
@@ -1135,14 +1135,14 @@ func TestInvalidMetricFormat(t *testing.T) {
 
 	test.s.config.MetricFormat = "invalid"
 
-	err := test.s.send(context.Background(), MetricsPipeline, strings.NewReader(""), newFields(pdata.NewAttributeMap()))
+	err := test.s.send(context.Background(), MetricsPipeline, newCountingReader(0).withString(""), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, `unsupported metrics format: invalid`)
 }
 
 func TestInvalidPipeline(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){})
 
-	err := test.s.send(context.Background(), "invalidPipeline", strings.NewReader(""), newFields(pdata.NewAttributeMap()))
+	err := test.s.send(context.Background(), "invalidPipeline", newCountingReader(0).withString(""), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, `unexpected pipeline: invalidPipeline`)
 }
 
@@ -1167,7 +1167,7 @@ func TestSendCompressGzip(t *testing.T) {
 	require.NoError(t, err)
 
 	test.s.compressor = c
-	reader := strings.NewReader("Some example log")
+	reader := newCountingReader(0).withString("Some example log")
 
 	err = test.s.send(context.Background(), LogsPipeline, reader, newFields(pdata.NewAttributeMap()))
 	require.NoError(t, err)
@@ -1195,7 +1195,7 @@ func TestSendCompressDeflate(t *testing.T) {
 	require.NoError(t, err)
 
 	test.s.compressor = c
-	reader := strings.NewReader("Some example log")
+	reader := newCountingReader(0).withString("Some example log")
 
 	err = test.s.send(context.Background(), LogsPipeline, reader, newFields(pdata.NewAttributeMap()))
 	require.NoError(t, err)
@@ -1205,7 +1205,7 @@ func TestCompressionError(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){})
 
 	test.s.compressor = getTestCompressor(errors.New("read error"), nil)
-	reader := strings.NewReader("Some example log")
+	reader := newCountingReader(0).withString("Some example log")
 
 	err := test.s.send(context.Background(), LogsPipeline, reader, newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, "read error")
@@ -1215,7 +1215,7 @@ func TestInvalidContentEncoding(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){})
 
 	test.s.config.CompressEncoding = "test"
-	reader := strings.NewReader("Some example log")
+	reader := newCountingReader(0).withString("Some example log")
 
 	err := test.s.send(context.Background(), LogsPipeline, reader, newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, "invalid content encoding: test")


### PR DESCRIPTION
Signed-off-by: Dominik Rosiek <drosiek@sumologic.com>

Generated metrics
```
# HELP otelcol_sumologic_requests_bytes Total size of requests (in bytes)
# TYPE otelcol_sumologic_requests_bytes counter
otelcol_sumologic_requests_bytes{endpoint="http://localhost:3000",pipeline="metrics",service_instance_id="00e0fe04-5899-4b4b-9e4d-c2dee53af447",service_version="latest",status_code="0"} 297107
otelcol_sumologic_requests_bytes{endpoint="http://localhost:3000",pipeline="metrics",service_instance_id="00e0fe04-5899-4b4b-9e4d-c2dee53af447",service_version="latest",status_code="200"} 1.727096e+06
# HELP otelcol_sumologic_requests_duration Duration of HTTP requests (in milliseconds)
# TYPE otelcol_sumologic_requests_duration counter
otelcol_sumologic_requests_duration{endpoint="http://localhost:3000",pipeline="metrics",service_instance_id="00e0fe04-5899-4b4b-9e4d-c2dee53af447",service_version="latest",status_code="0"} 0
otelcol_sumologic_requests_duration{endpoint="http://localhost:3000",pipeline="metrics",service_instance_id="00e0fe04-5899-4b4b-9e4d-c2dee53af447",service_version="latest",status_code="200"} 280
# HELP otelcol_sumologic_requests_records Total size of requests (in number of records)
# TYPE otelcol_sumologic_requests_records counter
otelcol_sumologic_requests_records{endpoint="http://localhost:3000",pipeline="metrics",service_instance_id="00e0fe04-5899-4b4b-9e4d-c2dee53af447",service_version="latest",status_code="0"} 16384
otelcol_sumologic_requests_records{endpoint="http://localhost:3000",pipeline="metrics",service_instance_id="00e0fe04-5899-4b4b-9e4d-c2dee53af447",service_version="latest",status_code="200"} 95232
# HELP otelcol_sumologic_requests_sent Number of requests
# TYPE otelcol_sumologic_requests_sent counter
otelcol_sumologic_requests_sent{endpoint="http://localhost:3000",pipeline="metrics",service_instance_id="00e0fe04-5899-4b4b-9e4d-c2dee53af447",service_version="latest",status_code="0"} 2
otelcol_sumologic_requests_sent{endpoint="http://localhost:3000",pipeline="metrics",service_instance_id="00e0fe04-5899-4b4b-9e4d-c2dee53af447",service_version="latest",status_code="200"} 12
```