### PR TITLE
fix(cascadingfilterprocessor): prevent overriding metrics in cascading filter processor - add processor tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore(deps): bump golang from 1.18 to 1.18.1 [#546][#546]
 - chore: bump OT core to v0.49.0 [#550][#550]
 
+### Fixed
+
+- fix(cascadingfilterprocessor): prevent overriding metrics in cascading filter processor - add processor tag [#539][#539]
+
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.48.0-sumo-0...main
 [#546]: https://github.com/SumoLogic/sumologic-otel-collector/pull/546
 [#550]: https://github.com/SumoLogic/sumologic-otel-collector/pull/550
 [#553]: https://github.com/SumoLogic/sumologic-otel-collector/pull/553
+[#539]: https://github.com/SumoLogic/sumologic-otel-collector/pull/539
 
 ## [v0.48.0-sumo-0]
 

--- a/pkg/processor/cascadingfilterprocessor/metrics.go
+++ b/pkg/processor/cascadingfilterprocessor/metrics.go
@@ -34,6 +34,7 @@ var (
 	tagPolicyKey, _                  = tag.NewKey("policy")
 	tagCascadingFilterDecisionKey, _ = tag.NewKey("cascading_filter_decision")
 	tagPolicyDecisionKey, _          = tag.NewKey("policy_decision")
+	tagProcessorKey, _               = tag.NewKey("processor")
 
 	statDecisionLatencyMicroSec  = stats.Int64("policy_decision_latency", "Latency (in microseconds) of a given filtering policy", "µs")
 	statOverallDecisionLatencyus = stats.Int64("cascading_filtering_batch_processing_latency", "Latency (in microseconds) of each run of the cascading filter timer", "µs")
@@ -64,6 +65,7 @@ func CascadingFilterMetricViews(level configtelemetry.Level) []*view.View {
 		Name:        statOverallDecisionLatencyus.Name(),
 		Measure:     statOverallDecisionLatencyus,
 		Description: statOverallDecisionLatencyus.Description(),
+		TagKeys:     []tag.Key{tagProcessorKey},
 		Aggregation: latencyDistributionAggregation,
 	}
 
@@ -71,6 +73,7 @@ func CascadingFilterMetricViews(level configtelemetry.Level) []*view.View {
 		Name:        statTraceRemovalAgeSec.Name(),
 		Measure:     statTraceRemovalAgeSec,
 		Description: statTraceRemovalAgeSec.Description(),
+		TagKeys:     []tag.Key{tagProcessorKey},
 		Aggregation: ageDistributionAggregation,
 	}
 
@@ -78,6 +81,7 @@ func CascadingFilterMetricViews(level configtelemetry.Level) []*view.View {
 		Name:        statLateSpanArrivalAfterDecision.Name(),
 		Measure:     statLateSpanArrivalAfterDecision,
 		Description: statLateSpanArrivalAfterDecision.Description(),
+		TagKeys:     []tag.Key{tagProcessorKey},
 		Aggregation: ageDistributionAggregation,
 	}
 
@@ -85,6 +89,7 @@ func CascadingFilterMetricViews(level configtelemetry.Level) []*view.View {
 		Name:        statPolicyEvaluationErrorCount.Name(),
 		Measure:     statPolicyEvaluationErrorCount,
 		Description: statPolicyEvaluationErrorCount.Description(),
+		TagKeys:     []tag.Key{tagProcessorKey},
 		Aggregation: view.Sum(),
 	}
 
@@ -92,7 +97,7 @@ func CascadingFilterMetricViews(level configtelemetry.Level) []*view.View {
 		Name:        statCascadingFilterDecision.Name(),
 		Measure:     statCascadingFilterDecision,
 		Description: statCascadingFilterDecision.Description(),
-		TagKeys:     []tag.Key{tagPolicyKey, tagCascadingFilterDecisionKey},
+		TagKeys:     []tag.Key{tagProcessorKey, tagPolicyKey, tagCascadingFilterDecisionKey},
 		Aggregation: view.Sum(),
 	}
 
@@ -100,7 +105,7 @@ func CascadingFilterMetricViews(level configtelemetry.Level) []*view.View {
 		Name:        statPolicyDecision.Name(),
 		Measure:     statPolicyDecision,
 		Description: statPolicyDecision.Description(),
-		TagKeys:     []tag.Key{tagPolicyKey, tagPolicyDecisionKey},
+		TagKeys:     []tag.Key{tagProcessorKey, tagPolicyKey, tagPolicyDecisionKey},
 		Aggregation: view.Sum(),
 	}
 
@@ -108,7 +113,7 @@ func CascadingFilterMetricViews(level configtelemetry.Level) []*view.View {
 		Name:        statDecisionLatencyMicroSec.Name(),
 		Measure:     statDecisionLatencyMicroSec,
 		Description: statDecisionLatencyMicroSec.Description(),
-		TagKeys:     []tag.Key{tagPolicyKey},
+		TagKeys:     []tag.Key{tagProcessorKey, tagPolicyKey},
 		Aggregation: view.Sum(),
 	}
 
@@ -116,18 +121,21 @@ func CascadingFilterMetricViews(level configtelemetry.Level) []*view.View {
 		Name:        statDroppedTooEarlyCount.Name(),
 		Measure:     statDroppedTooEarlyCount,
 		Description: statDroppedTooEarlyCount.Description(),
+		TagKeys:     []tag.Key{tagProcessorKey},
 		Aggregation: view.Sum(),
 	}
 	countTraceIDArrivalView := &view.View{
 		Name:        statNewTraceIDReceivedCount.Name(),
 		Measure:     statNewTraceIDReceivedCount,
 		Description: statNewTraceIDReceivedCount.Description(),
+		TagKeys:     []tag.Key{tagProcessorKey},
 		Aggregation: view.Sum(),
 	}
 	trackTracesOnMemorylView := &view.View{
 		Name:        statTracesOnMemoryGauge.Name(),
 		Measure:     statTracesOnMemoryGauge,
 		Description: statTracesOnMemoryGauge.Description(),
+		TagKeys:     []tag.Key{tagProcessorKey},
 		Aggregation: view.LastValue(),
 	}
 

--- a/pkg/processor/cascadingfilterprocessor/processor_test.go
+++ b/pkg/processor/cascadingfilterprocessor/processor_test.go
@@ -24,12 +24,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.uber.org/zap"
 
 	"github.com/SumoLogic/sumologic-otel-collector/pkg/processor/cascadingfilterprocessor/bigendianconverter"
-	"github.com/SumoLogic/sumologic-otel-collector/pkg/processor/cascadingfilterprocessor/config"
+	cfconfig "github.com/SumoLogic/sumologic-otel-collector/pkg/processor/cascadingfilterprocessor/config"
 	"github.com/SumoLogic/sumologic-otel-collector/pkg/processor/cascadingfilterprocessor/idbatcher"
 	"github.com/SumoLogic/sumologic-otel-collector/pkg/processor/cascadingfilterprocessor/sampling"
 )
@@ -39,14 +40,17 @@ const (
 )
 
 //nolint:unused
-var testPolicy = []config.TraceAcceptCfg{{
+var testPolicy = []cfconfig.TraceAcceptCfg{{
 	Name:           "test-policy",
 	SpansPerSecond: 1000,
 }}
 
 func TestSequentialTraceArrival(t *testing.T) {
 	traceIds, batches := generateIdsAndBatches(128)
-	cfg := config.Config{
+	id1 := config.NewComponentIDWithName("cascading_filter", "1")
+	ps1 := config.NewProcessorSettings(id1)
+	cfg := cfconfig.Config{
+		ProcessorSettings:       &ps1,
 		DecisionWait:            defaultTestDecisionWait,
 		NumTraces:               uint64(2 * len(traceIds)),
 		ExpectedNewTracesPerSec: 64,
@@ -71,7 +75,10 @@ func TestConcurrentTraceArrival(t *testing.T) {
 	traceIds, batches := generateIdsAndBatches(128)
 
 	var wg sync.WaitGroup
-	cfg := config.Config{
+	id1 := config.NewComponentIDWithName("cascading_filter", "1")
+	ps1 := config.NewProcessorSettings(id1)
+	cfg := cfconfig.Config{
+		ProcessorSettings:       &ps1,
 		DecisionWait:            defaultTestDecisionWait,
 		NumTraces:               uint64(2 * len(traceIds)),
 		ExpectedNewTracesPerSec: 64,
@@ -110,7 +117,10 @@ func TestConcurrentTraceArrival(t *testing.T) {
 func TestSequentialTraceMapSize(t *testing.T) {
 	traceIds, batches := generateIdsAndBatches(210)
 	const maxSize = 100
-	cfg := config.Config{
+	id1 := config.NewComponentIDWithName("cascading_filter", "1")
+	ps1 := config.NewProcessorSettings(id1)
+	cfg := cfconfig.Config{
+		ProcessorSettings:       &ps1,
 		DecisionWait:            defaultTestDecisionWait,
 		NumTraces:               uint64(maxSize),
 		ExpectedNewTracesPerSec: 64,
@@ -136,7 +146,10 @@ func TestConcurrentTraceMapSize(t *testing.T) {
 	_, batches := generateIdsAndBatches(210)
 	const maxSize = 100
 	var wg sync.WaitGroup
-	cfg := config.Config{
+	id1 := config.NewComponentIDWithName("cascading_filter", "1")
+	ps1 := config.NewProcessorSettings(id1)
+	cfg := cfconfig.Config{
+		ProcessorSettings:       &ps1,
 		DecisionWait:            defaultTestDecisionWait,
 		NumTraces:               uint64(maxSize),
 		ExpectedNewTracesPerSec: 64,


### PR DESCRIPTION
When two cascading filter processor instances were running on one collector, the metrics values were overridden. Adding the instance_name tag fixes this issue