### PR TITLE
docs: add breaking change description to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking changes
+
+- chore: bump OT core to v0.49.0 [#550][#550] ([upgrade guide][upgrade-guide-log-collection])
+
 ### Changed
 
 - docs: clarify status of sumologicextension [#553][#553]
 - chore(deps): bump golang from 1.18 to 1.18.1 [#546][#546]
-- chore: bump OT core to v0.49.0 [#550][#550]
 
 ### Fixed
 
 - fix(cascadingfilterprocessor): prevent overriding metrics in cascading filter processor - add processor tag [#539][#539]
 
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.48.0-sumo-0...main
+[upgrade-guide-log-collection]: docs/Upgrading.md#several-changes-to-receivers-using-opentelemetry-log-collection
 [#546]: https://github.com/SumoLogic/sumologic-otel-collector/pull/546
 [#550]: https://github.com/SumoLogic/sumologic-otel-collector/pull/550
 [#553]: https://github.com/SumoLogic/sumologic-otel-collector/pull/553

--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -1,0 +1,14 @@
+# Upgrading
+
+## Upgrading to 0.49.0-sumo-0
+
+### Several changes to receivers using [opentelemetry-log-collection][opentelemetry-log-collection]
+
+The affected receivers are: `filelog`, `syslog`, `tcplog`, `udplog`, and `journald`.
+
+[opentelemetry-log-collection] is a shared library used by the aforementioned receivers. This release contains several breaking
+changes to its configuration syntax.
+Please refer to the [official upgrade guide][opentelemetry-log-collection-upgrade-guide] for more information.
+
+[opentelemetry-log-collection]: https://github.com/open-telemetry/opentelemetry-log-collection
+[opentelemetry-log-collection-upgrade-guide]: https://github.com/open-telemetry/opentelemetry-log-collection/releases/tag/v0.29.0


### PR DESCRIPTION
Describe the breaking change to `opentelemetry-log-collection` in the changelog.