### PR TITLE
Add CumulativeToDelta Processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.52.0-sumo-0]
-
 See [Upgrade guide][upgrade_guide_v0_52_0] for the breaking changes in this version.
+
+## [Unreleased]
+
+### Added
+
+- feat: Enable cumulativetodeltaprocessor [#595]
+
+### Changed
+
+[Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.52.0-sumo-0...main
+
+## [v0.52.0-sumo-0]
 
 ### Breaking changes
 

--- a/README.md
+++ b/README.md
@@ -28,44 +28,44 @@ The components with an asterisk `*` are upstream OpenTelemetry components with a
 
 The rest of the components in the table are pure upstream OpenTelemetry components.
 
-|                         Receivers                          |                       Processors                       |               Exporters                |                 Extensions                  |
-|:----------------------------------------------------------:|:------------------------------------------------------:|:--------------------------------------:|:-------------------------------------------:|
-| [awscontainerinsightreceiver][awscontainerinsightreceiver] |           [attributes][attributesprocessor]*           |        [carbon][carbonexporter]        | [bearertokenauth][bearertokenauthextension] |
-|  [awsecscontainermetrics][awsecscontainermetricsreceiver]  |                [batch][batchprocessor]                 |          [file][fileexporter]          |    [file_storage][filestorageextension]     |
-|                 [awsxray][awsxrayreceiver]                 |     [`cascading_filter`][cascadingfilterprocessor]     |         [kafka][kafkaexporter]         |    [health_check][healthcheckextension]     |
-|                  [carbon][carbonreceiver]                  |               [filter][filterprocessor]*               | [loadbalancing][loadbalancingexporter] |     [memory_ballast][ballastextension]      |
-|                [collectd][collectdreceiver]                |         [groupbyattrs][groupbyattrsprocessor]          |       [logging][loggingexporter]       |          [oidc][oidcauthextension]          |
-|            [docker_stats][dockerstatsreceiver]             |         [groupbytrace][groupbytraceprocessor]          |          [otlp][otlpexporter]          |           [pprof][pprofextension]           |
-|      [dotnet_diagnostics][dotnetdiagnosticsreceiver]       |              [`k8s_tagger`][k8sprocessor]              |      [otlphttp][otlphttpexporter]      |      [`sumologic`][sumologicextension]      |
-|                 [filelog][filelogreceiver]                 |        [memory_limiter][memorylimiterprocessor]        |    [`sumologic`][sumologicexporter]    |          [zpages][zpagesextension]          |
-|           [fluentforward][fluentforwardreceiver]           |     [`metric_frequency`][metricfrequencyprocessor]     |                                        |                                             |
-|      [googlecloudspanner][googlecloudspannerreceiver]      |     [metricstransform][metricstransformprocessor]      |                                        |                                             |
-|             [hostmetrics][hostmetricsreceiver]             | [probabilistic_sampler][probabilisticsamplerprocessor] |                                        |                                             |
-|                  [jaeger][jaegerreceiver]                  |             [resource][resourceprocessor]*             |                                        |                                             |
-|                     [jmx][jmxreceiver]                     |    [resourcedetection][resourcedetectionprocessor]     |                                        |                                             |
-|                [journald][journaldreceiver]                |              [routing][routingprocessor]               |                                        |                                             |
-|                   [kafka][kafkareceiver]                   |              [`source`][sourceprocessor]               |                                        |                                             |
-|            [kafkametrics][kafkametricsreceiver]            |                 [span][spanprocessor]                  |                                        |                                             |
-|              [opencensus][opencensusreceiver]              |          [spanmetrics][spanmetricsprocessor]           |                                        |                                             |
-|                    [otlp][otlpreceiver]                    |     [`sumologic_schema`][sumologicschemaprocessor]     |                                        |                                             |
-|               [podman_stats][podmanreceiver]               |     [`sumologic_syslog`][sumologicsyslogprocessor]     |                                        |                                             |
-|              [prometheus][prometheusreceiver]              |         [tail_sampling][tailsamplingprocessor]         |                                        |                                             |
-|       [prometheus_simple][simpleprometheusreceiver]        |                                                        |                                        |                                             |
-|               [`raw_k8_sevents`][rawk8seventsreceiver]     |                                                        |                                        |                                             |
-|            [receiver_creator][receivercreator]             |                                                        |                                        |                                             |
-|                   [redis][redisreceiver]                   |                                                        |                                        |                                             |
-|                    [sapm][sapmreceiver]                    |                                                        |                                        |                                             |
-|                [signalfx][signalfxreceiver]                |                                                        |                                        |                                             |
-|              [splunk_hec][splunkhecreceiver]               |                                                        |                                        |                                             |
-|                  [statsd][statsdreceiver]                  |                                                        |                                        |                                             |
-|                  [syslog][syslogreceiver]                  |                                                        |                                        |                                             |
-|                  [tcplog][tcplogreceiver]                  |                                                        |                                        |                                             |
-|               [`telegraf`][telegrafreceiver]               |                                                        |                                        |                                             |
-|                  [udplog][udplogreceiver]                  |                                                        |                                        |                                             |
-|               [wavefront][wavefrontreceiver]               |                                                        |                                        |                                             |
-|     [windowsperfcounters][windowsperfcountersreceiver]     |                                                        |                                        |                                             |
-|                  [zipkin][zipkinreceiver]                  |                                                        |                                        |                                             |
-|               [zookeeper][zookeeperreceiver]               |                                                        |                                        |                                             |
+|                         Receivers                          |                        Processors                        |               Exporters                |                 Extensions                  |
+| :--------------------------------------------------------: | :------------------------------------------------------: | :------------------------------------: | :-----------------------------------------: |
+| [awscontainerinsightreceiver][awscontainerinsightreceiver] |            [attributes][attributesprocessor]*            |        [carbon][carbonexporter]        | [bearertokenauth][bearertokenauthextension] |
+|  [awsecscontainermetrics][awsecscontainermetricsreceiver]  |                 [batch][batchprocessor]                  |          [file][fileexporter]          |    [file_storage][filestorageextension]     |
+|                 [awsxray][awsxrayreceiver]                 |      [`cascading_filter`][cascadingfilterprocessor]      |         [kafka][kafkaexporter]         |    [health_check][healthcheckextension]     |
+|                  [carbon][carbonreceiver]                  | [cumulativetodeltaprocessor][cumulativetodeltaprocessor] | [loadbalancing][loadbalancingexporter] |     [memory_ballast][ballastextension]      |
+|                [collectd][collectdreceiver]                |                [filter][filterprocessor]*                |       [logging][loggingexporter]       |          [oidc][oidcauthextension]          |
+|            [docker_stats][dockerstatsreceiver]             |          [groupbyattrs][groupbyattrsprocessor]           |          [otlp][otlpexporter]          |           [pprof][pprofextension]           |
+|      [dotnet_diagnostics][dotnetdiagnosticsreceiver]       |          [groupbytrace][groupbytraceprocessor]           |      [otlphttp][otlphttpexporter]      |      [`sumologic`][sumologicextension]      |
+|                 [filelog][filelogreceiver]                 |               [`k8s_tagger`][k8sprocessor]               |    [`sumologic`][sumologicexporter]    |          [zpages][zpagesextension]          |
+|           [fluentforward][fluentforwardreceiver]           |         [memory_limiter][memorylimiterprocessor]         |                                        |                                             |
+|      [googlecloudspanner][googlecloudspannerreceiver]      |      [`metric_frequency`][metricfrequencyprocessor]      |                                        |                                             |
+|             [hostmetrics][hostmetricsreceiver]             |      [metricstransform][metricstransformprocessor]       |                                        |                                             |
+|                  [jaeger][jaegerreceiver]                  |  [probabilistic_sampler][probabilisticsamplerprocessor]  |                                        |                                             |
+|                     [jmx][jmxreceiver]                     |              [resource][resourceprocessor]*              |                                        |                                             |
+|                [journald][journaldreceiver]                |     [resourcedetection][resourcedetectionprocessor]      |                                        |                                             |
+|                   [kafka][kafkareceiver]                   |               [routing][routingprocessor]                |                                        |                                             |
+|            [kafkametrics][kafkametricsreceiver]            |               [`source`][sourceprocessor]                |                                        |                                             |
+|              [opencensus][opencensusreceiver]              |                  [span][spanprocessor]                   |                                        |                                             |
+|                    [otlp][otlpreceiver]                    |           [spanmetrics][spanmetricsprocessor]            |                                        |                                             |
+|               [podman_stats][podmanreceiver]               |      [`sumologic_schema`][sumologicschemaprocessor]      |                                        |                                             |
+|              [prometheus][prometheusreceiver]              |      [`sumologic_syslog`][sumologicsyslogprocessor]      |                                        |                                             |
+|       [prometheus_simple][simpleprometheusreceiver]        |          [tail_sampling][tailsamplingprocessor]          |                                        |                                             |
+|          [`raw_k8_sevents`][rawk8seventsreceiver]          |                                                          |                                        |                                             |
+|            [receiver_creator][receivercreator]             |                                                          |                                        |                                             |
+|                   [redis][redisreceiver]                   |                                                          |                                        |                                             |
+|                    [sapm][sapmreceiver]                    |                                                          |                                        |                                             |
+|                [signalfx][signalfxreceiver]                |                                                          |                                        |                                             |
+|              [splunk_hec][splunkhecreceiver]               |                                                          |                                        |                                             |
+|                  [statsd][statsdreceiver]                  |                                                          |                                        |                                             |
+|                  [syslog][syslogreceiver]                  |                                                          |                                        |                                             |
+|                  [tcplog][tcplogreceiver]                  |                                                          |                                        |                                             |
+|               [`telegraf`][telegrafreceiver]               |                                                          |                                        |                                             |
+|                  [udplog][udplogreceiver]                  |                                                          |                                        |                                             |
+|               [wavefront][wavefrontreceiver]               |                                                          |                                        |                                             |
+|     [windowsperfcounters][windowsperfcountersreceiver]     |                                                          |                                        |                                             |
+|                  [zipkin][zipkinreceiver]                  |                                                          |                                        |                                             |
+|               [zookeeper][zookeeperreceiver]               |                                                          |                                        |                                             |
 
 [awscontainerinsightreceiver]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.52.0/receiver/awscontainerinsightreceiver
 [awsecscontainermetricsreceiver]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.52.0/receiver/awsecscontainermetricsreceiver
@@ -107,6 +107,7 @@ The rest of the components in the table are pure upstream OpenTelemetry componen
 [attributesprocessor]: https://github.com/SumoLogic/opentelemetry-collector-contrib/tree/v0.52.0-filterprocessor/processor/attributesprocessor
 [batchprocessor]: https://github.com/open-telemetry/opentelemetry-collector/tree/v0.52.0/processor/batchprocessor
 [cascadingfilterprocessor]: ./pkg/processor/cascadingfilterprocessor
+[cumulativetodeltaprocessor]:  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.52.0/processor/cumulativetodeltaprocessor
 [filterprocessor]: https://github.com/SumoLogic/opentelemetry-collector-contrib/tree/v0.52.0-filterprocessor/processor/filterprocessor
 [groupbyattrsprocessor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.52.0/processor/groupbyattrsprocessor
 [groupbytraceprocessor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.52.0/processor/groupbytraceprocessor

--- a/otelcolbuilder/.otelcol-builder.yaml
+++ b/otelcolbuilder/.otelcol-builder.yaml
@@ -57,6 +57,7 @@ processors:
 
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.52.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.52.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.52.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.52.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor v0.52.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.52.0"


### PR DESCRIPTION
* Addresses: https://github.com/SumoLogic/sumologic-otel-collector/issues/595

* [Cumulative To Delta Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor)

* My use case of this is that not all vendors support Cumulative metrics and being able to use this processor to convert them to Delta would be incredibly helpful.