### PR TITLE
feat: define stability levels for components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This release deprecates the following features, which will be removed in `v0.60.
 ### Changed
 
 - feat(sumologicexporter): deprecate source templates ([upgrade guide][upgrade_guide_v0_57_0_deprecate_source_templates])
+- feat: define stability levels for components
 
 [upgrade_guide_v0_57_0_deprecate_source_templates]: ./docs/Upgrading.md#sumologic-exporter-drop-support-for-source-headers
 

--- a/pkg/exporter/sumologicexporter/README.md
+++ b/pkg/exporter/sumologicexporter/README.md
@@ -1,5 +1,7 @@
 # Sumo Logic Exporter
 
+**Stability level**: Beta
+
 This exporter supports sending logs and metrics data to [Sumo Logic](https://www.sumologic.com/).
 
 We strongly recommend to use this exporter with [sumologicextension](../../extension/sumologicextension/README.md).

--- a/pkg/exporter/sumologicexporter/factory.go
+++ b/pkg/exporter/sumologicexporter/factory.go
@@ -25,7 +25,8 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr = "sumologic"
+	typeStr        = "sumologic"
+	stabilityLevel = component.StabilityLevelBeta
 )
 
 // NewFactory returns a new factory for the sumologic exporter.
@@ -33,9 +34,9 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithLogsExporter(createLogsExporter),
-		component.WithMetricsExporter(createMetricsExporter),
-		component.WithTracesExporter(createTracesExporter),
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, stabilityLevel),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stabilityLevel),
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stabilityLevel),
 	)
 }
 

--- a/pkg/extension/sumologicextension/README.md
+++ b/pkg/extension/sumologicextension/README.md
@@ -1,5 +1,7 @@
 # Sumo Logic Extension
 
+**Stability level**: Beta
+
 This extension is to be used as part of Sumo Logic collector in conjuction with
 [`sumologicexporter`][sumologicexporter] in order to export telemetry data to
 [Sumo Logic][sumologic].

--- a/pkg/processor/cascadingfilterprocessor/README.md
+++ b/pkg/processor/cascadingfilterprocessor/README.md
@@ -1,5 +1,7 @@
 # Cascading Filter Processor
 
+**Stability level**: Beta
+
 Supported pipeline types: traces
 
 The Cascading Filter processor is a fork of [tailsamplingprocessor][tailsamplingprocessor] which allows for defining smart cascading filtering rules with preset limits.

--- a/pkg/processor/cascadingfilterprocessor/factory.go
+++ b/pkg/processor/cascadingfilterprocessor/factory.go
@@ -29,7 +29,8 @@ import (
 
 const (
 	// The value of "type" Cascading Filter in configuration.
-	typeStr = "cascading_filter"
+	typeStr        = "cascading_filter"
+	stabilityLevel = component.StabilityLevelBeta
 )
 
 func init() {
@@ -45,7 +46,7 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessor(createTraceProcessor))
+		component.WithTracesProcessorAndStabilityLevel(createTraceProcessor, stabilityLevel))
 }
 
 func createDefaultConfig() config.Processor {

--- a/pkg/processor/k8sprocessor/README.md
+++ b/pkg/processor/k8sprocessor/README.md
@@ -1,5 +1,7 @@
 # Kubernetes Processor
 
+**Stability level**: Beta
+
 The `k8sprocessor` automatically tags logs, metrics and traces with Kubernetes metadata
 like pod name, namespace name etc.
 

--- a/pkg/processor/k8sprocessor/factory.go
+++ b/pkg/processor/k8sprocessor/factory.go
@@ -28,7 +28,8 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr = "k8s_tagger"
+	typeStr        = "k8s_tagger"
+	stabilityLevel = component.StabilityLevelBeta
 )
 
 var kubeClientProvider = kube.ClientProvider(nil)
@@ -39,9 +40,9 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessor(createTracesProcessor),
-		component.WithMetricsProcessor(createMetricsProcessor),
-		component.WithLogsProcessor(createLogsProcessor),
+		component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, stabilityLevel),
+		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, stabilityLevel),
+		component.WithLogsProcessorAndStabilityLevel(createLogsProcessor, stabilityLevel),
 	)
 }
 

--- a/pkg/processor/metricfrequencyprocessor/README.md
+++ b/pkg/processor/metricfrequencyprocessor/README.md
@@ -1,5 +1,7 @@
 # Metric Frequency Processor
 
+**Stability level**: Beta
+
 The `metricfrequencyprocessor` is a metrics processor that helps reduce DPM by automatic tuning of metrics reporting
 frequency which adjusts for metric's information volume.
 

--- a/pkg/processor/metricfrequencyprocessor/factory.go
+++ b/pkg/processor/metricfrequencyprocessor/factory.go
@@ -22,13 +22,14 @@ const (
 	defaultDataPointExpirationTime        = 1 * time.Hour
 	defaultDataPointCacheCleanupInterval  = 10 * time.Minute
 	defaultMetricCacheCleanupInterval     = 3 * time.Hour
+	stabilityLevel                        = component.StabilityLevelBeta
 )
 
 func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		cfgType,
 		createDefaultConfig,
-		component.WithMetricsProcessor(createMetricsProcessor),
+		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, stabilityLevel),
 	)
 }
 

--- a/pkg/processor/sourceprocessor/README.md
+++ b/pkg/processor/sourceprocessor/README.md
@@ -1,5 +1,7 @@
 # Source Processor
 
+**Stability level**: Beta
+
 The `sourceprocessor` adds `_sourceName` and other tags related to Sumo Logic metadata taxonomy.
 
 It is recommended to use `k8sprocessor` to provide attributes used in default values.

--- a/pkg/processor/sourceprocessor/factory.go
+++ b/pkg/processor/sourceprocessor/factory.go
@@ -39,6 +39,8 @@ const (
 	defaultPodKey             = "k8s.pod.name"
 	defaultPodNameKey         = "k8s.pod.pod_name"
 	defaultPodTemplateHashKey = "k8s.pod.label.pod-template-hash"
+
+	stabilityLevel = component.StabilityLevelBeta
 )
 
 var processorCapabilities = consumer.Capabilities{MutatesData: true}
@@ -48,9 +50,9 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessor(createTraceProcessor),
-		component.WithMetricsProcessor(createMetricsProcessor),
-		component.WithLogsProcessor(createLogsProcessor),
+		component.WithTracesProcessorAndStabilityLevel(createTraceProcessor, stabilityLevel),
+		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, stabilityLevel),
+		component.WithLogsProcessorAndStabilityLevel(createLogsProcessor, stabilityLevel),
 	)
 }
 

--- a/pkg/processor/sumologicschemaprocessor/README.md
+++ b/pkg/processor/sumologicschemaprocessor/README.md
@@ -1,5 +1,7 @@
 # Sumo Logic Schema Processor
 
+**Stability level**: Beta
+
 The Sumo Logic Schema processor (config name: `sumologic_schema`)
 modifies the metadata on logs, metrics and traces sent to [Sumo Logic][sumologic_webpage]
 so that the Sumo Logic [apps][sumologic_apps] can make full use of the ingested data.

--- a/pkg/processor/sumologicschemaprocessor/factory.go
+++ b/pkg/processor/sumologicschemaprocessor/factory.go
@@ -25,7 +25,8 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr = "sumologic_schema"
+	typeStr        = "sumologic_schema"
+	stabilityLevel = component.StabilityLevelBeta
 )
 
 var processorCapabilities = consumer.Capabilities{MutatesData: true}
@@ -35,9 +36,9 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessor(createTracesProcessor),
-		component.WithMetricsProcessor(createMetricsProcessor),
-		component.WithLogsProcessor(createLogsProcessor))
+		component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, stabilityLevel),
+		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, stabilityLevel),
+		component.WithLogsProcessorAndStabilityLevel(createLogsProcessor, stabilityLevel))
 }
 
 func createLogsProcessor(

--- a/pkg/processor/sumologicsyslogprocessor/README.md
+++ b/pkg/processor/sumologicsyslogprocessor/README.md
@@ -1,5 +1,7 @@
 # Sumo Logic Syslog Processor
 
+**Stability level**: Beta
+
 Supported pipeline types: logs
 
 The Sumo Logic Syslog processor can be used to create attribute with facility name

--- a/pkg/processor/sumologicsyslogprocessor/factory.go
+++ b/pkg/processor/sumologicsyslogprocessor/factory.go
@@ -25,7 +25,8 @@ import (
 
 const (
 	// The value of "type" Tail Sampling in configuration.
-	typeStr = "sumologic_syslog"
+	typeStr        = "sumologic_syslog"
+	stabilityLevel = component.StabilityLevelBeta
 )
 
 var processorCapabilities = consumer.Capabilities{MutatesData: true}
@@ -35,7 +36,7 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithLogsProcessor(createLogProcessor))
+		component.WithLogsProcessorAndStabilityLevel(createLogProcessor, stabilityLevel))
 }
 
 func createDefaultConfig() config.Processor {

--- a/pkg/receiver/rawk8seventsreceiver/README.md
+++ b/pkg/receiver/rawk8seventsreceiver/README.md
@@ -1,11 +1,11 @@
 # Raw Kubernetes Events Receiver
 
+**Stability level**: Beta
+
 Receiver for ingesting Kubernetes Events in their raw format, exactly as the Kubernetes API returns them.
 It intends to return exactly the same output as the following [Fluentd plugin].
 
 Supported pipeline types: logs
-
-> :construction: This receiver is in **ALPHA**. Configuration fields, behaviour and log data model are subject to change.
 
 ## Configuration
 

--- a/pkg/receiver/rawk8seventsreceiver/factory.go
+++ b/pkg/receiver/rawk8seventsreceiver/factory.go
@@ -28,7 +28,8 @@ import (
 
 const (
 	// Value of "type" key in configuration.
-	typeStr = "raw_k8s_events"
+	typeStr        = "raw_k8s_events"
+	stabilityLevel = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for rawk8sevents receiver.
@@ -36,7 +37,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithLogsReceiver(createLogsReceiver))
+		component.WithLogsReceiverAndStabilityLevel(createLogsReceiver, stabilityLevel))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/pkg/receiver/telegrafreceiver/README.md
+++ b/pkg/receiver/telegrafreceiver/README.md
@@ -1,5 +1,7 @@
 # Telegraf Receiver
 
+**Stability level**: Beta
+
 Telegraf receiver for ingesting metrics from various [input plugins][input_plugins]
 into otc pipeline.
 

--- a/pkg/receiver/telegrafreceiver/factory.go
+++ b/pkg/receiver/telegrafreceiver/factory.go
@@ -27,8 +27,9 @@ import (
 )
 
 const (
-	typeStr    = "telegraf"
-	versionStr = "v0.1"
+	typeStr        = "telegraf"
+	versionStr     = "v0.1"
+	stabilityLevel = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for telegraf receiver.
@@ -36,7 +37,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver),
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stabilityLevel),
 	)
 }
 


### PR DESCRIPTION
As for upstream version v0.57.2, the components must have a stability level defined. This PR does this.

I couldn't recall what exactly have we agreed on, so I have set all the levels to **beta**. Feel free to disagree with this.