### PR TITLE
fix(cascadingfilterprocessor): do not attach sampling.rule attribute if trace accept rules are not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.50.0-sumo-0...main
 
+### Fixed
+
+- fix: fix(cascadingfilterprocessor): do not attach sampling.rule attribute if trace accept rules are not specified [#575][#575]
+
+[#575]: https://github.com/SumoLogic/sumologic-otel-collector/pull/575
+
 ## [v0.50.0-sumo-0]
 
 ### Released 2022-04-29

--- a/pkg/processor/cascadingfilterprocessor/processor.go
+++ b/pkg/processor/cascadingfilterprocessor/processor.go
@@ -416,7 +416,8 @@ func (cfsp *cascadingFilterSpanProcessor) samplingPolicyOnTick() {
 
 			if trace.SelectedByProbabilisticFilter {
 				updateProbabilisticRateTag(allSpans, selectedByProbabilisticFilterSpans, totalSpans)
-			} else {
+			} else if len(cfsp.traceAcceptRules) > 0 {
+				// Set filtering tag only if there were actually any accept rules set otherwise
 				updateFilteringTag(allSpans)
 			}
 


### PR DESCRIPTION
This makes sure that `sampling.rule` attr is attached only when trace accept filters are defined only. 

Previously, when drop trace filters were specified the `sampling.rule=filtered` attribute was attached, which in lack of probabilistic filter caused Trace2Metrics calculations create no actual metrics