### PR TITLE
feat(sumologicexporter): do not send empty OTLP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- feat(sumologicexporter): do not send empty OTLP requests [#660]
+
 ### Fixed
 
 - fix(sumologicexporter): translate Telegraf metrics with OTLP format [#659]
 
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.54.0-sumo-0...main
 [#659]: https://github.com/SumoLogic/sumologic-otel-collector/pull/659
+[#660]: https://github.com/SumoLogic/sumologic-otel-collector/pull/660
 
 ## [v0.54.0-sumo-0]
 

--- a/pkg/exporter/sumologicexporter/exporter_test.go
+++ b/pkg/exporter/sumologicexporter/exporter_test.go
@@ -1588,17 +1588,7 @@ func TestSendEmptyLogsOTLP(t *testing.T) {
 
 func TestSendEmptyMetricsOTLP(t *testing.T) {
 	test := prepareExporterTest(t, createTestConfig(), []func(w http.ResponseWriter, req *http.Request){
-		// A request with empty body is sent
-		func(w http.ResponseWriter, req *http.Request) {
-			body := extractBody(t, req)
-
-			md, err := otlp.NewProtobufMetricsUnmarshaler().UnmarshalMetrics([]byte(body))
-			assert.NoError(t, err)
-			assert.NotNil(t, md)
-
-			assert.Equal(t, "", body)
-			assert.Equal(t, "application/x-protobuf", req.Header.Get("Content-Type"))
-		},
+		// No request is sent
 	})
 	test.exp.config.MetricFormat = OTLPMetricFormat
 
@@ -1610,17 +1600,7 @@ func TestSendEmptyMetricsOTLP(t *testing.T) {
 
 func TestSendEmptyTraces(t *testing.T) {
 	test := prepareExporterTest(t, createTestConfig(), []func(w http.ResponseWriter, req *http.Request){
-		// A request with empty body is sent
-		func(w http.ResponseWriter, req *http.Request) {
-			body := extractBody(t, req)
-
-			md, err := otlp.NewProtobufTracesUnmarshaler().UnmarshalTraces([]byte(body))
-			assert.NoError(t, err)
-			assert.NotNil(t, md)
-
-			assert.Equal(t, "", body)
-			assert.Equal(t, "application/x-protobuf", req.Header.Get("Content-Type"))
-		},
+		// No request is sent
 	})
 
 	traces := ptrace.NewTraces()

--- a/pkg/exporter/sumologicexporter/sender.go
+++ b/pkg/exporter/sumologicexporter/sender.go
@@ -593,6 +593,11 @@ func (s *sender) sendNonOTLPMetrics(ctx context.Context, md pmetric.Metrics) (pm
 
 func (s *sender) sendOTLPMetrics(ctx context.Context, md pmetric.Metrics) error {
 	rms := md.ResourceMetrics()
+	if rms.Len() == 0 {
+		s.logger.Debug("there are no metrics to send, moving on")
+		return nil
+	}
+
 	for i := 0; i < rms.Len(); i++ {
 		rm := rms.At(i)
 
@@ -649,6 +654,11 @@ func (s *sender) sendTraces(ctx context.Context, td ptrace.Traces) error {
 
 // sendOTLPTraces sends trace records in OTLP format
 func (s *sender) sendOTLPTraces(ctx context.Context, td ptrace.Traces) error {
+	if td.ResourceSpans().Len() == 0 {
+		s.logger.Debug("there are no traces to send, moving on")
+		return nil
+	}
+
 	capacity := td.SpanCount()
 	for i := 0; i < td.ResourceSpans().Len(); i++ {
 		s.addSourceResourceAttributes(td.ResourceSpans().At(i).Resource().Attributes())


### PR DESCRIPTION
Currently, when en empty metrics or traces dataset is passed to the Sumo Logic exporter, an empty-bodied request is sent to the backend.
This behavior is in fact in line with what the upstream OTLP HTTP exporter does for all signals - logs, metrics and traces.

This change modifies this behavior for metrics and traces so that the empty request is not sent. This is to prevent an unnecessary network call.

For logs, the current behavior is to not send the empty request when an empty dataset is passed to the exporter, and there is no change to this behavior.