### PR TITLE
Restore support for go 1.17

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.17'
 
       # As described in
       # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
@@ -72,7 +72,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.17'
 
       # As described in
       # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -103,6 +103,7 @@ jobs:
             runs_on: ubuntu-20.04
           - arch_os: darwin_amd64
             runs_on: macos-latest
+        go: [ '1.18', '1.17']
     steps:
       - uses: actions/checkout@v3
 
@@ -121,7 +122,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: ${{ matrix.go }}
 
       # As described in
       # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
@@ -151,6 +152,7 @@ jobs:
     strategy:
       matrix:
         arch_os: [ 'linux_amd64' ]
+        go: [ '1.18', '1.17']
     steps:
       - uses: actions/checkout@v3
 
@@ -169,7 +171,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: ${{ matrix.go }}
 
       # As described in
       # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
@@ -216,6 +218,7 @@ jobs:
             runs_on: ubuntu-20.04
           - arch_os: darwin_amd64
             runs_on: macos-latest
+        go: [ '1.18', '1.17']
     steps:
       - uses: actions/checkout@v3
 
@@ -239,7 +242,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: ${{ matrix.go }}
 
       # As described in
       # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -103,7 +103,6 @@ jobs:
             runs_on: ubuntu-20.04
           - arch_os: darwin_amd64
             runs_on: macos-latest
-        go: [ '1.18', '1.17']
     steps:
       - uses: actions/checkout@v3
 
@@ -122,7 +121,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ matrix.go }}
+          go-version: '1.17'
 
       # As described in
       # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
@@ -152,7 +151,6 @@ jobs:
     strategy:
       matrix:
         arch_os: [ 'linux_amd64' ]
-        go: [ '1.18', '1.17']
     steps:
       - uses: actions/checkout@v3
 
@@ -171,7 +169,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ matrix.go }}
+          go-version: '1.17'
 
       # As described in
       # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
@@ -218,7 +216,6 @@ jobs:
             runs_on: ubuntu-20.04
           - arch_os: darwin_amd64
             runs_on: macos-latest
-        go: [ '1.18', '1.17']
     steps:
       - uses: actions/checkout@v3
 
@@ -242,7 +239,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ matrix.go }}
+          go-version: '1.17'
 
       # As described in
       # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.17'
 
       # As described in
       # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
@@ -104,7 +104,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.17'
 
       # As described in
       # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ for more details.
 
 - refactor(sumologicexporter): use golang.org/x/exp/slices for sorting fields [#519][#519]
 - refactor(sumologicextension): use bytes slices and strings.Builder to decrease allocations [#530][#530]
+- chore: restore support for building otelcol on go 1.17 [#574][#574]
 
 [v0.48.0-sumo-0]: https://github.com/SumoLogic/sumologic-otel-collector/releases/tag/v0.48.0-sumo-0
 [#519]: https://github.com/SumoLogic/sumologic-otel-collector/pull/519
@@ -97,6 +98,7 @@ for more details.
 [#530]: https://github.com/SumoLogic/sumologic-otel-collector/pull/530
 [#534]: https://github.com/SumoLogic/sumologic-otel-collector/pull/534
 [#536]: https://github.com/SumoLogic/sumologic-otel-collector/pull/536
+[#574]: https://github.com/SumoLogic/sumologic-otel-collector/pull/574
 
 ## [v0.47.0-sumo-0]
 

--- a/pkg/exporter/sumologicexporter/exporter.go
+++ b/pkg/exporter/sumologicexporter/exporter.go
@@ -89,7 +89,7 @@ func initExporter(cfg *Config, createSettings component.ExporterCreateSettings) 
 		logger:  createSettings.Logger,
 		sources: sfs,
 		compressorPool: sync.Pool{
-			New: func() any {
+			New: func() interface{} {
 				c, err := newCompressor(cfg.CompressEncoding)
 				if err != nil {
 					return fmt.Errorf("failed to initialize compressor: %w", err)

--- a/pkg/exporter/sumologicexporter/fields.go
+++ b/pkg/exporter/sumologicexporter/fields.go
@@ -15,11 +15,11 @@
 package sumologicexporter
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	"golang.org/x/exp/slices"
 )
 
 // fields represents metadata
@@ -90,7 +90,7 @@ func (f fields) string() string {
 		)
 		return true
 	})
-	slices.Sort(returnValue)
+	sort.Strings(returnValue)
 
 	return strings.Join(returnValue, ", ")
 }

--- a/pkg/exporter/sumologicexporter/go.mod
+++ b/pkg/exporter/sumologicexporter/go.mod
@@ -13,7 +13,6 @@ require (
 	go.opentelemetry.io/collector/pdata v0.50.0
 	go.uber.org/multierr v1.8.0
 	go.uber.org/zap v1.21.0
-	golang.org/x/exp v0.0.0-20220328175248-053ad81199eb
 )
 
 require (

--- a/pkg/exporter/sumologicexporter/go.sum
+++ b/pkg/exporter/sumologicexporter/go.sum
@@ -221,8 +221,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20220328175248-053ad81199eb h1:pC9Okm6BVmxEw76PUu0XUbOTQ92JX11hfvqTjAV3qxM=
-golang.org/x/exp v0.0.0-20220328175248-053ad81199eb/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=


### PR DESCRIPTION
otelcol must be built also on [Go+BoringCrypto](https://github.com/golang/go/blob/dev.boringcrypto.go1.18/README.boringcrypto.md). 
currently Go+BoringCrypto  for go 1.18 is not available so we must restore support for go 1.17, list of available releases: https://github.com/golang/go/blob/dev.boringcrypto.go1.18/misc/boring/RELEASES.

CI pipelines will be adjusted for building otelcol on [Go+BoringCrypto](https://github.com/golang/go/blob/dev.boringcrypto.go1.18/README.boringcrypto.md) in another pull request.
This PR contains necessary changes in the code to support go 1.17 with go version change in CI pipelines to prove that it is building on go 1.17.

This PR reverts some changes introduced in:
- https://github.com/SumoLogic/sumologic-otel-collector/pull/519
- https://github.com/SumoLogic/sumologic-otel-collector/pull/518
