### PR TITLE
chore(Makefile): use bash as default shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 GOLANGCI_LINT_VERSION ?= v1.45.2
+SHELL := /usr/bin/env bash
 
 all: markdownlint yamllint
 


### PR DESCRIPTION
https://stackoverflow.com/a/589300

Fixes:

```
➜  ~ cd projects/sumologic-otel-collector 
➜  sumologic-otel-collector git:(main) ✗ git reset --hard
HEAD is now at 1e0f157 docs(known-issues): describe filelog multiline issue
➜  sumologic-otel-collector git:(main) ✗ export TAG=v0.0.59-beta.1 ; make add-tag 
Adding tag v0.0.59-beta.1
/bin/sh: 2: Bad substitution
make: *** [Makefile:126: add-tag] Error 2
```