### PR TITLE
ci: allow release updates

### DIFF
--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -314,6 +314,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
           prerelease: true
+
+          allowUpdates: true
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true
+
           body: |
             ## v${{ steps.extract_tag.outputs.tag }}
 


### PR DESCRIPTION
| - | - |
|-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| allowUpdates          | An optional flag which indicates if we should update a release if it already exists. Defaults to false.                                                                         |
| omitBody              | Indicates if the release body should be omitted.                                                                                                                                |
| omitBodyDuringUpdate  | Indicates if the release body should be omitted during updates. The body will still be applied for newly created releases. This will preserve the existing body during updates. |

Related config: https://github.com/ncipollo/release-action#action-inputs