### PR TITLE
fix(sumologicexporter): batch metrics if source headers match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat: add rawk8seventsreceiver [#547][#547]
 
+### Fixed
+
+- fix: fix(sumologicexporter): batch metrics if source headers match [#561][#561]
+
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.49.0-sumo-0...main
 [#547]: https://github.com/SumoLogic/sumologic-otel-collector/pull/547
+[#561]: https://github.com/SumoLogic/sumologic-otel-collector/pull/561
 
 ## [v0.49.0-sumo-0]
 

--- a/pkg/exporter/sumologicexporter/exporter_test.go
+++ b/pkg/exporter/sumologicexporter/exporter_test.go
@@ -818,21 +818,14 @@ gauge_metric_name{test="test_value",test2="second_value",remote_name="156955",ur
 			expectedError: "failed sending data: status: 500 Internal Server Error",
 		},
 		{
-			name: "sent separately when metrics under different resources",
+			name: "sent together when metrics under different resources",
 			callbacks: []func(w http.ResponseWriter, req *http.Request){
 				func(w http.ResponseWriter, req *http.Request) {
 					w.WriteHeader(500)
 
 					body := extractBody(t, req)
-					expected := `test.metric.data{test="test_value",test2="second_value"} 14500 1605534165000`
-					assert.Equal(t, expected, body)
-					assert.Equal(t, "application/vnd.sumologic.prometheus", req.Header.Get("Content-Type"))
-				},
-				func(w http.ResponseWriter, req *http.Request) {
-					w.WriteHeader(500)
-
-					body := extractBody(t, req)
-					expected := `gauge_metric_name{foo="bar",remote_name="156920",url="http://example_url"} 124 1608124661166
+					expected := `test.metric.data{test="test_value",test2="second_value"} 14500 1605534165000
+gauge_metric_name{foo="bar",remote_name="156920",url="http://example_url"} 124 1608124661166
 gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1608124662166`
 					assert.Equal(t, expected, body)
 					assert.Equal(t, "application/vnd.sumologic.prometheus", req.Header.Get("Content-Type"))
@@ -853,7 +846,7 @@ gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1
 				)
 				return metrics
 			},
-			expectedError: "failed sending data: status: 500 Internal Server Error (x2)",
+			expectedError: "failed sending data: status: 500 Internal Server Error",
 		},
 	}
 


### PR DESCRIPTION
#549 changed log and metrics exporting to send each Resource in a separate batch. This behaviour is correct for logs, whose metadata is passed via a X-Sumo-Fields http header, but is wasteful for metrics, where it's passed in the body. This change makes the exporter send all metrics in a batch in a single request, unless the source headers are different.

To achieve this we change several internal interfaces:
* `sendNonOtlpMetrics` now takes and returns a `pmetric.Metrics`, like the tracing equivalent
* the metrics sender now operates on resources, instead of individual datapoints
* removed some superfluous error handling around string builders