### PR TITLE
fix(ci): add condition to check symbols only when build related files changed

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -420,6 +420,7 @@ jobs:
           grep -E "/(receiver|exporter|processor|extension)/"
 
       - name: Show BoringSSL symbols
+        if: steps.changed-files.outputs.any_changed == 'true'
         working-directory: ./otelcolbuilder/cmd
         run: |
           go tool nm otelcol-sumo-fips-${{matrix.arch_os}} | \


### PR DESCRIPTION
configuration in github workflow: https://github.com/SumoLogic/sumologic-otel-collector/blob/1fdc63b4bcdfd78a0cc5f927439e910ec3a92d57/.github/workflows/pull_requests.yml#L365 

related failure of github action: https://github.com/SumoLogic/sumologic-otel-collector/runs/7674560442?check_suite_focus=true