### PR TITLE
chore(telegrafreceiver): update telegraf to v1.22.0-sumo-2

### DIFF
--- a/otelcolbuilder/.otelcol-builder.yaml
+++ b/otelcolbuilder/.otelcol-builder.yaml
@@ -145,7 +145,7 @@ replaces:
 
   # ----------------------------------------------------------------------------
   # Needed for telegrafreceiver
-  - github.com/influxdata/telegraf => github.com/SumoLogic/telegraf v1.22.0-sumo-1
+  - github.com/influxdata/telegraf => github.com/SumoLogic/telegraf v1.22.0-sumo-2
 
   # TODO: remove this when:
   # - regexp log filtering is released upstream:

--- a/pkg/receiver/telegrafreceiver/go.mod
+++ b/pkg/receiver/telegrafreceiver/go.mod
@@ -140,4 +140,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
-replace github.com/influxdata/telegraf => github.com/SumoLogic/telegraf v1.22.0-sumo-1
+replace github.com/influxdata/telegraf => github.com/SumoLogic/telegraf v1.22.0-sumo-2

--- a/pkg/receiver/telegrafreceiver/go.sum
+++ b/pkg/receiver/telegrafreceiver/go.sum
@@ -108,8 +108,8 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
-github.com/SumoLogic/telegraf v1.22.0-sumo-1 h1:DasBVU8IPnSZVOOP1WHAemQb8MwUQUlyA2MdGcTg0jA=
-github.com/SumoLogic/telegraf v1.22.0-sumo-1/go.mod h1:VbJ7vmk18cTPKQB50VtSM6f+dBzJ5cUAtBHZQwjJa/o=
+github.com/SumoLogic/telegraf v1.22.0-sumo-2 h1:4WJW4LKW2nXzgp+rAhjtPeWVZJOokWm63d2CWm90b5U=
+github.com/SumoLogic/telegraf v1.22.0-sumo-2/go.mod h1:VbJ7vmk18cTPKQB50VtSM6f+dBzJ5cUAtBHZQwjJa/o=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=


### PR DESCRIPTION
This version contains a backpressure fix to http_listener_v2: https://github.com/SumoLogic/telegraf/pull/38.