### PR TITLE
fix(ci): ensure we can connect to docker daemon when building images

### DIFF
--- a/ci/build-push-multiplatform.sh
+++ b/ci/build-push-multiplatform.sh
@@ -2,11 +2,19 @@
 
 set -eo pipefail
 
+while ! docker buildx ls; do
+    echo "Cannot connect to docker daemon"
+    sleep 1
+done
+
+readonly DOCKER_BUILDX_LS_OUT=$(docker buildx ls <<-END
+END
+)
+
 # check for arm support only if we try to build it
-if echo "${PLATFORM}" | grep -q arm && ! docker buildx ls | grep -q arm ; then
+if echo ${PLATFORM} | grep -q arm && ! grep -q arm <<< ${DOCKER_BUILDX_LS_OUT}; then
     echo "Your Buildx seems to lack ARM architecture support"
-    echo
-    docker buildx ls
+    echo "${DOCKER_BUILDX_LS_OUT}"
     exit 1
 fi
 


### PR DESCRIPTION
It seems that sometimes runner can't connect to docker daemon (that's an assumption since we capture `docker buildx ..`'s output in `| grep ...` pipe).

This PR adds a loop that ensures we can connect to docker daemon and it also reuses the once used output of `docker buildx ls`.

It also adds a debug print of the very same output instead of issuing the command again to ensure what we get printed in CI logs is what actually caused the job to fail.

Example of a failed CI job: https://github.com/SumoLogic/sumologic-otel-collector/actions/runs/2090188603