### PR TITLE
refactor(sumologicexporter): optimize compressor using sync.Pool

### DIFF
--- a/pkg/exporter/sumologicexporter/config.go
+++ b/pkg/exporter/sumologicexporter/config.go
@@ -155,12 +155,8 @@ func (cfg *Config) Validate() error {
 		return fmt.Errorf("unexpected trace format: %s", cfg.TraceFormat)
 	}
 
-	switch cfg.CompressEncoding {
-	case GZIPCompression:
-	case DeflateCompression:
-	case NoCompression:
-	default:
-		return fmt.Errorf("unexpected compression encoding: %s", cfg.CompressEncoding)
+	if err := cfg.CompressEncoding.Validate(); err != nil {
+		return err
 	}
 
 	if len(cfg.HTTPClientSettings.Endpoint) == 0 && cfg.HTTPClientSettings.Auth == nil {
@@ -194,6 +190,19 @@ type PipelineType string
 
 // CompressEncodingType represents type of the pipeline
 type CompressEncodingType string
+
+func (cet CompressEncodingType) Validate() error {
+	switch cet {
+	case GZIPCompression:
+	case NoCompression:
+	case DeflateCompression:
+
+	default:
+		return fmt.Errorf("invalid compression encoding type: %v", cet)
+	}
+
+	return nil
+}
 
 const (
 	// TextFormat represents log_format: text

--- a/pkg/exporter/sumologicexporter/config_test.go
+++ b/pkg/exporter/sumologicexporter/config_test.go
@@ -57,7 +57,7 @@ func TestInitExporterInvalidLogFormat(t *testing.T) {
 		},
 		{
 			name:          "unexpected compression encoding",
-			expectedError: errors.New("unexpected compression encoding: test_format"),
+			expectedError: errors.New("invalid compression encoding type: test_format"),
 			cfg: &Config{
 				LogFormat:        "json",
 				MetricFormat:     "carbon2",

--- a/pkg/exporter/sumologicexporter/sender_test.go
+++ b/pkg/exporter/sumologicexporter/sender_test.go
@@ -186,6 +186,16 @@ func exampleLog() []pdata.LogRecord {
 	return buffer
 }
 
+func exampleNLogs(n int) []pdata.LogRecord {
+	buffer := make([]pdata.LogRecord, n)
+	for i := 0; i < n; i++ {
+		buffer[i] = pdata.NewLogRecord()
+		buffer[i].Body().SetStringVal("Example log")
+	}
+
+	return buffer
+}
+
 func exampleTwoLogs() []pdata.LogRecord {
 	buffer := make([]pdata.LogRecord, 2)
 	buffer[0] = pdata.NewLogRecord()


### PR DESCRIPTION
This PR tries to address unnecessary creation of data compressor instances on every `push(Logs|Metrics|Traces)` invocation using `sync.Pool`

```
$ go test -v -count 1 -run ^$ -bench Benchmark_ExporterPushLogs -benchmem -count 5 -benchtime 200x . > old.txt
$ git(5651893) gco -
Previous HEAD position was 5651893 tests(sumologicexporter): add exporter logs sending benchmark
Switched to branch 'optimize-compression'
$ go test -v -count 1 -run ^$ -bench Benchmark_ExporterPushLogs -benchmem -count 5 -benchtime 200x . > new.txt
$ benchcmp old.txt new.txt
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                         old ns/op     new ns/op     delta
Benchmark_ExporterPushLogs-16     2396758       2079249       -13.25%
Benchmark_ExporterPushLogs-16     2558661       2250972       -12.03%
Benchmark_ExporterPushLogs-16     3170924       2782736       -12.24%
Benchmark_ExporterPushLogs-16     2857462       2505237       -12.33%
Benchmark_ExporterPushLogs-16     3131852       2938191       -6.18%

benchmark                         old allocs     new allocs     delta
Benchmark_ExporterPushLogs-16     24928          24744          -0.74%
Benchmark_ExporterPushLogs-16     24923          24732          -0.77%
Benchmark_ExporterPushLogs-16     24928          24735          -0.77%
Benchmark_ExporterPushLogs-16     24935          24741          -0.78%
Benchmark_ExporterPushLogs-16     24933          24734          -0.80%

benchmark                         old bytes     new bytes     delta
Benchmark_ExporterPushLogs-16     13578172      3824937       -71.83%
Benchmark_ExporterPushLogs-16     13575409      3562536       -73.76%
Benchmark_ExporterPushLogs-16     13575177      3666318       -72.99%
Benchmark_ExporterPushLogs-16     13579142      3653744       -73.09%
Benchmark_ExporterPushLogs-16     13576525      3586314       -73.58%
```