### PR TITLE
feat(sumologicexporter): do not retry on '400 Bad Request' response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - feat(sumologicexporter): do not send empty OTLP requests [#660]
+- feat(sumologicexporter): do not retry on '400 Bad Request' response [#661]
 
 ### Fixed
 
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.54.0-sumo-0...main
 [#659]: https://github.com/SumoLogic/sumologic-otel-collector/pull/659
 [#660]: https://github.com/SumoLogic/sumologic-otel-collector/pull/660
+[#661]: https://github.com/SumoLogic/sumologic-otel-collector/pull/661
 
 ## [v0.54.0-sumo-0]
 


### PR DESCRIPTION
If the server responds with '400 Bad Request', the exporter should not retry the request.
This is in line what the upstream OTLP HTTP exporter does:
https://github.com/open-telemetry/opentelemetry-collector/blob/v0.55.0/exporter/otlphttpexporter/otlp.go#L181-L184