### PR TITLE
fix(telegrafreceiver): retry recoverable errors

### DIFF
--- a/otelcolbuilder/cmd/testdata/telegrafreceiver_sumologicexporter_endpoint.yaml
+++ b/otelcolbuilder/cmd/testdata/telegrafreceiver_sumologicexporter_endpoint.yaml
@@ -1,6 +1,8 @@
 receivers:
   telegraf:
     separate_field: false
+    consume_retry_delay: 1s
+    consume_max_retries: 3
     agent_config: |
       [agent]
         interval = "1s"

--- a/pkg/receiver/telegrafreceiver/README.md
+++ b/pkg/receiver/telegrafreceiver/README.md
@@ -25,6 +25,11 @@ The Following settings are optional:
 
 - `separate_field` (default value is `false`): Specify whether metric field
   should be added separately as data point label.
+- `consume_retry_delay` (default value is `500ms`): The retry delay for recoverable
+  errors from the rest of the pipeline. Don't change this or the related setting below
+  unless you know what you're doing.
+- `consume_max_retries` (default value is `10`): The maximum number of retries for recoverable
+  errors from the rest of the pipeline.
 
 Example:
 

--- a/pkg/receiver/telegrafreceiver/config.go
+++ b/pkg/receiver/telegrafreceiver/config.go
@@ -15,6 +15,8 @@
 package telegrafreceiver
 
 import (
+	"time"
+
 	"go.opentelemetry.io/collector/config"
 )
 
@@ -31,4 +33,11 @@ type Config struct {
 	// concatenated with metric name like e.g. metric=mem_available or maybe rather
 	// have it as a separate label like e.g. metric=mem field=available
 	SeparateField bool `mapstructure:"separate_field"`
+
+	// ConsumeRetryDelay is the retry delay for recoverable pipeline errors
+	// one frequent source of these kinds of errors is the memory_limiter processor
+	ConsumeRetryDelay time.Duration `mapstructure:"consume_retry_delay"`
+
+	// ConsumeMaxRetries is the maximum number of retries for recoverable pipeline errors
+	ConsumeMaxRetries uint64 `mapstructure:"consume_max_retries"`
 }

--- a/pkg/receiver/telegrafreceiver/go.mod
+++ b/pkg/receiver/telegrafreceiver/go.mod
@@ -3,6 +3,7 @@ module github.com/SumoLogic/sumologic-otel-collector/pkg/receiver/telegrafreceiv
 go 1.18
 
 require (
+	github.com/cenkalti/backoff/v4 v4.1.2
 	github.com/influxdata/telegraf v1.22.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/collector v0.47.0

--- a/pkg/receiver/telegrafreceiver/go.sum
+++ b/pkg/receiver/telegrafreceiver/go.sum
@@ -54,6 +54,7 @@ github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.1/go.mod h1:JFgpikqFJ/MleTTxwepExTKnFUKKszPS8UavbQYUMuw=
 github.com/Azure/go-autorest/autorest v0.11.12/go.mod h1:eipySxLmqSyC5s5k1CLupqet0PSENBEDP93LQ9a8QYw=
+github.com/Azure/go-autorest/autorest v0.11.18 h1:90Y4srNYrwOtAgVo3ndrQkTYn6kf1Eg/AjTFJ8Is2aM=
 github.com/Azure/go-autorest/autorest v0.11.18/go.mod h1:dSiJPy22c3u0OtOKDNttNgqpNFY/GeWa7GH/Pz56QRA=
 github.com/Azure/go-autorest/autorest/adal v0.9.0/go.mod h1:/c022QCutn2P7uY+/oQWWNcK9YU+MH96NgK+jErpbcg=
 github.com/Azure/go-autorest/autorest/adal v0.9.5/go.mod h1:B7KF7jKIeC9Mct5spmyCB/A8CG/sEz1vwIRGv/bbw7A=
@@ -196,6 +197,8 @@ github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
+github.com/cenkalti/backoff/v4 v4.1.2 h1:6Yo7N8UP2K6LWZnW94DLVSSrbobcWdVzAYOisuDPIFo=
+github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/pkg/receiver/telegrafreceiver/receiver_test.go
+++ b/pkg/receiver/telegrafreceiver/receiver_test.go
@@ -16,11 +16,20 @@ package telegrafreceiver
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func createTestConfig() *Config {
@@ -34,6 +43,26 @@ func createTestConfig() *Config {
 	return config
 }
 
+type countingErrorConsumer struct {
+	err       error
+	CallCount int
+}
+
+func (er *countingErrorConsumer) ConsumeMetrics(context.Context, pdata.Metrics) error {
+	er.CallCount++
+	return er.err
+}
+
+func (er *countingErrorConsumer) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{}
+}
+
+// newCountingErrorConsumer returns a Consumer that drops all received data and returns the specified error to Consume* callers
+// It also counts the number of time Consume* was called
+func newCountingErrorConsumer(err error) *countingErrorConsumer {
+	return &countingErrorConsumer{err: err, CallCount: 0}
+}
+
 func TestStartShutdown(t *testing.T) {
 	ctx := context.Background()
 	cfg := createTestConfig()
@@ -41,4 +70,48 @@ func TestStartShutdown(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, receiver.Start(ctx, componenttest.NewNopHost()))
 	require.NoError(t, receiver.Shutdown(ctx))
+}
+
+func TestConsumeRetryOnRecoverableError(t *testing.T) {
+	ctx := context.Background()
+	maxRetries := 1
+	core, observedLogs := observer.New(zapcore.InfoLevel)
+	logger := zap.New(core)
+	consumerError := errors.New("recoverable error")
+	consumer := newCountingErrorConsumer(consumerError)
+	receiver := &telegrafreceiver{
+		consumer:          consumer,
+		logger:            logger,
+		metricConverter:   newConverter(true, logger),
+		consumeRetryDelay: time.Nanosecond,
+		consumeMaxRetries: uint64(maxRetries),
+	}
+
+	metrics := pdata.Metrics{}
+	err := receiver.consumeWithRetry(ctx, metrics)
+	assert.NotEqual(t, nil, err)
+	assert.Equal(t, maxRetries+1, consumer.CallCount)
+	assert.Equal(t, maxRetries, observedLogs.Len())
+	assert.Equal(t, maxRetries, observedLogs.FilterMessage("ConsumeMetrics() recoverable error, will retry").Len())
+}
+
+func TestConsumeNoRetryOnPermanentError(t *testing.T) {
+	ctx := context.Background()
+	core, observedLogs := observer.New(zapcore.InfoLevel)
+	logger := zap.New(core)
+	consumerError := consumererror.NewPermanent(errors.New("recoverable error"))
+	consumer := newCountingErrorConsumer(consumerError)
+	receiver := &telegrafreceiver{
+		consumer:          consumer,
+		logger:            logger,
+		metricConverter:   newConverter(true, logger),
+		consumeRetryDelay: time.Nanosecond,
+		consumeMaxRetries: 10,
+	}
+
+	metrics := pdata.Metrics{}
+	err := receiver.consumeWithRetry(ctx, metrics)
+	assert.Error(t, err)
+	assert.Equal(t, 1, consumer.CallCount)
+	assert.Equal(t, 0, observedLogs.Len())
 }


### PR DESCRIPTION
Retry recoverable errors from the rest of the pipeline using a simple constant backoff strategy. I've made the backoff configurable primarily to make testing easier, but users shouldn't really touch these values in most circumstances, which is why I'm not including them in the README.