### PR TITLE
fix(k8sprocessor): only apply the node filter to Pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- fix(k8sprocessor): only apply the node filter to Pods [#668]
+
+[Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.55.0-sumo-0...main
+[#668]: https://github.com/SumoLogic/sumologic-otel-collector/pull/668
+
 ## [v0.55.0-sumo-0]
 
 ### Released 2022-07-13

--- a/pkg/processor/k8sprocessor/kube/client_test.go
+++ b/pkg/processor/k8sprocessor/kube/client_test.go
@@ -850,6 +850,22 @@ func TestFilters(t *testing.T) {
 	}
 }
 
+func TestNodeFilterDoesntApplyToOwners(t *testing.T) {
+	filters := Filters{
+		Node: "ec2-test",
+	}
+	c, _ := newTestClientWithRulesAndFilters(t, ExtractionRules{OwnerLookupEnabled: true}, filters)
+
+	// verify that the Pod informer has the Node selector set
+	inf := c.informer.(*FakeInformer)
+	assert.Equal(t, "", inf.labelSelector.String())
+	assert.Equal(t, "spec.nodeName=ec2-test", inf.fieldSelector.String())
+
+	// verify that the owner provider does NOT have the Node selector set
+	ownerProvider := c.op.(*fakeOwnerCache)
+	assert.Equal(t, "", ownerProvider.fieldSelector.String())
+}
+
 func TestPodIgnorePatterns(t *testing.T) {
 	testCases := []struct {
 		ignore bool

--- a/pkg/processor/k8sprocessor/kube/fake_owner.go
+++ b/pkg/processor/k8sprocessor/kube/fake_owner.go
@@ -26,8 +26,12 @@ import (
 
 // fakeOwnerCache is a simple structure which aids querying for owners
 type fakeOwnerCache struct {
-	logger       *zap.Logger
-	objectOwners map[string]*ObjectOwner
+	logger          *zap.Logger
+	objectOwners    map[string]*ObjectOwner
+	labelSelector   labels.Selector
+	fieldSelector   fields.Selector
+	extractionRules ExtractionRules
+	namespace       string
 }
 
 // NewOwnerProvider creates new instance of the owners api
@@ -37,7 +41,12 @@ func newFakeOwnerProvider(logger *zap.Logger,
 	fieldSelector fields.Selector,
 	extractionRules ExtractionRules,
 	namespace string) (OwnerAPI, error) {
-	ownerCache := fakeOwnerCache{}
+	ownerCache := fakeOwnerCache{
+		labelSelector:   labelSelector,
+		fieldSelector:   fieldSelector,
+		extractionRules: extractionRules,
+		namespace:       namespace,
+	}
 	ownerCache.objectOwners = map[string]*ObjectOwner{}
 	ownerCache.logger = logger
 


### PR DESCRIPTION
The Node filter should only be used for the Pod informer, as only Pods have the `spec.Node` field. This fixes #651 @mat-rumian 