### PR TITLE
fix: CI for FIPS builds

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -134,7 +134,7 @@ jobs:
     strategy:
       matrix:
         go: [ '1.18.2b7' ]
-        arch_os: [ 'linux_amd64' , 'linux_arm64' ]
+        arch_os: [ 'linux_amd64']
     steps:
       - uses: actions/checkout@v3
 
@@ -170,7 +170,7 @@ jobs:
         working-directory: ./otelcolbuilder
 
       - name: Build
-        run: make otelcol-sumo-${{matrix.arch_os}} FIPS_SUFFIX="-fips"
+        run: make otelcol-sumo-${{matrix.arch_os}} FIPS_SUFFIX="-fips" CGO_ENABLED=1
         working-directory: ./otelcolbuilder
 
       - name: Show included modules
@@ -180,77 +180,11 @@ jobs:
           grep -E "/(receiver|exporter|processor|extension)/" | \
           tee otelcol-sumo-fips-${{matrix.arch_os}}_modules.txt
 
-      - name: Store binary as action artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: otelcol-sumo-fips-${{matrix.arch_os}}
-          path: ./otelcolbuilder/cmd/otelcol-sumo-fips-${{matrix.arch_os}}
-          if-no-files-found: error
-
-      - name: Store list of included modules as action artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: otelcol-sumo-fips-${{matrix.arch_os}}_modules.txt
-          path: ./otelcolbuilder/cmd/otelcol-sumo-fips-${{matrix.arch_os}}_modules.txt
-          if-no-files-found: error
-
-  # pipeline to build FIPS compliance binary on Go+BoringCrypto for darwin
-  build-fips-darwin:
-    name: Build
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        go: [ '1.18.2b7' ]
-        arch_os: [ 'darwin_amd64' , 'darwin_arm64']
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Fetch current branch
-        run: ./ci/fetch_current_branch.sh
-
-      - name: Build and install Go+BoringCrypto
-        run: |
-          wget https://go-boringcrypto.storage.googleapis.com/go${{ matrix.go }}.src.tar.gz \
-            && tar -xf go${{ matrix.go }}.src.tar.gz \
-            && cd go/src/ \
-            && GOROOT_BOOTSTRAP=/usr ./make.bash \
-            && cd .. \
-            && sudo rm -rf /usr/local/bin/go \
-            && sudo cp bin/go* /usr/local/bin/
-
-      - name: Check go version
-        run: go version
-
-      # As described in
-      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
-      - uses: actions/cache@v3
-        with:
-          path: |
-            /home/runner/go/pkg/mod
-            /home/runner/.cache/go-build
-            /Users/runner/go/pkg/mod
-            /Users/runner/Library/Caches/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Add opentelemetry-collector-builder installation dir to PATH
-        run: echo "$HOME/bin" >> $GITHUB_PATH
-
-      - name: Install opentelemetry-collector-builder
-        run: make install-builder
-        working-directory: ./otelcolbuilder
-
-      - name: Build
-        run: make otelcol-sumo-${{matrix.arch_os}} FIPS_SUFFIX="-fips"
-        working-directory: ./otelcolbuilder
-
-      - name: Show included modules
+      - name: Show BoringSSL symbols
         working-directory: ./otelcolbuilder/cmd
         run: |
-          go version -m otelcol-sumo-fips-${{matrix.arch_os}} | \
-          grep -E "/(receiver|exporter|processor|extension)/" | \
-          tee otelcol-sumo-fips-${{matrix.arch_os}}_modules.txt
+          go tool nm otelcol-sumo-fips-${{matrix.arch_os}} | \
+          grep "_Cfunc__goboringcrypto_"
 
       - name: Store binary as action artifact
         uses: actions/upload-artifact@v3
@@ -302,11 +236,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEV }}
 
       - name: Download FIPS binary action artifact from build phase
+        if: matrix.arch_os == 'linux_amd64'
         uses: actions/download-artifact@v3
         with:
           name: otelcol-sumo-fips-${{matrix.arch_os}}
 
       - name: Build and push FIPS image to Open Source ECR
+        if: matrix.arch_os == 'linux_amd64'
         run: |
           cp otelcol-sumo-fips-${{ matrix.arch_os }} otelcol-sumo
           make build-push-container-multiplatform-dev-fips \
@@ -361,7 +297,7 @@ jobs:
         run: |
           make push-container-manifest-dev \
             BUILD_TAG=${{ steps.extract_tag.outputs.tag }}-fips \
-            PLATFORMS="linux/amd64 linux/arm64" \
+            PLATFORMS="linux/amd64" \
             LATEST_TAG_FIPS_SUFFIX="-fips"
 
       - name: Push joint container manifest for all platforms to Open Source ECR

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -354,7 +354,7 @@ jobs:
     strategy:
       matrix:
         go: [ '1.18.2b7' ]
-        arch_os: [ 'linux_amd64' , 'linux_arm64' ]
+        arch_os: [ 'linux_amd64']
 
     steps:
       - uses: actions/checkout@v3
@@ -409,7 +409,7 @@ jobs:
 
       - name: Build
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: make otelcol-sumo-${{matrix.arch_os}} FIPS_SUFFIX="-fips"
+        run: make otelcol-sumo-${{matrix.arch_os}} FIPS_SUFFIX="-fips" CGO_ENABLED=1
         working-directory: ./otelcolbuilder
 
       - name: Show included modules
@@ -419,88 +419,11 @@ jobs:
           go version -m otelcol-sumo-fips-${{matrix.arch_os}} | \
           grep -E "/(receiver|exporter|processor|extension)/"
 
-      - name: Store binary as action artifact
-        if: steps.changed-files.outputs.any_changed == 'true'
-        uses: actions/upload-artifact@v3
-        with:
-          name: otelcol-sumo-fips-${{matrix.arch_os}}
-          path: ./otelcolbuilder/cmd/otelcol-sumo-fips-${{matrix.arch_os}}
-          if-no-files-found: error
-
-  # pipeline to build FIPS compliance binary on Go+BoringCrypto for darwin
-  build-fips-darwin:
-    name: Build
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        go: [ '1.18.2b7' ]
-        arch_os: [ 'darwin_amd64' , 'darwin_arm64']
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Fetch current branch
-        run: ./ci/fetch_current_branch.sh
-
-      - name: Check if build related files changed
-        id: changed-files
-        uses: tj-actions/changed-files@v11
-        with:
-          files: |
-            otelcolbuilder/.gon_config.json
-            go.mod
-            go.sum
-            \.(go|yaml|yml)$
-            Makefile
-            Makefile.common
-            Dockerfile.*
-
-      - name: Build and install Go+BoringCrypto
-        run: |
-          wget https://go-boringcrypto.storage.googleapis.com/go${{ matrix.go }}.src.tar.gz \
-            && tar -xf go${{ matrix.go }}.src.tar.gz \
-            && cd go/src/ \
-            && GOROOT_BOOTSTRAP=/usr ./make.bash \
-            && cd .. \
-            && sudo rm -rf /usr/local/bin/go \
-            && sudo cp bin/go* /usr/local/bin/
-
-      - name: Check go version
-        run: go version
-
-      # As described in
-      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
-      - uses: actions/cache@v3
-        if: steps.changed-files.outputs.any_changed == 'true'
-        with:
-          path: |
-            /home/runner/go/pkg/mod
-            /home/runner/.cache/go-build
-            /Users/runner/go/pkg/mod
-            /Users/runner/Library/Caches/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Add opentelemetry-collector-builder installation dir to PATH
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: echo "$HOME/bin" >> $GITHUB_PATH
-
-      - name: Install opentelemetry-collector-builder
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: make install-builder
-        working-directory: ./otelcolbuilder
-
-      - name: Build
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: make otelcol-sumo-${{matrix.arch_os}} FIPS_SUFFIX="-fips"
-        working-directory: ./otelcolbuilder
-
-      - name: Show included modules
-        if: steps.changed-files.outputs.any_changed == 'true'
+      - name: Show BoringSSL symbols
         working-directory: ./otelcolbuilder/cmd
         run: |
-          go version -m otelcol-sumo-fips-${{matrix.arch_os}} | \
-          grep -E "/(receiver|exporter|processor|extension)/"
+          go tool nm otelcol-sumo-fips-${{matrix.arch_os}} | \
+          grep "_Cfunc__goboringcrypto_"
 
       - name: Store binary as action artifact
         if: steps.changed-files.outputs.any_changed == 'true'
@@ -566,19 +489,19 @@ jobs:
         run: make test-built-image
 
       - name: Download FIPS binary action artifact from build phase
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: steps.changed-files.outputs.any_changed == 'true' && matrix.arch_os == 'linux_amd64'
         uses: actions/download-artifact@v3
         with:
           name: otelcol-sumo-fips-${{matrix.arch_os}}
           path: artifacts/
 
       - name: Build the FIPS container image
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: steps.changed-files.outputs.any_changed == 'true' && matrix.arch_os == 'linux_amd64'
         run: |
           cp artifacts/otelcol-sumo-fips-${{matrix.arch_os}} otelcol-sumo
           make build-container-multiplatform \
             PLATFORM=${{ matrix.arch_os }} LATEST_TAG_FIPS_SUFFIX="-fips"
 
       - name: Test built FIPS image
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: steps.changed-files.outputs.any_changed == 'true' && matrix.arch_os == 'linux_amd64'
         run: make test-built-image BUILD_TAG="latest-fips"

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -206,7 +206,7 @@ jobs:
     strategy:
       matrix:
         go: [ '1.18.2b7' ]
-        arch_os: [ 'linux_amd64' , 'linux_arm64' ]
+        arch_os: [ 'linux_amd64' ]
     steps:
       - uses: actions/checkout@v3
 
@@ -247,7 +247,7 @@ jobs:
         run: make prepare-tag TAG=${{ steps.extract_tag.outputs.tag }}
 
       - name: Build
-        run: make otelcol-sumo-${{matrix.arch_os}} FIPS_SUFFIX="-fips"
+        run: make otelcol-sumo-${{matrix.arch_os}} FIPS_SUFFIX="-fips" CGO_ENABLED=1
         working-directory: ./otelcolbuilder
 
       - name: Set filename
@@ -258,114 +258,11 @@ jobs:
         run: cp otelcol-sumo-fips-${{matrix.arch_os}} ${{ steps.set_filename.outputs.filename }}
         working-directory: ./otelcolbuilder/cmd
 
-      - name: Show included modules
+      - name: Show BoringSSL symbols
         working-directory: ./otelcolbuilder/cmd
         run: |
-          go version -m ${{ steps.set_filename.outputs.filename }} | \
-          grep -E "/(receiver|exporter|processor|extension)/" | \
-          tee otelcol-sumo-fips-${{matrix.arch_os}}_modules.txt
-
-      - name: Store binary as action artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{matrix.arch_os}}
-          path: ./otelcolbuilder/cmd/${{ steps.set_filename.outputs.filename }}
-          if-no-files-found: error
-
-  # pipeline to build FIPS compliance binary on Go+BoringCrypto on darwin
-  build-fips-darwin:
-    name: Build
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        go: [ '1.18.2b7' ]
-        arch_os: [ 'darwin_amd64' , 'darwin_arm64' ]
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Fetch current branch
-        run: ./ci/fetch_current_branch.sh
-
-      - name: Build and install Go+BoringCrypto
-        run: |
-          wget https://go-boringcrypto.storage.googleapis.com/go${{ matrix.go }}.src.tar.gz \
-            && tar -xf go${{ matrix.go }}.src.tar.gz \
-            && cd go/src/ \
-            && GOROOT_BOOTSTRAP=/usr ./make.bash \
-            && cd .. \
-            && sudo rm -rf /usr/local/bin/go \
-            && sudo cp bin/go* /usr/local/bin/
-
-      - name: Check go version
-        run: go version
-
-      # As described in
-      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
-      - uses: actions/cache@v3
-        with:
-          path: |
-            /Users/runner/go/pkg/mod
-            /Users/runner/Library/Caches/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Extract tag
-        id: extract_tag
-        run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/v})"
-
-      - name: Add opentelemetry-collector-builder installation dir to PATH
-        run: echo "$HOME/bin" >> $GITHUB_PATH
-
-      - name: Install opentelemetry-collector-builder
-        run: make install-builder
-        working-directory: ./otelcolbuilder
-
-      - name: Prepare tags in otelcolbuilder's config
-        run: make prepare-tag TAG=${{ steps.extract_tag.outputs.tag }}
-
-      - name: Build
-        run: make otelcol-sumo-${{matrix.arch_os}} FIPS_SUFFIX="-fips"
-        working-directory: ./otelcolbuilder
-
-      - name: Set filename
-        id: set_filename
-        run: echo "::set-output name=filename::$(echo otelcol-sumo-${{ steps.extract_tag.outputs.tag }}-fips-${{matrix.arch_os}})"
-
-      - name: Import Code-Signing Certificates
-        uses: Apple-Actions/import-codesign-certs@v1
-        with:
-          # The certificates in a PKCS12 file encoded as a base64 string
-          p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
-          # The password used to import the PKCS12 file.
-          p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
-
-      # NOTE: gon's brew tap (as many others) has stopped working for some reason.
-      # Related issue: https://github.com/mitchellh/gon/issues/56
-      # - name: Install gon via HomeBrew for code signing and app notarization
-      #   run: |
-      #     brew tap mitchellh/gon
-      #     brew install mitchellh/gon/gon
-
-      - name: Install gon for code signing and app notarization
-        run: |
-          curl -Lo gon.dmg https://github.com/mitchellh/gon/releases/download/v0.2.3/gon_macos.dmg
-          sudo hdiutil attach gon.dmg
-          cp /Volumes/gon/gon "$HOME/bin"
-
-      - name: Sign the mac binaries with Gon
-        env:
-          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
-        working-directory: ./otelcolbuilder/
-        run: make fips-${{matrix.arch_os}}-sign
-
-      - name: Rename .dmg to include tag in filename
-        run: cp otelcol-sumo-fips-${{matrix.arch_os}}.dmg ${{ steps.set_filename.outputs.filename }}.dmg
-        working-directory: ./otelcolbuilder/cmd
-
-      - name: Rename binary to include tag in filename
-        run: cp otelcol-sumo-fips-${{matrix.arch_os}} ${{ steps.set_filename.outputs.filename }}
-        working-directory: ./otelcolbuilder/cmd
+          go tool nm ${{ steps.set_filename.outputs.filename }} | \
+          grep "_Cfunc__goboringcrypto_"
 
       - name: Show included modules
         working-directory: ./otelcolbuilder/cmd
@@ -373,15 +270,6 @@ jobs:
           go version -m ${{ steps.set_filename.outputs.filename }} | \
           grep -E "/(receiver|exporter|processor|extension)/" | \
           tee otelcol-sumo-fips-${{matrix.arch_os}}_modules.txt
-
-      # Store binary and .dmg into pipeline artifacts after they have been signed
-
-      - name: Store .dmg as action artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{matrix.arch_os}}.dmg
-          path: ./otelcolbuilder/cmd/${{ steps.set_filename.outputs.filename }}.dmg
-          if-no-files-found: error
 
       - name: Store binary as action artifact
         uses: actions/upload-artifact@v3
@@ -440,6 +328,7 @@ jobs:
           path: artifacts/
 
       - name: Build and push FIPS image to Open Source ECR
+        if: matrix.arch_os == 'linux_amd64'
         run: |
           cp artifacts/${{ steps.set_filename_fips.outputs.filename_fips }} otelcol-sumo
           make build-push-container-multiplatform \
@@ -493,7 +382,7 @@ jobs:
         run: |
           make push-container-manifest \
             BUILD_TAG=${{ steps.extract_tag.outputs.tag }}-fips \
-            PLATFORMS="linux/amd64 linux/arm64" \
+            PLATFORMS="linux/amd64" \
             LATEST_TAG_FIPS_SUFFIX="-fips"
 
       - name: Push joint container manifest for all platforms to Open Source ECR
@@ -509,7 +398,6 @@ jobs:
       - build
       - build-darwin
       - build-fips
-      - build-fips-darwin
       - build-container-images
       - push-docker-manifest
     steps:

--- a/otelcolbuilder/Makefile
+++ b/otelcolbuilder/Makefile
@@ -23,6 +23,13 @@ else
 CGO_ENABLED ?= 0
 endif
 
+# We don't want to strip symbols for FIPS builds, as they're useful for verifying the build
+ifeq ($(FIPS_SUFFIX),"")
+LDFLAGS="-s -w"
+else
+LDFLAGS="-w"
+endif
+
 .PHONY: _install-bin
 _install-bin:
 	@mkdir -p /$(HOME)/bin
@@ -68,7 +75,7 @@ _gobuild:
 	(cd cmd && \
 		CGO_ENABLED=$(CGO_ENABLED) go build -v \
 		-tags enable_unstable \
-		-ldflags="-s -w" \
+		-ldflags=$(LDFLAGS) \
 		-trimpath \
 		-o ./$(BINARY_NAME) . \
 	)


### PR DESCRIPTION
Changes: 
* BoringCrypto is not FIPS-certified on MacOS, removed the build
* BoringCrypto is not FiPS-certified on ARM, removed the build
* CGO must be enabled, enabled it
* Added a step to show symbols to verify