### PR TITLE
fix(k8sprocessor): store only necessary Pod data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat(sumologicexporter)!: remove support for Carbon2 metrics format [#590][#590]
 - feat(sumologicexporter)!: remove support for Graphite metrics format [#592][#592]
 
+### Fixed
+
+- fix(k8sprocessor): store only necessary Pod data [#593][#593]
+
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.51.0-sumo-0...main
 [#590]: https://github.com/SumoLogic/sumologic-otel-collector/pull/590
 [#592]: https://github.com/SumoLogic/sumologic-otel-collector/pull/592
+[#593]: https://github.com/SumoLogic/sumologic-otel-collector/pull/593
 
 ## [v0.51.0-sumo-0]
 

--- a/pkg/processor/k8sprocessor/kube/client_test.go
+++ b/pkg/processor/k8sprocessor/kube/client_test.go
@@ -767,7 +767,10 @@ func TestExtractionRules(t *testing.T) {
 			}
 			c.Rules = tc.rules
 
-			c.handlePodAdd(pod)
+			// manually call the data removal function here
+			// normally the informer does this, but fully emulating the informer in this test is annoying
+			transformedPod := removeUnnecessaryPodData(pod, c.Rules)
+			c.handlePodAdd(transformedPod)
 			p, ok := c.GetPod(PodIdentifier(pod.Status.PodIP))
 			require.True(t, ok)
 


### PR DESCRIPTION
Informers are a convenient mechanism for maintaining an eventually-consistent local cache of Kubernetes objects. One of the problems with them used to be that it was difficult to customize the object data stored in the cache, leading to unnecessarily large memory usage even when the client only cared about a small subset of the data. `client-go` 0.23.0 added a mechanism to do this, where it's possible to provide the informer with a transform function applied to the object before it's stored and event handlers are fired.

We supply a transform function to only retain the Pod data we use in our cache. Truthfully, we could get rid of all of it, as we keep the computed metadata in a separate data structure, but that would require implementing a custom Store. The transform function approach is much simpler in comparison.

The result is a close to 10x reduction in processor memory usage in large clusters (5000+ Pods).