### PR TITLE
fix(sumologicexporter): translate Telegraf metrics with OTLP format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- fix(sumologicexporter): translate Telegraf metrics with OTLP format [#659]
+
+[Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.54.0-sumo-0...main
+[#659]: https://github.com/SumoLogic/sumologic-otel-collector/pull/659
+
 ## [v0.54.0-sumo-0]
 
 ### Released 2022-07-04

--- a/pkg/exporter/sumologicexporter/sender.go
+++ b/pkg/exporter/sumologicexporter/sender.go
@@ -596,11 +596,6 @@ func (s *sender) sendOTLPMetrics(ctx context.Context, md pmetric.Metrics) error 
 	for i := 0; i < rms.Len(); i++ {
 		rm := rms.At(i)
 
-		if s.config.TranslateAttributes {
-			translateAttributes(rm.Resource().Attributes()).
-				CopyTo(rm.Resource().Attributes())
-		}
-
 		s.addSourceResourceAttributes(rm.Resource().Attributes())
 	}
 


### PR DESCRIPTION
This change fixes a regression introduced in https://github.com/SumoLogic/sumologic-otel-collector/pull/536 that caused the metric name translations (the feature under the `translate_telegraf_attributes` setting) to not work when using the OTLP format.
This change refactors the code so that all modifications to metrics (attribute translation, metrics translation, dropping routing attribute) are done before branching the code into different sending formats.