### PR TITLE
refactor(sumologicexporter): use golang.org/x/exp/slices for sorting fields

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,20 +25,24 @@ linters-settings:
     tab-width: 8
 
 linters:
-  disable-all: false
+  disable-all: true
   enable:
     - gofmt
     - deadcode
-    - unused
     - errcheck
     - goimports
     - misspell
     - noctx
     - lll
-  disable:
-    - maligned
-    - prealloc
-  fast: false
+    - govet
+    - ineffassign
+    - structcheck
+    - typecheck
+    - varcheck
+    # These linters are problematic when using go1.18 and generic code like in golang.org/x/exp/slices
+    # - unused
+    # - gosimple
+    # - staticcheck
 
 issues:
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.

--- a/pkg/exporter/sumologicexporter/fields.go
+++ b/pkg/exporter/sumologicexporter/fields.go
@@ -15,11 +15,11 @@
 package sumologicexporter
 
 import (
-	"sort"
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
 	"go.opentelemetry.io/collector/model/pdata"
+	"golang.org/x/exp/slices"
 )
 
 // fields represents metadata
@@ -80,7 +80,7 @@ func (f fields) string() string {
 		)
 		return true
 	})
-	sort.Strings(returnValue)
+	slices.Sort(returnValue)
 
 	return strings.Join(returnValue, ", ")
 }

--- a/pkg/exporter/sumologicexporter/go.mod
+++ b/pkg/exporter/sumologicexporter/go.mod
@@ -12,6 +12,7 @@ require (
 	go.opentelemetry.io/collector/model v0.47.0
 	go.uber.org/multierr v1.8.0
 	go.uber.org/zap v1.21.0
+	golang.org/x/exp v0.0.0-20220328175248-053ad81199eb
 )
 
 require (

--- a/pkg/exporter/sumologicexporter/go.sum
+++ b/pkg/exporter/sumologicexporter/go.sum
@@ -213,6 +213,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20220328175248-053ad81199eb h1:pC9Okm6BVmxEw76PUu0XUbOTQ92JX11hfvqTjAV3qxM=
+golang.org/x/exp v0.0.0-20220328175248-053ad81199eb/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=


### PR DESCRIPTION
This PR uses generic slice sorting algorithm and saves yet another allocation in `fields.string()`.

Related article: https://eli.thegreenplace.net/2022/faster-sorting-with-go-generics/

```
benchcmp old.txt new.txt
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark              old ns/op     new ns/op     delta
BenchmarkFields-16     646           618           -4.32%
BenchmarkFields-16     642           603           -6.03%
BenchmarkFields-16     636           614           -3.35%
BenchmarkFields-16     640           616           -3.72%
BenchmarkFields-16     648           612           -5.56%

benchmark              old allocs     new allocs     delta
BenchmarkFields-16     11             10             -9.09%
BenchmarkFields-16     11             10             -9.09%
BenchmarkFields-16     11             10             -9.09%
BenchmarkFields-16     11             10             -9.09%
BenchmarkFields-16     11             10             -9.09%

benchmark              old bytes     new bytes     delta
BenchmarkFields-16     368           344           -6.52%
BenchmarkFields-16     368           344           -6.52%
BenchmarkFields-16     368           344           -6.52%
BenchmarkFields-16     368           344           -6.52%
BenchmarkFields-16     368           344           -6.52%
```

**EDIT**: the linter fails because we don't have full generics support in golangci-lint just yet: https://github.com/golangci/golangci-lint/issues/2649