### PR TITLE
feat(build): validate FIPS mode at build time and runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - feat: add glob config provider [#713]
+- feat(build): validate FIPS mode at build time and runtime [#693]
 
 ### Changed
 
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#713]: https://github.com/SumoLogic/sumologic-otel-collector/pull/713
 [#724]: https://github.com/SumoLogic/sumologic-otel-collector/pull/724
 [#746]: https://github.com/SumoLogic/sumologic-otel-collector/pull/746
+[#693]: https://github.com/SumoLogic/sumologic-otel-collector/pull/693
 
 ## [v0.57.2-sumo-0]
 

--- a/otelcolbuilder/.gitignore
+++ b/otelcolbuilder/.gitignore
@@ -3,3 +3,4 @@ cmd/*
 !cmd/testdata/
 !cmd/configprovider.go
 !cmd/main.go.patch
+!cmd/fips.go

--- a/otelcolbuilder/cmd/fips.go
+++ b/otelcolbuilder/cmd/fips.go
@@ -1,0 +1,20 @@
+//go:build boringcrypto
+
+package main
+
+import (
+	"log"
+
+	"crypto/boring"
+	_ "crypto/tls/fipsonly"
+)
+
+func init() {
+	attestFIPS()
+}
+
+func attestFIPS() {
+	if boring.Enabled() {
+		log.Print("Using BoringSSL and running in FIPS mode")
+	}
+}


### PR DESCRIPTION
This adds an additional file to the main package which:
1. Imports a module that is supposed to guarantee that we're always running in FIPS mode: https://go.googlesource.com/go/+/dev.boringcrypto/src/crypto/tls/fipsonly/fipsonly.go
2. Adds an init check for whether we're using BoringSSL and prints a log line if so

It's not clear whether this is a good enough solution to attest that we're running in FIPS mode. Maybe we should also add a test that tries to use a FIPS-incompatible cipher for TLS and fails?