### PR TITLE
fix(sumologicexporter): treat resource attributes as fields for otlp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(sumologicexporter): treat resource attributes as fields for otlp #536
+
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.47.0-sumo-0...main
+[#536]: https://github.com/SumoLogic/sumologic-otel-collector/pull/536
 
 ## [v0.47.0-sumo-0]
 

--- a/pkg/exporter/sumologicexporter/README.md
+++ b/pkg/exporter/sumologicexporter/README.md
@@ -101,6 +101,8 @@ exporters:
     # list of regexes for attributes which should be sent as metadata,
     # use OpenTelemetry attribute names, see "Attribute translation" documentation
     # chapter from this document.
+    #
+    # NOTE: Those apply only to non-OTLP data formats.
     metadata_attributes:
       - <regex1>
       - <regex2>

--- a/pkg/exporter/sumologicexporter/exporter.go
+++ b/pkg/exporter/sumologicexporter/exporter.go
@@ -224,13 +224,6 @@ func newTracesExporter(
 // It returns the number of unsent logs and an error which contains a list of dropped records
 // so they can be handled by OTC retry mechanism
 func (se *sumologicexporter) pushLogsData(ctx context.Context, ld pdata.Logs) error {
-	var (
-		currentMetadata  fields = newFields(pdata.NewAttributeMap())
-		previousMetadata fields = newFields(pdata.NewAttributeMap())
-		errs             []error
-		droppedRecords   []logPair
-	)
-
 	compr, err := se.getCompressor()
 	if err != nil {
 		return consumererror.NewLogs(err, ld)
@@ -250,6 +243,22 @@ func (se *sumologicexporter) pushLogsData(ctx context.Context, ld pdata.Logs) er
 		metricsUrl,
 		logsUrl,
 		tracesUrl,
+	)
+
+	// Follow different execution path for OTLP format
+	if sdr.config.LogFormat == OTLPLogFormat {
+		if err := sdr.sendOTLPLogs(ctx, ld); err != nil {
+			se.handleUnauthorizedErrors(ctx, err)
+			return consumererror.NewLogs(err, ld)
+		}
+		return nil
+	}
+
+	var (
+		currentMetadata  fields = newFields(pdata.NewAttributeMap())
+		previousMetadata fields = newFields(pdata.NewAttributeMap())
+		errs             []error
+		droppedRecords   []logPair
 	)
 
 	// Iterate over ResourceLogs
@@ -351,14 +360,6 @@ func (se *sumologicexporter) pushLogsData(ctx context.Context, ld pdata.Logs) er
 // it returns number of unsent metrics and error which contains list of dropped records
 // so they can be handle by the OTC retry mechanism
 func (se *sumologicexporter) pushMetricsData(ctx context.Context, md pdata.Metrics) error {
-	var (
-		currentMetadata  fields = newFields(pdata.NewAttributeMap())
-		previousMetadata fields = newFields(pdata.NewAttributeMap())
-		errs             []error
-		droppedRecords   []metricPair
-		attributes       pdata.AttributeMap
-	)
-
 	compr, err := se.getCompressor()
 	if err != nil {
 		return consumererror.NewMetrics(err, md)
@@ -380,12 +381,28 @@ func (se *sumologicexporter) pushMetricsData(ctx context.Context, md pdata.Metri
 		tracesUrl,
 	)
 
+	// Follow different execution path for OTLP format
+	if sdr.config.MetricFormat == OTLPMetricFormat {
+		if err := sdr.sendOTLPMetrics(ctx, md); err != nil {
+			se.handleUnauthorizedErrors(ctx, err)
+			return consumererror.NewMetrics(err, md)
+		}
+		return nil
+	}
+
+	var (
+		currentMetadata  fields = newFields(pdata.NewAttributeMap())
+		previousMetadata fields = newFields(pdata.NewAttributeMap())
+		errs             []error
+		droppedRecords   []metricPair
+	)
+
 	// Iterate over ResourceMetrics
 	rms := md.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
 		rm := rms.At(i)
 
-		attributes = rm.Resource().Attributes()
+		attributes := rm.Resource().Attributes()
 
 		// drop routing attribute
 		se.dropRoutingAttribute(attributes)
@@ -489,8 +506,6 @@ func (se *sumologicexporter) handleUnauthorizedErrors(ctx context.Context, errs 
 }
 
 func (se *sumologicexporter) pushTracesData(ctx context.Context, td pdata.Traces) error {
-	var currentMetadata fields = newFields(pdata.NewAttributeMap())
-
 	compr, err := se.getCompressor()
 	if err != nil {
 		return consumererror.NewTraces(err, td)
@@ -518,13 +533,9 @@ func (se *sumologicexporter) pushTracesData(ctx context.Context, td pdata.Traces
 		se.dropRoutingAttribute(rss.At(i).Resource().Attributes())
 	}
 
-	err = sdr.sendTraces(ctx, td, currentMetadata)
+	err = sdr.sendTraces(ctx, td)
 	se.handleUnauthorizedErrors(ctx, err)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (se *sumologicexporter) getCompressor() (compressor, error) {

--- a/pkg/exporter/sumologicexporter/exporter.go
+++ b/pkg/exporter/sumologicexporter/exporter.go
@@ -307,7 +307,7 @@ func (se *sumologicexporter) pushLogsData(ctx context.Context, ld pdata.Logs) er
 				// If metadata differs from currently buffered, flush the buffer
 				if !currentMetadata.equals(previousMetadata) && !previousMetadata.isEmpty() {
 					var dropped []logPair
-					dropped, err = sdr.sendLogs(ctx, previousMetadata)
+					dropped, err = sdr.sendNonOTLPLogs(ctx, previousMetadata)
 					if err != nil {
 						errs = append(errs, err)
 						droppedRecords = append(droppedRecords, dropped...)
@@ -330,7 +330,7 @@ func (se *sumologicexporter) pushLogsData(ctx context.Context, ld pdata.Logs) er
 	}
 
 	// Flush pending logs
-	dropped, err := sdr.sendLogs(ctx, previousMetadata)
+	dropped, err := sdr.sendNonOTLPLogs(ctx, previousMetadata)
 	if err != nil {
 		droppedRecords = append(droppedRecords, dropped...)
 		errs = append(errs, err)
@@ -437,7 +437,7 @@ func (se *sumologicexporter) pushMetricsData(ctx context.Context, md pdata.Metri
 				if !currentMetadata.equals(previousMetadata) && !previousMetadata.isEmpty() {
 					var dropped []metricPair
 					var err error
-					dropped, err = sdr.sendMetrics(ctx, previousMetadata)
+					dropped, err = sdr.sendNonOTLPMetrics(ctx, previousMetadata)
 					if err != nil {
 						errs = append(errs, err)
 						droppedRecords = append(droppedRecords, dropped...)
@@ -460,7 +460,7 @@ func (se *sumologicexporter) pushMetricsData(ctx context.Context, md pdata.Metri
 	}
 
 	// Flush pending metrics
-	dropped, err := sdr.sendMetrics(ctx, previousMetadata)
+	dropped, err := sdr.sendNonOTLPMetrics(ctx, previousMetadata)
 	if err != nil {
 		droppedRecords = append(droppedRecords, dropped...)
 		errs = append(errs, err)

--- a/pkg/exporter/sumologicexporter/exporter_test.go
+++ b/pkg/exporter/sumologicexporter/exporter_test.go
@@ -1454,7 +1454,7 @@ func TestPushOTLPMetrics_AttributeTranslation(t *testing.T) {
 				cfg := createConfig()
 				// NOTE: MetadataAttributes does not have an impact on exporter
 				// behavior when using OTLP. What gets sent as fields is purely
-				// depdendent on what's in resource attributes.
+				// dependent on what's in resource attributes.
 				cfg.MetadataAttributes = []string{}
 				cfg.SourceCategory = "source_category_with_hostname_%{host.name}"
 				cfg.SourceHost = "%{host}"

--- a/pkg/exporter/sumologicexporter/exporter_test.go
+++ b/pkg/exporter/sumologicexporter/exporter_test.go
@@ -276,6 +276,8 @@ func TestPushInvalidCompressor(t *testing.T) {
 }
 
 func TestPushFailedBatch(t *testing.T) {
+	t.Parallel()
+
 	test := prepareExporterTest(t, createTestConfig(), []func(w http.ResponseWriter, req *http.Request){
 		func(w http.ResponseWriter, req *http.Request) {
 			w.WriteHeader(500)
@@ -392,9 +394,12 @@ func TestPushOTLPLogs_AttributeTranslation(t *testing.T) {
 			name: "enabled",
 			configFunc: func() *Config {
 				config := createTestConfig()
-				config.MetadataAttributes = []string{`host\.name`}
-				config.SourceCategory = "%{host.name}"
-				config.SourceHost = "%{host}"
+				// NOTE: MetadataAttributes does not have an impact on exporter
+				// behavior when using OTLP. What gets sent as fields is purely
+				// depdendent on what's in resource attributes.
+				config.MetadataAttributes = []string{}
+				config.SourceCategory = "category_with_host_template_%{host.name}"
+				config.SourceHost = "%{host.name}"
 				config.LogFormat = OTLPLogFormat
 				config.TranslateAttributes = true
 				return config
@@ -402,18 +407,22 @@ func TestPushOTLPLogs_AttributeTranslation(t *testing.T) {
 			callbacks: []func(w http.ResponseWriter, req *http.Request){
 				func(w http.ResponseWriter, req *http.Request) {
 					body := extractBody(t, req)
-					//nolint:lll
-					assert.Equal(t, "\n\xae\x01\nB\n\x1d\n\v_sourceHost\x12\x0e\n\fharry-potter\n!\n\x0f_sourceCategory\x12\x0e\n\fharry-potter\x12h\n\x00\x12d*\r\n\vExample log2\x16\n\x04host\x12\x0e\n\fharry-potter2\x18\n\fInstanceType\x12\b\n\x06wizard2\x1d\n\v_sourceName\x12\x0e\n\f/tmp/log.logJ\x00R\x00", body)
-					// TODO: Revisit: this should probably be empty when sending with OTLP
-					assert.Equal(t, "host=harry-potter", req.Header.Get("X-Sumo-Fields"), "X-Sumo-Fields")
-					// TODO: Revisit: this should probably be empty when sending with OTLP
-					assert.Equal(t, "harry-potter", req.Header.Get("X-Sumo-Category"), "X-Sumo-Category")
 
-					// This gets the value from 'host.name' because we do not disallow
-					// using Sumo schema and 'host.name' from OT convention
-					// translates into 'host' in Sumo convention
-					// TODO: Revisit: this should probably be empty when sending with OTLP
-					assert.Equal(t, "harry-potter", req.Header.Get("X-Sumo-Host"), "X-Sumo-Host")
+					//nolint:lll
+					assert.Equal(t, "\n\xcb\x01\n\xaf\x01\n\x16\n\x04host\x12\x0e\n\fharry-potter\n\x18\n\fInstanceType\x12\b\n\x06wizard\n\x1d\n\v_sourceName\x12\x0e\n\f/tmp/log.log\n\x1d\n\v_sourceHost\x12\x0e\n\fharry-potter\n=\n\x0f_sourceCategory\x12*\n(category_with_host_template_harry-potter\x12\x17\n\x00\x12\x13*\r\n\vExample logJ\x00R\x00", body)
+
+					assert.Empty(t, req.Header.Get("X-Sumo-Fields"),
+						"We should not get X-Sumo-Fields header when sending data with OTLP",
+					)
+					assert.Empty(t, req.Header.Get("X-Sumo-Category"),
+						"We should not get X-Sumo-Category header when sending data with OTLP",
+					)
+					assert.Empty(t, req.Header.Get("X-Sumo-Name"),
+						"We should not get X-Sumo-Name header when sending data with OTLP",
+					)
+					assert.Empty(t, req.Header.Get("X-Sumo-Host"),
+						"We should not get X-Sumo-Host header when sending data with OTLP",
+					)
 				},
 			},
 		},
@@ -421,9 +430,12 @@ func TestPushOTLPLogs_AttributeTranslation(t *testing.T) {
 			name: "disabled",
 			configFunc: func() *Config {
 				config := createTestConfig()
-				config.MetadataAttributes = []string{`host\.name`}
-				config.SourceCategory = "%{host.name}"
-				config.SourceHost = "%{host}"
+				// NOTE: MetadataAttributes does not have an impact on exporter
+				// behavior when using OTLP. What gets sent as fields is purely
+				// depdendent on what's in resource attributes.
+				config.MetadataAttributes = []string{}
+				config.SourceCategory = "category_with_host_template_%{host.name}"
+				config.SourceHost = "%{host.name}"
 				config.LogFormat = OTLPLogFormat
 				config.TranslateAttributes = false
 				return config
@@ -431,15 +443,22 @@ func TestPushOTLPLogs_AttributeTranslation(t *testing.T) {
 			callbacks: []func(w http.ResponseWriter, req *http.Request){
 				func(w http.ResponseWriter, req *http.Request) {
 					body := extractBody(t, req)
-					//nolint:lll
-					assert.Equal(t, "\n\xb4\x01\n?\n\x1a\n\v_sourceHost\x12\v\n\tundefined\n!\n\x0f_sourceCategory\x12\x0e\n\fharry-potter\x12q\n\x00\x12m*\r\n\vExample log2\x1b\n\thost.name\x12\x0e\n\fharry-potter2\x15\n\thost.type\x12\b\n\x06wizard2$\n\x12file.path.resolved\x12\x0e\n\f/tmp/log.logJ\x00R\x00", body)
 
-					// TODO: Revisit: this should probably be empty when sending with OTLP
-					assert.Equal(t, "host.name=harry-potter", req.Header.Get("X-Sumo-Fields"), "X-Sumo-Fields")
-					// TODO: Revisit: this should probably be empty when sending with OTLP
-					assert.Equal(t, "harry-potter", req.Header.Get("X-Sumo-Category"), "X-Sumo-Category")
-					// TODO: Revisit: this should probably be empty when sending with OTLP
-					assert.Equal(t, "undefined", req.Header.Get("X-Sumo-Host"), "X-Sumo-Host")
+					//nolint:lll
+					assert.Equal(t, "\n\xd4\x01\n\xb8\x01\n\x1b\n\thost.name\x12\x0e\n\fharry-potter\n\x15\n\thost.type\x12\b\n\x06wizard\n$\n\x12file.path.resolved\x12\x0e\n\f/tmp/log.log\n\x1d\n\v_sourceHost\x12\x0e\n\fharry-potter\n=\n\x0f_sourceCategory\x12*\n(category_with_host_template_harry-potter\x12\x17\n\x00\x12\x13*\r\n\vExample logJ\x00R\x00", body)
+
+					assert.Empty(t, req.Header.Get("X-Sumo-Fields"),
+						"We should not get X-Sumo-Fields header when sending data with OTLP",
+					)
+					assert.Empty(t, req.Header.Get("X-Sumo-Category"),
+						"We should not get X-Sumo-Category header when sending data with OTLP",
+					)
+					assert.Empty(t, req.Header.Get("X-Sumo-Name"),
+						"We should not get X-Sumo-Name header when sending data with OTLP",
+					)
+					assert.Empty(t, req.Header.Get("X-Sumo-Host"),
+						"We should not get X-Sumo-Host header when sending data with OTLP",
+					)
 				},
 			},
 		},
@@ -1425,51 +1444,42 @@ func TestPushOTLPMetrics_AttributeTranslation(t *testing.T) {
 	}
 
 	testcases := []struct {
-		name            string
-		cfgFn           func() *Config
-		expectedHeaders map[string]string
-		expectedBody    string
+		name         string
+		cfgFn        func() *Config
+		expectedBody string
 	}{
 		{
 			name: "enabled",
 			cfgFn: func() *Config {
 				cfg := createConfig()
-				cfg.MetadataAttributes = []string{`host\.name`}
-				cfg.SourceCategory = "%{host.name}"
+				// NOTE: MetadataAttributes does not have an impact on exporter
+				// behavior when using OTLP. What gets sent as fields is purely
+				// depdendent on what's in resource attributes.
+				cfg.MetadataAttributes = []string{}
+				cfg.SourceCategory = "source_category_with_hostname_%{host.name}"
 				cfg.SourceHost = "%{host}"
 				// This is and should be done by default:
 				// cfg.TranslateAttributes = true
 				return cfg
 			},
-			expectedHeaders: map[string]string{
-				"Content-Type":    "application/x-protobuf",
-				"X-Sumo-Category": "harry-potter",
-
-				// This gets the value from 'host.name' because we do not disallow
-				// using Sumo schema and 'host.name' from OT convention
-				// translates into 'host' in Sumo convention
-				"X-Sumo-Host": "harry-potter",
-			},
 			//nolint:lll
-			expectedBody: "\n\xdb\x01\n\xa3\x01\n\x14\n\x04test\x12\f\n\ntest_value\n\x17\n\x05test2\x12\x0e\n\fsecond_value\n\x16\n\x04host\x12\x0e\n\fharry-potter\n\x18\n\fInstanceType\x12\b\n\x06wizard\n\x1d\n\v_sourceHost\x12\x0e\n\fharry-potter\n!\n\x0f_sourceCategory\x12\x0e\n\fharry-potter\x123\n\x00\x12/\n\x10test.metric.data\x1a\x05bytes:\x14\n\x12\x19\x00\x12\x94\v\xd1\x00H\x161\xa48\x00\x00\x00\x00\x00\x00",
+			expectedBody: "\n\xf9\x01\n\xc1\x01\n\x14\n\x04test\x12\f\n\ntest_value\n\x17\n\x05test2\x12\x0e\n\fsecond_value\n\x16\n\x04host\x12\x0e\n\fharry-potter\n\x18\n\fInstanceType\x12\b\n\x06wizard\n\x1d\n\v_sourceHost\x12\x0e\n\fharry-potter\n?\n\x0f_sourceCategory\x12,\n*source_category_with_hostname_harry-potter\x123\n\x00\x12/\n\x10test.metric.data\x1a\x05bytes:\x14\n\x12\x19\x00\x12\x94\v\xd1\x00H\x161\xa48\x00\x00\x00\x00\x00\x00",
 		},
 		{
 			name: "disabled",
 			cfgFn: func() *Config {
 				cfg := createConfig()
-				cfg.MetadataAttributes = []string{`host\.name`}
-				cfg.SourceCategory = "%{host.name}"
-				cfg.SourceHost = "%{host}"
+				// NOTE: MetadataAttributes does not have an impact on exporter
+				// behavior when using OTLP. What gets sent as fields is purely
+				// depdendent on what's in resource attributes.
+				cfg.MetadataAttributes = []string{}
+				cfg.SourceCategory = "source_category_with_hostname_%{host.name}"
+				cfg.SourceHost = "%{host.name}"
 				cfg.TranslateAttributes = false
 				return cfg
 			},
-			expectedHeaders: map[string]string{
-				"Content-Type":    "application/x-protobuf",
-				"X-Sumo-Category": "harry-potter",
-				"X-Sumo-Host":     "undefined",
-			},
 			//nolint:lll
-			expectedBody: "\n\xda\x01\n\xa2\x01\n\x14\n\x04test\x12\f\n\ntest_value\n\x17\n\x05test2\x12\x0e\n\fsecond_value\n\x1b\n\thost.name\x12\x0e\n\fharry-potter\n\x15\n\thost.type\x12\b\n\x06wizard\n\x1a\n\v_sourceHost\x12\v\n\tundefined\n!\n\x0f_sourceCategory\x12\x0e\n\fharry-potter\x123\n\x00\x12/\n\x10test.metric.data\x1a\x05bytes:\x14\n\x12\x19\x00\x12\x94\v\xd1\x00H\x161\xa48\x00\x00\x00\x00\x00\x00",
+			expectedBody: "\n\xfb\x01\n\xc3\x01\n\x14\n\x04test\x12\f\n\ntest_value\n\x17\n\x05test2\x12\x0e\n\fsecond_value\n\x1b\n\thost.name\x12\x0e\n\fharry-potter\n\x15\n\thost.type\x12\b\n\x06wizard\n\x1d\n\v_sourceHost\x12\x0e\n\fharry-potter\n?\n\x0f_sourceCategory\x12,\n*source_category_with_hostname_harry-potter\x123\n\x00\x12/\n\x10test.metric.data\x1a\x05bytes:\x14\n\x12\x19\x00\x12\x94\v\xd1\x00H\x161\xa48\x00\x00\x00\x00\x00\x00",
 		},
 	}
 
@@ -1487,11 +1497,21 @@ func TestPushOTLPMetrics_AttributeTranslation(t *testing.T) {
 			callbacks := []func(w http.ResponseWriter, req *http.Request){
 				func(w http.ResponseWriter, req *http.Request) {
 					assert.Equal(t, tc.expectedBody, extractBody(t, req))
-					for header, expectedValue := range tc.expectedHeaders {
-						assert.Equalf(t, expectedValue, req.Header.Get(header),
-							"Unexpected value in header: %s", header,
-						)
-					}
+
+					assert.Equal(t, "application/x-protobuf", req.Header.Get("Content-Type"))
+
+					assert.Empty(t, req.Header.Get("X-Sumo-Fields"),
+						"We should not get X-Sumo-Fields header when sending data with OTLP",
+					)
+					assert.Empty(t, req.Header.Get("X-Sumo-Category"),
+						"We should not get X-Sumo-Category header when sending data with OTLP",
+					)
+					assert.Empty(t, req.Header.Get("X-Sumo-Name"),
+						"We should not get X-Sumo-Name header when sending data with OTLP",
+					)
+					assert.Empty(t, req.Header.Get("X-Sumo-Host"),
+						"We should not get X-Sumo-Host header when sending data with OTLP",
+					)
 				},
 			}
 			test := prepareExporterTest(t, config, callbacks)

--- a/pkg/exporter/sumologicexporter/fields.go
+++ b/pkg/exporter/sumologicexporter/fields.go
@@ -24,13 +24,19 @@ import (
 
 // fields represents metadata
 type fields struct {
-	orig pdata.AttributeMap
+	orig        pdata.AttributeMap
+	initialized bool
 }
 
 func newFields(attrMap pdata.AttributeMap) fields {
 	return fields{
-		orig: attrMap,
+		orig:        attrMap,
+		initialized: true,
 	}
+}
+
+func (f fields) isInitialized() bool {
+	return f.initialized
 }
 
 func (f fields) isEmpty() bool {
@@ -47,6 +53,10 @@ func (f fields) equals(other fields) bool {
 
 // string returns fields as ordered key=value string with `, ` as separator
 func (f fields) string() string {
+	if !f.initialized {
+		return ""
+	}
+
 	returnValue := make([]string, 0, f.orig.Len())
 
 	f.orig.Range(func(k string, v pdata.AttributeValue) bool {

--- a/pkg/exporter/sumologicexporter/sender_test.go
+++ b/pkg/exporter/sumologicexporter/sender_test.go
@@ -319,7 +319,7 @@ func TestSendLogs(t *testing.T) {
 
 	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
-	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "value", "key2": "value2"}))
+	_, err := test.s.sendNonOTLPLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "value", "key2": "value2"}))
 	assert.NoError(t, err)
 	assert.EqualValues(t, 1, *test.reqCounter)
 }
@@ -337,7 +337,7 @@ func TestSendLogsWithEmptyField(t *testing.T) {
 
 	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
-	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "value", "key2": "value2", "service": ""}))
+	_, err := test.s.sendNonOTLPLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "value", "key2": "value2", "service": ""}))
 	assert.NoError(t, err)
 	assert.EqualValues(t, 1, *test.reqCounter)
 }
@@ -357,7 +357,7 @@ func TestSendLogsMultitype(t *testing.T) {
 
 	test.s.logBuffer = logRecordsToLogPair(exampleMultitypeLogs())
 
-	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "value", "key2": "value2"}))
+	_, err := test.s.sendNonOTLPLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "value", "key2": "value2"}))
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, 1, *test.reqCounter)
@@ -377,7 +377,7 @@ func TestSendLogsSplit(t *testing.T) {
 	test.s.config.MaxRequestBodySize = 10
 	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
-	_, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
+	_, err := test.s.sendNonOTLPLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, 2, *test.reqCounter)
@@ -406,7 +406,7 @@ func TestSendLogsSplitFailedOne(t *testing.T) {
 	test.s.config.LogFormat = TextFormat
 	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
-	dropped, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
+	dropped, err := test.s.sendNonOTLPLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, "failed sending data: status: 500 Internal Server Error, id: 1TIRY-KGIVX-TPQRJ, errors: [{Code:internal.error Message:Internal server error.}]")
 	assert.Equal(t, test.s.logBuffer[0:1], dropped)
 
@@ -432,7 +432,7 @@ func TestSendLogsSplitFailedAll(t *testing.T) {
 	test.s.config.LogFormat = TextFormat
 	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
-	dropped, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
+	dropped, err := test.s.sendNonOTLPLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(
 		t,
 		err,
@@ -561,7 +561,7 @@ func TestSendLogsJsonConfig(t *testing.T) {
 			test.s.config.LogFormat = JSONFormat
 			test.s.logBuffer = tc.logBuffer
 
-			_, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
+			_, err := test.s.sendNonOTLPLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 			assert.NoError(t, err)
 
 			assert.EqualValues(t, 1, *test.reqCounter)
@@ -587,7 +587,7 @@ func TestSendLogsJson(t *testing.T) {
 	test.s.config.LogFormat = JSONFormat
 	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
-	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key": "value"}))
+	_, err := test.s.sendNonOTLPLogs(context.Background(), fieldsFromMap(map[string]string{"key": "value"}))
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, 1, *test.reqCounter)
@@ -611,7 +611,7 @@ func TestSendLogsJsonMultitype(t *testing.T) {
 	test.s.config.LogFormat = JSONFormat
 	test.s.logBuffer = logRecordsToLogPair(exampleMultitypeLogs())
 
-	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key": "value"}))
+	_, err := test.s.sendNonOTLPLogs(context.Background(), fieldsFromMap(map[string]string{"key": "value"}))
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, 1, *test.reqCounter)
@@ -636,7 +636,7 @@ func TestSendLogsJsonSplit(t *testing.T) {
 	test.s.config.MaxRequestBodySize = 10
 	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
-	_, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
+	_, err := test.s.sendNonOTLPLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, 2, *test.reqCounter)
@@ -665,7 +665,7 @@ func TestSendLogsJsonSplitFailedOne(t *testing.T) {
 	test.s.config.MaxRequestBodySize = 10
 	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
-	dropped, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
+	dropped, err := test.s.sendNonOTLPLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, "failed sending data: status: 500 Internal Server Error")
 	assert.Equal(t, test.s.logBuffer[0:1], dropped)
 
@@ -697,7 +697,7 @@ func TestSendLogsJsonSplitFailedAll(t *testing.T) {
 	test.s.config.MaxRequestBodySize = 10
 	test.s.logBuffer = logRecordsToLogPair(exampleTwoLogs())
 
-	dropped, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
+	dropped, err := test.s.sendNonOTLPLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(
 		t,
 		err,
@@ -717,7 +717,7 @@ func TestSendLogsUnexpectedFormat(t *testing.T) {
 	logs := logRecordsToLogPair(exampleTwoLogs())
 	test.s.logBuffer = logs
 
-	dropped, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
+	dropped, err := test.s.sendNonOTLPLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.Error(t, err)
 	assert.Equal(t, logs, dropped)
 }
@@ -772,7 +772,7 @@ func TestOverrideSourceName(t *testing.T) {
 		test.s.sources.name = getTestSourceFormat(t, "Test source name/%{key1}")
 		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
-		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
+		_, err := test.s.sendNonOTLPLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 		assert.NoError(t, err)
 
 		assert.EqualValues(t, 1, *test.reqCounter)
@@ -790,7 +790,7 @@ func TestOverrideSourceName(t *testing.T) {
 		test.s.sources.name = getTestSourceFormat(t, "Test source name/%{key1}")
 		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
-		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
+		_, err := test.s.sendNonOTLPLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 		assert.NoError(t, err)
 
 		assert.EqualValues(t, 1, *test.reqCounter)
@@ -837,7 +837,7 @@ func TestOverrideSourceCategory(t *testing.T) {
 		test.s.sources.category = getTestSourceFormat(t, "Test source category/%{key1}")
 		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
-		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
+		_, err := test.s.sendNonOTLPLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 		assert.NoError(t, err)
 	})
 
@@ -853,7 +853,7 @@ func TestOverrideSourceCategory(t *testing.T) {
 		test.s.sources.category = getTestSourceFormat(t, "Test source category/%{key1}")
 		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
-		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
+		_, err := test.s.sendNonOTLPLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 		assert.NoError(t, err)
 
 		assert.EqualValues(t, 1, *test.reqCounter)
@@ -900,7 +900,7 @@ func TestOverrideSourceHost(t *testing.T) {
 		test.s.sources.host = getTestSourceFormat(t, "Test source host/%{key1}")
 		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
-		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
+		_, err := test.s.sendNonOTLPLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 		assert.NoError(t, err)
 	})
 
@@ -916,7 +916,7 @@ func TestOverrideSourceHost(t *testing.T) {
 		test.s.sources.host = getTestSourceFormat(t, "Test source host/%{key1}")
 		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
-		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
+		_, err := test.s.sendNonOTLPLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 		assert.NoError(t, err)
 
 		assert.EqualValues(t, 1, *test.reqCounter)
@@ -1004,7 +1004,7 @@ func TestLogsDontSendSourceFieldsInXSumoFieldsHeader(t *testing.T) {
 		test.s.sources.category = getTestSourceFormat(t, "Test source category/%{key1}")
 		test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
-		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(
+		_, err := test.s.sendNonOTLPLogs(context.Background(), fieldsFromMap(
 			map[string]string{
 				"key1":            "key1_val",
 				"_sourceName":     "test_source_name",
@@ -1044,7 +1044,7 @@ func TestLogsHandlesReceiverResponses(t *testing.T) {
 			),
 		)
 
-		_, err := test.s.sendLogs(context.Background(), fieldsFromMap(
+		_, err := test.s.sendNonOTLPLogs(context.Background(), fieldsFromMap(
 			map[string]string{
 				"cluster":         "abcaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				"code":            "4222222222222222222222222222222222222222222222222222222222222222222222222222222222222",
@@ -1140,7 +1140,7 @@ func TestInvalidEndpoint(t *testing.T) {
 	test.s.config.HTTPClientSettings.Endpoint = ":"
 	test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
-	_, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
+	_, err := test.s.sendNonOTLPLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, `parse ":": missing protocol scheme`)
 }
 
@@ -1150,7 +1150,7 @@ func TestInvalidPostRequest(t *testing.T) {
 	test.s.config.HTTPClientSettings.Endpoint = ""
 	test.s.logBuffer = logRecordsToLogPair(exampleLog())
 
-	_, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
+	_, err := test.s.sendNonOTLPLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, `Post "": unsupported protocol scheme ""`)
 }
 
@@ -1284,7 +1284,7 @@ gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1
 		exampleIntMetric(),
 		exampleIntGaugeMetric(),
 	}
-	_, err := test.s.sendMetrics(context.Background(), flds)
+	_, err := test.s.sendNonOTLPMetrics(context.Background(), flds)
 	assert.NoError(t, err)
 }
 
@@ -1309,7 +1309,7 @@ gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1
 		exampleIntGaugeMetric(),
 	}
 
-	_, err := test.s.sendMetrics(context.Background(), newFields(pdata.NewAttributeMap()))
+	_, err := test.s.sendNonOTLPMetrics(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.NoError(t, err)
 }
 
@@ -1336,7 +1336,7 @@ gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1
 		exampleIntGaugeMetric(),
 	}
 
-	dropped, err := test.s.sendMetrics(context.Background(), newFields(pdata.NewAttributeMap()))
+	dropped, err := test.s.sendNonOTLPMetrics(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, "failed sending data: status: 500 Internal Server Error")
 	assert.Equal(t, test.s.metricBuffer[0:1], dropped)
 }
@@ -1366,7 +1366,7 @@ gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1
 		exampleIntGaugeMetric(),
 	}
 
-	dropped, err := test.s.sendMetrics(context.Background(), newFields(pdata.NewAttributeMap()))
+	dropped, err := test.s.sendNonOTLPMetrics(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(
 		t,
 		err,
@@ -1386,7 +1386,7 @@ func TestSendMetricsUnexpectedFormat(t *testing.T) {
 	}
 	test.s.metricBuffer = metrics
 
-	dropped, err := test.s.sendMetrics(context.Background(), newFields(pdata.NewAttributeMap()))
+	dropped, err := test.s.sendNonOTLPMetrics(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, "unexpected metric format: invalid")
 	assert.Equal(t, dropped, metrics)
 }
@@ -1466,7 +1466,7 @@ foo=bar metric=gauge_metric_name  245 1608124662`
 	test.s.metricBuffer[0].attributes.InsertString("escape me", "=invalid\n")
 	test.s.metricBuffer[0].attributes.InsertBool("metric", true)
 
-	_, err := test.s.sendMetrics(context.Background(), flds)
+	_, err := test.s.sendNonOTLPMetrics(context.Background(), flds)
 	assert.NoError(t, err)
 }
 
@@ -1501,6 +1501,6 @@ gauge_metric_name.. 245 1608124662`
 	test.s.metricBuffer[0].attributes.InsertString("unit", "m/s")
 	test.s.metricBuffer[0].attributes.InsertBool("metric", true)
 
-	_, err = test.s.sendMetrics(context.Background(), flds)
+	_, err = test.s.sendNonOTLPMetrics(context.Background(), flds)
 	assert.NoError(t, err)
 }

--- a/pkg/exporter/sumologicexporter/source_format.go
+++ b/pkg/exporter/sumologicexporter/source_format.go
@@ -17,6 +17,8 @@ package sumologicexporter
 import (
 	"fmt"
 	"regexp"
+
+	"go.opentelemetry.io/collector/model/pdata"
 )
 
 type sourceFormats struct {
@@ -73,10 +75,19 @@ func newSourceFormats(cfg *Config) (sourceFormats, error) {
 // format converts sourceFormat to string.
 // Takes fields and put into template (%s placeholders) in order defined by matches
 func (s *sourceFormat) format(f fields) string {
+	return s.formatPdataMap(f.orig)
+}
+
+// formatPdataMap converts sourceFormat to string.
+// Takes pdata.Map attributes and puts them into template (%s placeholders)
+// in order defined by matches.
+//
+// The provided attribute map has to be initialized before calling this func.
+func (s *sourceFormat) formatPdataMap(m pdata.Map) string {
 	labels := make([]interface{}, 0, len(s.matches))
 
 	for _, matchset := range s.matches {
-		v, ok := f.orig.Get(matchset)
+		v, ok := m.Get(matchset)
 		if ok {
 			labels = append(labels, v.AsString())
 		} else {


### PR DESCRIPTION
This PR aims at treating OTLP resource level attributes as [fields](https://help.sumologic.com/Manage/Fields).

It also simplifies the OTLP flows a bit by removing the unnecessary batching from their logic.