### PR TITLE
feat(sumologicexporter): deprecate setting source headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.56.0-sumo-0...main
+This release deprecates the following features, which will be removed in `v0.60.0`:
+
+- feat(sumologicexporter): deprecate source templates ([upgrade guide][upgrade_guide_v0_57_0_deprecate_source_templates])
+
+### Changed
+
+- feat(sumologicexporter): deprecate source templates ([upgrade guide][upgrade_guide_v0_57_0_deprecate_source_templates])
+
+[upgrade_guide_v0_57_0_deprecate_source_templates]: ./docs/Upgrading.md#sumologic-exporter-drop-support-for-source-headers
 
 ## [v0.56.0-sumo-0]
 

--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -1,6 +1,7 @@
 # Upgrading
 
 - [Unreleased](#unreleased)
+  - [`sumologic` exporter: drop support for source templates](#sumologic-exporter-drop-support-for-source-headers)
 - [Upgrading to v0.56.0-sumo-0](#upgrading-to-v0560-sumo-0)
   - [`sumologic` exporter: drop support for translating attributes](#sumologic-exporter-drop-support-for-translating-attributes)
   - [`sumologic` exporter: drop support for translating Telegraf metric names](#sumologic-exporter-drop-support-for-translating-telegraf-metric-names)
@@ -20,6 +21,21 @@
     - [Moving record-level attributes used for metadata to the resource level](#moving-record-level-attributes-used-for-metadata-to-the-resource-level)
 
 ## Unreleased
+
+### `sumologic` exporter: drop support for source headers
+
+Since the exporter should not modify the data, setting the source headers is no longer supported in the `sumologic` exporter.
+This deprecation includes deprecating the source templates.
+
+If you need to set the `_source*` headers in the collector, use the `transform` processor, for example:
+
+```yaml
+processors:
+  # ...
+  transform:
+    logs:
+      - set(attributes["_sourceHost"], "source_host")
+```
 
 ## Upgrading to v0.56.0-sumo-0
 

--- a/pkg/exporter/sumologicexporter/README.md
+++ b/pkg/exporter/sumologicexporter/README.md
@@ -45,12 +45,15 @@ exporters:
     # For below described source related configuration,
     # please refer to "Source templates" documentation chapter from this document.
 
+    # DEPRECATED
     # desired source category, useful if you want to override the source category
     # configured for the source.
     source_category: <source_category>
+    # DEPRECATED
     # desired source name, useful if you want to override the source name
     # configured for the source.
     source_name: <source_name>
+    # DEPRECATED
     # desired host name, useful if you want to override the source host
     # configured for the source.
     source_host: <source_host>

--- a/pkg/exporter/sumologicexporter/config.go
+++ b/pkg/exporter/sumologicexporter/config.go
@@ -76,15 +76,18 @@ type Config struct {
 	DropRoutingAttribute string `mapstructure:"routing_atttribute_to_drop"`
 
 	// Sumo specific options
+	// DEPRECATED
 	// Desired source category.
 	// Useful if you want to override the source category configured for the source.
 	// Placeholders `%{attr_name}` will be replaced with attribute value for attr_name.
 	SourceCategory string `mapstructure:"source_category"`
 	// Desired source name.
+	// DEPRECATED
 	// Useful if you want to override the source name configured for the source.
 	// Placeholders `%{attr_name}` will be replaced with attribute value for attr_name.
 	SourceName string `mapstructure:"source_name"`
 	// Desired host name.
+	// DEPRECATED
 	// Useful if you want to override the source host configured for the source.
 	// Placeholders `%{attr_name}` will be replaced with attribute value for attr_name.
 	SourceHost string `mapstructure:"source_host"`

--- a/pkg/exporter/sumologicexporter/exporter.go
+++ b/pkg/exporter/sumologicexporter/exporter.go
@@ -43,7 +43,7 @@ const (
 
 const translationDeprecationBanner = `
 ***********************************************************************************************************************************************************
-***    Translating attributes is deprecated and is going to be dropped soon. Please see the migration document:                                  	    ***
+***    Translating attributes is deprecated and is going to be dropped soon. Please see the migration document:                                         ***
 ***    https://github.com/SumoLogic/sumologic-otel-collector/blob/main/docs/Upgrading.md#sumologic-exporter-drop-support-for-translating-attributes.    ***
 ***********************************************************************************************************************************************************
 `
@@ -52,6 +52,13 @@ const telegrafTranslationDeprecationBanner = `
 ***********************************************************************************************************************************************************
 ***    Translating Telegraf metric names is deprecated and is going to be dropped soon. Please see the migration document:                              ***
 ***    https://github.com/SumoLogic/sumologic-otel-collector/blob/main/docs/Upgrading.md#sumologic-exporter-drop-support-for-translating-attributes.    ***
+***********************************************************************************************************************************************************
+`
+
+const sourceTemplatesDeprecationBanner = `
+***********************************************************************************************************************************************************
+***    Adding source headers is deprecated and is going to be dropped soon. Please see the migration document:                                          ***
+***    https://github.com/SumoLogic/sumologic-otel-collector/blob/main/docs/Upgrading.md#sumologic-exporter-drop-support-for-source-headers.            ***
 ***********************************************************************************************************************************************************
 `
 
@@ -87,6 +94,10 @@ func initExporter(cfg *Config, createSettings component.ExporterCreateSettings) 
 
 	if cfg.TranslateTelegrafMetrics {
 		createSettings.Logger.Warn(telegrafTranslationDeprecationBanner)
+	}
+
+	if cfg.SourceCategory != "" || cfg.SourceHost != "" || cfg.SourceName != "" {
+		createSettings.Logger.Warn(sourceTemplatesDeprecationBanner)
 	}
 
 	sfs, err := newSourceFormats(cfg)


### PR DESCRIPTION
Ref: #255 (this PR does not resolve this yet, since it needs to be removed)

The feature of setting the source headers (and source templates) is now deprecated and is going to be removed in v0.60.0.