### PR TITLE
refactor(sumologicextension): use bytes slices and strings.Builder to decrease allocations

### DIFF
--- a/pkg/exporter/sumologicexporter/prometheus_formatter_test.go
+++ b/pkg/exporter/sumologicexporter/prometheus_formatter_test.go
@@ -28,7 +28,7 @@ func TestSanitizeKey(t *testing.T) {
 
 	key := "&^*123-abc-ABC!./?_:\n\r"
 	expected := "___123-abc-ABC_./__:__"
-	assert.Equal(t, expected, f.sanitizeKey(key))
+	assert.EqualValues(t, expected, f.sanitizeKeyBytes([]byte(key)))
 }
 
 func TestSanitizeValue(t *testing.T) {

--- a/pkg/exporter/sumologicexporter/prometheus_formatter_test.go
+++ b/pkg/exporter/sumologicexporter/prometheus_formatter_test.go
@@ -206,3 +206,15 @@ func TestPrometheusMetrics(t *testing.T) {
 		})
 	}
 }
+
+func Benchmark_PrometheusFormatter_Metric2String(b *testing.B) {
+	f, err := newPrometheusFormatter()
+	require.NoError(b, err)
+
+	metric := buildExampleHistogramMetric(true)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = f.metric2String(metric)
+	}
+}


### PR DESCRIPTION
```
$ benchcmp main.txt pr.txt
benchmark                                          old ns/op     new ns/op     delta
Benchmark_PrometheusFormatter_Metric2String-16     66901         53862         -19.49%
Benchmark_PrometheusFormatter_Metric2String-16     65607         53773         -18.04%
Benchmark_PrometheusFormatter_Metric2String-16     65205         54047         -17.11%

benchmark                                          old allocs     new allocs     delta
Benchmark_PrometheusFormatter_Metric2String-16     696            512            -26.44%
Benchmark_PrometheusFormatter_Metric2String-16     696            512            -26.44%
Benchmark_PrometheusFormatter_Metric2String-16     696            512            -26.44%

benchmark                                          old bytes     new bytes     delta
Benchmark_PrometheusFormatter_Metric2String-16     20326         15793         -22.30%
Benchmark_PrometheusFormatter_Metric2String-16     20341         15785         -22.40%
Benchmark_PrometheusFormatter_Metric2String-16     20315         15811         -22.17%
```