### PR TITLE
ci: disable MacOS builds while signing not possible

### DIFF
--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -87,117 +87,117 @@ jobs:
           path: ./otelcolbuilder/cmd/${{ steps.set_filename.outputs.filename }}
           if-no-files-found: error
 
-  build-darwin:
-    name: Build darwin
-    runs-on: ${{ matrix.runs_on }}
-    strategy:
-      matrix:
-        include:
-          - arch_os: darwin_amd64
-            runs_on: macos-latest
-          - arch_os: darwin_arm64
-            runs_on: macos-latest
-    steps:
-      - uses: actions/checkout@v3
+  # build-darwin:
+  #   name: Build darwin
+  #   runs-on: ${{ matrix.runs_on }}
+  #   strategy:
+  #     matrix:
+  #       include:
+  #         - arch_os: darwin_amd64
+  #           runs_on: macos-latest
+  #         - arch_os: darwin_arm64
+  #           runs_on: macos-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
 
-      - name: Fetch current branch
-        run: ./ci/fetch_current_branch.sh
+  #     - name: Fetch current branch
+  #       run: ./ci/fetch_current_branch.sh
 
-      - name: Setup go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.18'
+  #     - name: Setup go
+  #       uses: actions/setup-go@v3
+  #       with:
+  #         go-version: '1.18'
 
-      # As described in
-      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
-      - uses: actions/cache@v3
-        with:
-          path: |
-            /Users/runner/go/pkg/mod
-            /Users/runner/Library/Caches/go-build
-          key: ${{matrix.arch_os}}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{matrix.arch_os}}-go-
+  #     # As described in
+  #     # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
+  #     - uses: actions/cache@v3
+  #       with:
+  #         path: |
+  #           /Users/runner/go/pkg/mod
+  #           /Users/runner/Library/Caches/go-build
+  #         key: ${{matrix.arch_os}}-go-${{ hashFiles('**/go.sum') }}
+  #         restore-keys: |
+  #           ${{matrix.arch_os}}-go-
 
-      - name: Extract tag
-        id: extract_tag
-        run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/v})"
+  #     - name: Extract tag
+  #       id: extract_tag
+  #       run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/v})"
 
-      - name: Add opentelemetry-collector-builder installation dir to PATH
-        run: echo "$HOME/bin" >> $GITHUB_PATH
+  #     - name: Add opentelemetry-collector-builder installation dir to PATH
+  #       run: echo "$HOME/bin" >> $GITHUB_PATH
 
-      - name: Install opentelemetry-collector-builder
-        run: make install-builder
-        working-directory: ./otelcolbuilder
+  #     - name: Install opentelemetry-collector-builder
+  #       run: make install-builder
+  #       working-directory: ./otelcolbuilder
 
-      - name: Prepare tags in otelcolbuilder's config
-        run: make prepare-tag TAG=${{ steps.extract_tag.outputs.tag }}
+  #     - name: Prepare tags in otelcolbuilder's config
+  #       run: make prepare-tag TAG=${{ steps.extract_tag.outputs.tag }}
 
-      - name: Build
-        run: make otelcol-sumo-${{matrix.arch_os}}
-        working-directory: ./otelcolbuilder
+  #     - name: Build
+  #       run: make otelcol-sumo-${{matrix.arch_os}}
+  #       working-directory: ./otelcolbuilder
 
-      - name: Set filename
-        id: set_filename
-        run: echo "::set-output name=filename::$(echo otelcol-sumo-${{ steps.extract_tag.outputs.tag }}-${{matrix.arch_os}})"
+  #     - name: Set filename
+  #       id: set_filename
+  #       run: echo "::set-output name=filename::$(echo otelcol-sumo-${{ steps.extract_tag.outputs.tag }}-${{matrix.arch_os}})"
 
-      - name: Import Code-Signing Certificates
-        uses: Apple-Actions/import-codesign-certs@v1
-        with:
-          # The certificates in a PKCS12 file encoded as a base64 string
-          p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
-          # The password used to import the PKCS12 file.
-          p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
+  #     - name: Import Code-Signing Certificates
+  #       uses: Apple-Actions/import-codesign-certs@v1
+  #       with:
+  #         # The certificates in a PKCS12 file encoded as a base64 string
+  #         p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
+  #         # The password used to import the PKCS12 file.
+  #         p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
 
-      # NOTE: gon's brew tap (as many others) has stopped working for some reason.
-      # Related issue: https://github.com/mitchellh/gon/issues/56
-      # - name: Install gon via HomeBrew for code signing and app notarization
-      #   run: |
-      #     brew tap mitchellh/gon
-      #     brew install mitchellh/gon/gon
+  #     # NOTE: gon's brew tap (as many others) has stopped working for some reason.
+  #     # Related issue: https://github.com/mitchellh/gon/issues/56
+  #     # - name: Install gon via HomeBrew for code signing and app notarization
+  #     #   run: |
+  #     #     brew tap mitchellh/gon
+  #     #     brew install mitchellh/gon/gon
 
-      - name: Install gon for code signing and app notarization
-        run: |
-          curl -Lo gon.dmg https://github.com/mitchellh/gon/releases/download/v0.2.3/gon_macos.dmg
-          sudo hdiutil attach gon.dmg
-          cp /Volumes/gon/gon "$HOME/bin"
+  #     - name: Install gon for code signing and app notarization
+  #       run: |
+  #         curl -Lo gon.dmg https://github.com/mitchellh/gon/releases/download/v0.2.3/gon_macos.dmg
+  #         sudo hdiutil attach gon.dmg
+  #         cp /Volumes/gon/gon "$HOME/bin"
 
-      - name: Sign the mac binaries with Gon
-        env:
-          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
-        working-directory: ./otelcolbuilder/
-        run: make ${{matrix.arch_os}}-sign
+  #     - name: Sign the mac binaries with Gon
+  #       env:
+  #         AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+  #       working-directory: ./otelcolbuilder/
+  #       run: make ${{matrix.arch_os}}-sign
 
-      - name: Rename .dmg to include tag in filename
-        run: cp otelcol-sumo-${{matrix.arch_os}}.dmg ${{ steps.set_filename.outputs.filename }}.dmg
-        working-directory: ./otelcolbuilder/cmd
+  #     - name: Rename .dmg to include tag in filename
+  #       run: cp otelcol-sumo-${{matrix.arch_os}}.dmg ${{ steps.set_filename.outputs.filename }}.dmg
+  #       working-directory: ./otelcolbuilder/cmd
 
-      - name: Rename binary to include tag in filename
-        run: cp otelcol-sumo-${{matrix.arch_os}} ${{ steps.set_filename.outputs.filename }}
-        working-directory: ./otelcolbuilder/cmd
+  #     - name: Rename binary to include tag in filename
+  #       run: cp otelcol-sumo-${{matrix.arch_os}} ${{ steps.set_filename.outputs.filename }}
+  #       working-directory: ./otelcolbuilder/cmd
 
-      - name: Show included modules
-        working-directory: ./otelcolbuilder/cmd
-        run: |
-          go version -m ${{ steps.set_filename.outputs.filename }} | \
-          grep -E "/(receiver|exporter|processor|extension)/" | \
-          tee otelcol-sumo-${{matrix.arch_os}}_modules.txt
+  #     - name: Show included modules
+  #       working-directory: ./otelcolbuilder/cmd
+  #       run: |
+  #         go version -m ${{ steps.set_filename.outputs.filename }} | \
+  #         grep -E "/(receiver|exporter|processor|extension)/" | \
+  #         tee otelcol-sumo-${{matrix.arch_os}}_modules.txt
 
-      # Store binary and .dmg into pipeline artifacts after they have been signed
+  #     # Store binary and .dmg into pipeline artifacts after they have been signed
 
-      - name: Store .dmg as action artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{matrix.arch_os}}.dmg
-          path: ./otelcolbuilder/cmd/${{ steps.set_filename.outputs.filename }}.dmg
-          if-no-files-found: error
+  #     - name: Store .dmg as action artifact
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: ${{matrix.arch_os}}.dmg
+  #         path: ./otelcolbuilder/cmd/${{ steps.set_filename.outputs.filename }}.dmg
+  #         if-no-files-found: error
 
-      - name: Store binary as action artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{matrix.arch_os}}
-          path: ./otelcolbuilder/cmd/${{ steps.set_filename.outputs.filename }}
-          if-no-files-found: error
+  #     - name: Store binary as action artifact
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: ${{matrix.arch_os}}
+  #         path: ./otelcolbuilder/cmd/${{ steps.set_filename.outputs.filename }}
+  #         if-no-files-found: error
 
   build-container-images:
     name: Build container

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.53.0-sumo-0]
 
-### Released 2022-06-21
+### Released 2022-06-28
+
+:warning: Due to an infrastructure problem, this release lacks the MacOS binaries.
+We hope to restore building the binaries for MacOS as soon as possible.
 
 This release adds missing [receivers], [processors] and [extensions] from the OpenTelemetry Distribution.
 It also includes `journald` binary required by [journaldreceiver]
@@ -26,6 +29,7 @@ and begin support of arm64 architecture for Darwin OS.
 
 - chore(core): upgrade to v0.53.0 [#615]
 - feat(journaldreceiver): add missing dependencies [#577]
+- ci: disable MacOS builds while signing not possible [#628]
 
 [v0.53.0-sumo-0]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.52.0-sumo-0...v0.53.0-sumo-0
 [#597]: https://github.com/SumoLogic/sumologic-otel-collector/pull/597
@@ -35,6 +39,7 @@ and begin support of arm64 architecture for Darwin OS.
 [#616]: https://github.com/SumoLogic/sumologic-otel-collector/pull/616
 [#615]: https://github.com/SumoLogic/sumologic-otel-collector/pull/615
 [#614]: https://github.com/SumoLogic/sumologic-otel-collector/pull/614
+[#628]: https://github.com/SumoLogic/sumologic-otel-collector/pull/628
 [journaldreceiver]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.53.0/receiver/journaldreceiver#journald-receiver
 [receivers]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.53.0/receiver
 [processors]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.53.0/processor


### PR DESCRIPTION
There's an infrastructure issue with signing the MacOS binaries.
Until it is resolved, let's release new versions without MacOS binaries.
