### PR TITLE
chore(makefile): use default remote name `origin` in `push-tag` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,10 +138,10 @@ add-tag:
 push-tag:
 	@[ "${TAG}" ] || ( echo ">> env var TAG is not set"; exit 1 )
 	@echo "Pushing tag ${TAG}"
-	@git push upstream ${TAG}
+	@git push origin ${TAG}
 	@set -e; for dir in $(ALL_EXPORTABLE_MODULES); do \
 	  (echo Pushing tag "$${dir:2}/$${TAG}" && \
-	 	git push upstream "$${dir:2}/$${TAG}"); \
+	 	git push origin "$${dir:2}/$${TAG}"); \
 	done
 
 .PHONY: delete-tag


### PR DESCRIPTION
When cloning a repo, the remote is named `origin` by default, not `upstream`.
