### PR TITLE
feat(sumologicexporter, sumologicschemaprocessor)!: move translating metadata from sumologic exporter to sumologic schema processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+This release deprecates the following feature, which will be removed in `v0.59.0`:
+
+- 'sumologic' exporter: translate attributes ([upgrade guide][upgrade_guide_unreleased_moved_translation])
+
+### Added
+
+- feat(sumologicschemaprocessor): add translating attributes
+
+### Changed
+
+- feat(sumologicexporter): deprecate translating attributes ([upgrade guide][upgrade_guide_unreleased_moved_translation])
+
 ### Fixed
 
 - fix(k8sprocessor): only apply the node filter to Pods [#668]
 
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.55.0-sumo-0...main
 [#668]: https://github.com/SumoLogic/sumologic-otel-collector/pull/668
+[upgrade_guide_unreleased_moved_translation]: ./docs/Upgrading.md#sumologic-exporter-drop-support-for-translating-attributes
 
 ## [v0.55.0-sumo-0]
 

--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -1,7 +1,9 @@
 # Upgrading
 
+- [Unreleased](#unreleased)
+  - [`sumologic` exporter: moved translating attributes to `sumologicschema` processor](#sumologic-exporter-drop-support-for-translating-attributes)
 - [Upgrading to v0.55.0-sumo-0](#upgrading-to-v0550-sumo-0)
-  - [`filter` processor: Drop support for `expr` language](#filter-processor-drop-support-for-expr-language)
+  - [`filter` processor: drop support for `expr` language](#filter-processor-drop-support-for-expr-language)
 - [Upgrading to v0.52.0-sumo-0](#upgrading-to-v0520-sumo-0)
   - [`sumologic` exporter: Removed `carbon2` and `graphite` metric formats](#sumologic-exporter-removed-carbon2-and-graphite-metric-formats)
 - [Upgrading to v0.51.0-sumo-0](#upgrading-to-v0510-sumo-0)
@@ -14,6 +16,49 @@
   - [Sumo Logic exporter metadata handling](#sumo-logic-exporter-metadata-handling)
     - [Removing unnecessary metadata using the resourceprocessor](#removing-unnecessary-metadata-using-the-resourceprocessor)
     - [Moving record-level attributes used for metadata to the resource level](#moving-record-level-attributes-used-for-metadata-to-the-resource-level)
+
+## Unreleased
+
+### `sumologic` exporter: drop support for translating attributes
+
+Translating the attributes is harmless, but the exporters should not modify the data.
+This functionality has been moved to the [sumologicschema processor][sumologicschema_processor].
+Due to that, this functionality is now deprecated in the exporter and will be removed soon.
+
+However, if the attributes are not translated, some Sumo apps might not work correctly.
+To migrate, add a `sumologicschema` processor to your pipelines that use the `sumologic` exporter and disable that functionality in the exporter:
+
+```yaml
+processors:
+  # ...
+  sumologic_schema:
+    translate_attributes: true
+
+exporters:
+  sumologic:
+    # ...
+    translate_attributes: false
+
+# ...
+
+service:
+  pipelines:
+    logs:
+      processors:
+        # - ...
+        - sumologic_schema
+```
+
+**Note**: by default, the `sumologicschema` processor also adds `cloud.namespace` attribute to the data.
+If you don't want this to happen, you should explicitly disable this functionality:
+
+```yaml
+processors:
+  sumologic_schema:
+    add_cloud_namespace: false
+```
+
+[sumologicschema_processor]: ../pkg/processor/sumologicschemaprocessor/
 
 ## Upgrading to v0.55.0-sumo-0
 

--- a/pkg/exporter/sumologicexporter/README.md
+++ b/pkg/exporter/sumologicexporter/README.md
@@ -20,15 +20,15 @@ exporters:
     # default = 1_048_576 (1MB)
     max_request_body_size: <max_request_body_size>
 
-    # format to use when sending logs to Sumo, default = otlp,
+    # format to use when sending logs to Sumo Logic, default = otlp,
     # NOTE: only `otlp` is supported when used with sumologicextension
     log_format: {json, text, otlp}
 
-    # format to use when sending metrics to Sumo, default = otlp,
+    # format to use when sending metrics to Sumo Logic, default = otlp,
     # NOTE: only `otlp` is supported when used with sumologicextension
     metric_format: {otlp, prometheus}
 
-    # format to use when sending traces to Sumo,
+    # format to use when sending traces to Sumo Logic,
     # currently only otlp is supported
     trace_format: {otlp}
 
@@ -81,14 +81,15 @@ exporters:
       # default = false
       flatten_body: {true, false}
 
+    # DEPRECATED
     # translate_attributes specifies whether attributes should be translated
-    # from OpenTelemetry to Sumo conventions;
+    # from OpenTelemetry to Sumo Logic conventions;
     # see "Attribute translation" documentation chapter from this document,
     # default = true
     translate_attributes: {true, false}
 
     # Specifies whether telegraf metric names should be translated to match
-    # Sumo conventions expected in Sumo host related apps (for example
+    # Sumo Logic conventions expected in Sumo Logic host related apps (for example
     # `procstat_num_threads` => `Proc_Threads` or `cpu_usage_irq` => `CPU_Irq`).
     # See `translate_metrics.go` for full list of translations.
     # default = true
@@ -141,42 +142,45 @@ exporters:
 
 ## Attribute translation
 
-Attribute translation changes some of the attribute keys from OpenTelemetry convention to Sumo convention.
+**Note**: This functionality has been moved to the [sumologicschemaprocessor](../../processor/sumologicschemaprocessor/) and is now deprecated.
+Please check the [upgrade guide](../../../docs/Upgrading.md#sumologic-exporter-drop-support-for-translating-attributes) for migrating instructions.
+
+Attribute translation changes some of the attribute keys from OpenTelemetry convention to Sumo Logic convention.
 For example, OpenTelemetry convention for the attribute containing Kubernetes pod name is `k8s.pod.name`,
-but Sumo expects it to be in attribute named `pod`.
+but Sumo Logic expects it to be in attribute named `pod`.
 
 If attribute with target name eg. `pod` already exists,
 translation is not being done for corresponding attribute (`k8s.pod.name` in this example).
 
 This feature is turned on by default.
 To turn it off, set the `translate_attributes` configuration option to `false`.
-Note that this may cause some of Sumo apps, built-in dashboards to not work correctly.
+Note that this may cause some of Sumo Logic apps, built-in dashboards to not work correctly.
 
 Below is a list of all attribute keys that are being translated.
 
-| OTC key name              | Sumo key name      |
-|---------------------------|--------------------|
-| `cloud.account.id`        | `AccountId`        |
-| `cloud.availability_zone` | `AvailabilityZone` |
-| `cloud.platform`          | `aws_service`      |
-| `cloud.region`            | `Region`           |
-| `host.id`                 | `InstanceId`       |
-| `host.name`               | `host`             |
-| `host.type`               | `InstanceType`     |
-| `k8s.cluster.name`        | `Cluster`          |
-| `k8s.container.name`      | `container`        |
-| `k8s.daemonset.name`      | `daemonset`        |
-| `k8s.deployment.name`     | `deployment`       |
-| `k8s.namespace.name`      | `namespace`        |
-| `k8s.node.name`           | `node`             |
-| `k8s.service.name`        | `service`          |
-| `k8s.pod.hostname`        | `host`             |
-| `k8s.pod.name`            | `pod`              |
-| `k8s.pod.uid`             | `pod_id`           |
-| `k8s.replicaset.name`     | `replicaset`       |
-| `k8s.statefulset.name`    | `statefulset`      |
-| `service.name`            | `service`          |
-| `log.file.path_resolved`  | `_sourceName`      |
+| OTC key name              | Sumo Logic key name |
+|---------------------------|---------------------|
+| `cloud.account.id`        | `AccountId`         |
+| `cloud.availability_zone` | `AvailabilityZone`  |
+| `cloud.platform`          | `aws_service`       |
+| `cloud.region`            | `Region`            |
+| `host.id`                 | `InstanceId`        |
+| `host.name`               | `host`              |
+| `host.type`               | `InstanceType`      |
+| `k8s.cluster.name`        | `Cluster`           |
+| `k8s.container.name`      | `container`         |
+| `k8s.daemonset.name`      | `daemonset`         |
+| `k8s.deployment.name`     | `deployment`        |
+| `k8s.namespace.name`      | `namespace`         |
+| `k8s.node.name`           | `node`              |
+| `k8s.service.name`        | `service`           |
+| `k8s.pod.hostname`        | `host`              |
+| `k8s.pod.name`            | `pod`               |
+| `k8s.pod.uid`             | `pod_id`            |
+| `k8s.replicaset.name`     | `replicaset`        |
+| `k8s.statefulset.name`    | `statefulset`       |
+| `service.name`            | `service`           |
+| `log.file.path_resolved`  | `_sourceName`       |
 
 ## Source Templates
 

--- a/pkg/exporter/sumologicexporter/config.go
+++ b/pkg/exporter/sumologicexporter/config.go
@@ -55,6 +55,7 @@ type Config struct {
 	// The format of traces you will be sending, currently only otlp format is supported
 	TraceFormat TraceFormatType `mapstructure:"trace_format"`
 
+	// DEPRECATED
 	// Specifies whether attributes should be translated
 	// from OpenTelemetry standard to Sumo conventions (for example `cloud.account.id` => `accountId`
 	// `k8s.pod.name` => `pod` etc).

--- a/pkg/exporter/sumologicexporter/exporter.go
+++ b/pkg/exporter/sumologicexporter/exporter.go
@@ -41,6 +41,13 @@ const (
 	tracesDataUrl  = "/api/v1/collector/traces"
 )
 
+const deprecationBanner = `
+***********************************************************************************************************************************************************
+***    Translating attributes is deprecated and is going to be dropped soon. Please see the migration document:                                  	    ***
+***    https://github.com/SumoLogic/sumologic-otel-collector/blob/main/docs/Upgrading.md#sumologic-exporter-drop-support-for-translating-attributes.    ***
+***********************************************************************************************************************************************************
+`
+
 type sumologicexporter struct {
 	sources sourceFormats
 	config  *Config
@@ -64,6 +71,8 @@ type sumologicexporter struct {
 
 func initExporter(cfg *Config, createSettings component.ExporterCreateSettings) (*sumologicexporter, error) {
 	if cfg.TranslateAttributes {
+		createSettings.Logger.Warn(deprecationBanner)
+
 		cfg.SourceCategory = translateConfigValue(cfg.SourceCategory)
 		cfg.SourceHost = translateConfigValue(cfg.SourceHost)
 		cfg.SourceName = translateConfigValue(cfg.SourceName)

--- a/pkg/processor/sumologicschemaprocessor/README.md
+++ b/pkg/processor/sumologicschemaprocessor/README.md
@@ -13,10 +13,16 @@ Supported pipeline types: logs, metrics, traces.
 
 ```yaml
 processors:
-  sumologicschema:
+  sumologic_schema:
     # Defines whether the `cloud.namespace` resource attribute should be added.
     # default = true
     add_cloud_namespace: {true,false}
+
+    # Defines whether attributes should be translated
+    # from OpenTelemetry to Sumo Logic conventions;
+    # see "Attribute translation" documentation chapter from this document.
+    # default = true
+    translate_attributes: {true,false}
 ```
 
 ## Features
@@ -42,3 +48,44 @@ and if found, adds the corresponding `cloud.namespace` resource attribute.
 If the `cloud.platform` resource attribute is not found or has a value that is not in the table, nothing is added.
 
 [opentelemetry_cloud_provider_attribute]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/resource/semantic_conventions/cloud.md
+
+### Attribute translation
+
+Attribute translation changes some of the attribute keys from OpenTelemetry convention to Sumo Logic convention.
+For example, OpenTelemetry convention for the attribute containing Kubernetes pod name is `k8s.pod.name`,
+but Sumo Logic expects it to be in attribute named `pod`.
+
+If attribute with target name eg. `pod` already exists,
+translation is not being done for corresponding attribute (`k8s.pod.name` in this example).
+
+This feature is turned on by default.
+To turn it off, set the `translate_attributes` configuration option to `false`.
+Note that this may cause some of Sumo Logic apps, built-in dashboards to not work correctly.
+
+**Note**: the attributes are **not** translated for traces.
+
+Below is a list of all attribute keys that are being translated.
+
+| OTC key name              | Sumo Logic key name |
+|---------------------------|---------------------|
+| `cloud.account.id`        | `AccountId`         |
+| `cloud.availability_zone` | `AvailabilityZone`  |
+| `cloud.platform`          | `aws_service`       |
+| `cloud.region`            | `Region`            |
+| `host.id`                 | `InstanceId`        |
+| `host.name`               | `host`              |
+| `host.type`               | `InstanceType`      |
+| `k8s.cluster.name`        | `Cluster`           |
+| `k8s.container.name`      | `container`         |
+| `k8s.daemonset.name`      | `daemonset`         |
+| `k8s.deployment.name`     | `deployment`        |
+| `k8s.namespace.name`      | `namespace`         |
+| `k8s.node.name`           | `node`              |
+| `k8s.service.name`        | `service`           |
+| `k8s.pod.hostname`        | `host`              |
+| `k8s.pod.name`            | `pod`               |
+| `k8s.pod.uid`             | `pod_id`            |
+| `k8s.replicaset.name`     | `replicaset`        |
+| `k8s.statefulset.name`    | `statefulset`       |
+| `service.name`            | `service`           |
+| `log.file.path_resolved`  | `_sourceName`       |

--- a/pkg/processor/sumologicschemaprocessor/config.go
+++ b/pkg/processor/sumologicschemaprocessor/config.go
@@ -19,11 +19,13 @@ import "go.opentelemetry.io/collector/config"
 type Config struct {
 	config.ProcessorSettings `mapstructure:",squash"`
 
-	AddCloudNamespace bool `mapstructure:"add_cloud_namespace"`
+	AddCloudNamespace   bool `mapstructure:"add_cloud_namespace"`
+	TranslateAttributes bool `mapstructure:"translate_attributes"`
 }
 
 const (
-	defaultAddCloudNamespace = true
+	defaultAddCloudNamespace   = true
+	defaultTranslateAttributes = true
 )
 
 // Ensure the Config struct satisfies the config.Processor interface.
@@ -31,8 +33,9 @@ var _ config.Processor = (*Config)(nil)
 
 func createDefaultConfig() config.Processor {
 	return &Config{
-		ProcessorSettings: config.NewProcessorSettings(config.NewComponentID(typeStr)),
-		AddCloudNamespace: defaultAddCloudNamespace,
+		ProcessorSettings:   config.NewProcessorSettings(config.NewComponentID(typeStr)),
+		AddCloudNamespace:   defaultAddCloudNamespace,
+		TranslateAttributes: defaultTranslateAttributes,
 	}
 }
 

--- a/pkg/processor/sumologicschemaprocessor/config_test.go
+++ b/pkg/processor/sumologicschemaprocessor/config_test.go
@@ -43,7 +43,17 @@ func TestLoadConfig(t *testing.T) {
 
 	assert.Equal(t, p1,
 		&Config{
-			ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "disabled-cloud-namespace")),
-			AddCloudNamespace: false,
+			ProcessorSettings:   config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "disabled-cloud-namespace")),
+			AddCloudNamespace:   false,
+			TranslateAttributes: true,
+		})
+
+	p2 := cfg.Processors[config.NewComponentIDWithName(typeStr, "disabled-attribute-translation")]
+
+	assert.Equal(t, p2,
+		&Config{
+			ProcessorSettings:   config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "disabled-attribute-translation")),
+			AddCloudNamespace:   true,
+			TranslateAttributes: false,
 		})
 }

--- a/pkg/processor/sumologicschemaprocessor/testdata/config.yaml
+++ b/pkg/processor/sumologicschemaprocessor/testdata/config.yaml
@@ -5,6 +5,8 @@ processors:
   sumologic_schema:
   sumologic_schema/disabled-cloud-namespace:
     add_cloud_namespace: false
+  sumologic_schema/disabled-attribute-translation:
+    translate_attributes: false
 
 exporters:
   nop:

--- a/pkg/processor/sumologicschemaprocessor/translate_attributes_processor.go
+++ b/pkg/processor/sumologicschemaprocessor/translate_attributes_processor.go
@@ -1,0 +1,106 @@
+// Copyright 2022 Sumo Logic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sumologicschemaprocessor
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// translateAttributesProcessor translates attribute names from OpenTelemetry to Sumo Logic convention
+type translateAttributesProcessor struct {
+	shouldTranslate bool
+}
+
+// attributeTranslations maps OpenTelemetry attribute names to Sumo Logic attribute names
+var attributeTranslations = map[string]string{
+	"cloud.account.id":        "AccountId",
+	"cloud.availability_zone": "AvailabilityZone",
+	"cloud.platform":          "aws_service",
+	"cloud.region":            "Region",
+	"host.id":                 "InstanceId",
+	"host.name":               "host",
+	"host.type":               "InstanceType",
+	"k8s.cluster.name":        "Cluster",
+	"k8s.container.name":      "container",
+	"k8s.daemonset.name":      "daemonset",
+	"k8s.deployment.name":     "deployment",
+	"k8s.namespace.name":      "namespace",
+	"k8s.node.name":           "node",
+	"k8s.service.name":        "service",
+	"k8s.pod.hostname":        "host",
+	"k8s.pod.name":            "pod",
+	"k8s.pod.uid":             "pod_id",
+	"k8s.replicaset.name":     "replicaset",
+	"k8s.statefulset.name":    "statefulset",
+	"service.name":            "service",
+	"log.file.path_resolved":  "_sourceName",
+}
+
+func newTranslateAttributesProcessor(shouldTranslate bool) (*translateAttributesProcessor, error) {
+	return &translateAttributesProcessor{
+		shouldTranslate: shouldTranslate,
+	}, nil
+}
+
+func (proc *translateAttributesProcessor) processLogs(logs plog.Logs) (plog.Logs, error) {
+	if proc.shouldTranslate {
+		for i := 0; i < logs.ResourceLogs().Len(); i++ {
+			translateAttributes(logs.ResourceLogs().At(i).Resource().Attributes())
+		}
+	}
+
+	return logs, nil
+}
+
+func (proc *translateAttributesProcessor) processMetrics(metrics pmetric.Metrics) (pmetric.Metrics, error) {
+	if proc.shouldTranslate {
+		for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
+			translateAttributes(metrics.ResourceMetrics().At(i).Resource().Attributes())
+		}
+	}
+
+	return metrics, nil
+}
+
+func (proc *translateAttributesProcessor) processTraces(traces ptrace.Traces) (ptrace.Traces, error) {
+	// No-op. Traces should not be translated.
+	return traces, nil
+}
+
+func translateAttributes(attributes pcommon.Map) {
+	result := pcommon.NewMap()
+	result.EnsureCapacity(attributes.Len())
+
+	attributes.Range(func(otKey string, value pcommon.Value) bool {
+		if sumoKey, ok := attributeTranslations[otKey]; ok {
+			// Only insert if it doesn't exist yet to prevent overwriting.
+			// We have to do it this way since the final return value is not
+			// ready yet to rely on .Insert() not overwriting.
+			if _, exists := attributes.Get(sumoKey); !exists {
+				result.Insert(sumoKey, value)
+			} else {
+				result.Insert(otKey, value)
+			}
+		} else {
+			result.Insert(otKey, value)
+		}
+		return true
+	})
+
+	result.CopyTo(attributes)
+}

--- a/pkg/processor/sumologicschemaprocessor/translate_attributes_processor_test.go
+++ b/pkg/processor/sumologicschemaprocessor/translate_attributes_processor_test.go
@@ -1,0 +1,156 @@
+// Copyright 2022 Sumo Logic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sumologicschemaprocessor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func TestTranslateAttributes(t *testing.T) {
+	attributes := pcommon.NewMap()
+	attributes.InsertString("host.name", "testing-host")
+	attributes.InsertString("host.id", "my-host-id")
+	attributes.InsertString("host.type", "my-host-type")
+	attributes.InsertString("k8s.cluster.name", "testing-cluster")
+	attributes.InsertString("k8s.deployment.name", "my-deployment-name")
+	attributes.InsertString("k8s.namespace.name", "my-namespace-name")
+	attributes.InsertString("k8s.service.name", "my-service-name, other-service")
+	attributes.InsertString("cloud.account.id", "my-account-id")
+	attributes.InsertString("cloud.availability_zone", "my-zone")
+	attributes.InsertString("cloud.region", "my-region")
+	require.Equal(t, 10, attributes.Len())
+
+	translateAttributes(attributes)
+
+	assert.Equal(t, 10, attributes.Len())
+	assertAttribute(t, attributes, "host", "testing-host")
+	assertAttribute(t, attributes, "host.name", "")
+	assertAttribute(t, attributes, "AccountId", "my-account-id")
+	assertAttribute(t, attributes, "cloud.account.id", "")
+	assertAttribute(t, attributes, "AvailabilityZone", "my-zone")
+	assertAttribute(t, attributes, "clout.availability_zone", "")
+	assertAttribute(t, attributes, "Region", "my-region")
+	assertAttribute(t, attributes, "cloud.region", "")
+	assertAttribute(t, attributes, "InstanceId", "my-host-id")
+	assertAttribute(t, attributes, "host.id", "")
+	assertAttribute(t, attributes, "InstanceType", "my-host-type")
+	assertAttribute(t, attributes, "host.type", "")
+	assertAttribute(t, attributes, "Cluster", "testing-cluster")
+	assertAttribute(t, attributes, "k8s.cluster.name", "")
+	assertAttribute(t, attributes, "deployment", "my-deployment-name")
+	assertAttribute(t, attributes, "k8s.deployment.name", "")
+	assertAttribute(t, attributes, "namespace", "my-namespace-name")
+	assertAttribute(t, attributes, "k8s.namespace.name", "")
+	assertAttribute(t, attributes, "service", "my-service-name, other-service")
+	assertAttribute(t, attributes, "k8s.service.name", "")
+}
+
+func TestTranslateAttributesDoesNothingWhenAttributeDoesNotExist(t *testing.T) {
+	attributes := pcommon.NewMap()
+	require.Equal(t, 0, attributes.Len())
+
+	translateAttributes(attributes)
+
+	assert.Equal(t, 0, attributes.Len())
+	assertAttribute(t, attributes, "host", "")
+}
+
+func TestTranslateAttributesLeavesOtherAttributesUnchanged(t *testing.T) {
+	attributes := pcommon.NewMap()
+	attributes.InsertString("one", "one1")
+	attributes.InsertString("host.name", "host1")
+	attributes.InsertString("three", "three1")
+	require.Equal(t, 3, attributes.Len())
+
+	translateAttributes(attributes)
+
+	assert.Equal(t, 3, attributes.Len())
+	assertAttribute(t, attributes, "one", "one1")
+	assertAttribute(t, attributes, "host", "host1")
+	assertAttribute(t, attributes, "three", "three1")
+}
+
+func TestTranslateAttributesDoesNotOverwriteExistingAttribute(t *testing.T) {
+	attributes := pcommon.NewMap()
+	attributes.InsertString("host", "host1")
+	attributes.InsertString("host.name", "hostname1")
+	require.Equal(t, 2, attributes.Len())
+
+	translateAttributes(attributes)
+
+	assert.Equal(t, 2, attributes.Len())
+	assertAttribute(t, attributes, "host", "host1")
+	assertAttribute(t, attributes, "host.name", "hostname1")
+}
+
+func TestTranslateAttributesDoesNotOverwriteMultipleExistingAttributes(t *testing.T) {
+	// Note: Current implementation of pcommon.Map does not allow to insert duplicate keys.
+	// See https://cloud-native.slack.com/archives/C01N5UCHTEH/p1624020829067500
+	attributes := pcommon.NewMap()
+	attributes.InsertString("host", "host1")
+	attributes.InsertString("host", "host2")
+	require.Equal(t, 1, attributes.Len())
+	attributes.InsertString("host.name", "hostname1")
+	require.Equal(t, 2, attributes.Len())
+
+	translateAttributes(attributes)
+
+	assert.Equal(t, 2, attributes.Len())
+	assertAttribute(t, attributes, "host", "host1")
+	assertAttribute(t, attributes, "host.name", "hostname1")
+}
+
+func assertAttribute(t *testing.T, metadata pcommon.Map, attributeName string, expectedValue string) {
+	value, exists := metadata.Get(attributeName)
+
+	if expectedValue == "" {
+		assert.False(t, exists)
+	} else {
+		assert.True(t, exists)
+		assert.Equal(t, expectedValue, value.StringVal())
+
+	}
+}
+
+var (
+	bench_pdata_attributes = map[string]interface{}{
+		"host.name":               pcommon.NewValueString("testing-host"),
+		"host.id":                 pcommon.NewValueString("my-host-id"),
+		"host.type":               pcommon.NewValueString("my-host-type"),
+		"k8s.cluster.name":        pcommon.NewValueString("testing-cluster"),
+		"k8s.deployment.name":     pcommon.NewValueString("my-deployment-name"),
+		"k8s.namespace.name":      pcommon.NewValueString("my-namespace-name"),
+		"k8s.service.name":        pcommon.NewValueString("my-service-name"),
+		"cloud.account.id":        pcommon.NewValueString("my-account-id"),
+		"cloud.availability_zone": pcommon.NewValueString("my-zone"),
+		"cloud.region":            pcommon.NewValueString("my-region"),
+		"abc":                     pcommon.NewValueString("abc"),
+		"def":                     pcommon.NewValueString("def"),
+		"xyz":                     pcommon.NewValueString("xyz"),
+		"jkl":                     pcommon.NewValueString("jkl"),
+		"dummy":                   pcommon.NewValueString("dummy"),
+	}
+	attributes = pcommon.NewMapFromRaw(bench_pdata_attributes)
+)
+
+func BenchmarkTranslateAttributes(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		translateAttributes(attributes)
+	}
+}


### PR DESCRIPTION
Fixes #649 

The `sumologic` exporter modifies data it gets by translating attributes from OpenTelemetry convention to Sumo convention. This PR moves this logic to the `sumologic schema` processor.

Technically this is ready for review, but it might have not been tested properly yet, so I'm marking this as a draft. 