### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -350,7 +350,6 @@ jobs:
       # Require darwin build to succeed to prevent pushing container images
       # when darwin build fails.
       - build-darwin
-      - build-fips-darwin
       - build-container-images
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
There was a remaining dependency on a nonexisting job after FIPS builds for darwin were removed.