### PR TITLE
chore: increase max line length for yamllint

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -5,7 +5,7 @@ rules:
     comments-indentation: disable
 
     line-length:
-        max: 170
+        max: 240
         level: warning
 
     indentation:


### PR DESCRIPTION
Some of the lines are naturally long and can't easily be broken up. This makes the check pass without warnings again.