### PR TITLE
fix(ci): fix path for FIPS binaries in dev pipeline

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -317,11 +317,10 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: otelcol-sumo-${{matrix.arch_os}}-fips
-          path: artifacts/
 
       - name: Build and push FIPS image to Open Source ECR
         run: |
-          cp artifacts/${{ steps.set_filename.outputs.filename }}-fips otelcol-sumo
+          cp otelcol-sumo-${{ matrix.arch_os }}-fips otelcol-sumo
           make build-push-container-multiplatform \
             BUILD_TAG=${{ steps.extract_tag.outputs.tag }}-fips \
             PLATFORM=${{ matrix.arch_os }}


### PR DESCRIPTION
I see that path for binary is different for dev builds than path in release builds,
I change path to the path which is set for non-fips binaries
it should fix: https://github.com/SumoLogic/sumologic-otel-collector/runs/7096431121?check_suite_focus=true