### PR TITLE
chore: replace deprecated methods

### DIFF
--- a/pkg/exporter/sumologicexporter/exporter.go
+++ b/pkg/exporter/sumologicexporter/exporter.go
@@ -483,7 +483,7 @@ func (se *sumologicexporter) configure(ctx context.Context) error {
 		return fmt.Errorf("no auth extension and no endpoint specified")
 	}
 
-	client, err := httpSettings.ToClientWithHost(se.host, component.TelemetrySettings{})
+	client, err := httpSettings.ToClient(se.host, component.TelemetrySettings{})
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP Client: %w", err)
 	}

--- a/pkg/exporter/sumologicexporter/factory.go
+++ b/pkg/exporter/sumologicexporter/factory.go
@@ -34,9 +34,9 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithLogsExporterAndStabilityLevel(createLogsExporter, stabilityLevel),
-		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stabilityLevel),
-		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stabilityLevel),
+		component.WithLogsExporter(createLogsExporter, stabilityLevel),
+		component.WithMetricsExporter(createMetricsExporter, stabilityLevel),
+		component.WithTracesExporter(createTracesExporter, stabilityLevel),
 	)
 }
 

--- a/pkg/processor/cascadingfilterprocessor/factory.go
+++ b/pkg/processor/cascadingfilterprocessor/factory.go
@@ -46,7 +46,7 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessorAndStabilityLevel(createTraceProcessor, stabilityLevel))
+		component.WithTracesProcessor(createTraceProcessor, stabilityLevel))
 }
 
 func createDefaultConfig() config.Processor {

--- a/pkg/processor/k8sprocessor/factory.go
+++ b/pkg/processor/k8sprocessor/factory.go
@@ -40,9 +40,9 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, stabilityLevel),
-		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, stabilityLevel),
-		component.WithLogsProcessorAndStabilityLevel(createLogsProcessor, stabilityLevel),
+		component.WithTracesProcessor(createTracesProcessor, stabilityLevel),
+		component.WithMetricsProcessor(createMetricsProcessor, stabilityLevel),
+		component.WithLogsProcessor(createLogsProcessor, stabilityLevel),
 	)
 }
 

--- a/pkg/processor/metricfrequencyprocessor/factory.go
+++ b/pkg/processor/metricfrequencyprocessor/factory.go
@@ -29,7 +29,7 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		cfgType,
 		createDefaultConfig,
-		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, stabilityLevel),
+		component.WithMetricsProcessor(createMetricsProcessor, stabilityLevel),
 	)
 }
 

--- a/pkg/processor/sourceprocessor/factory.go
+++ b/pkg/processor/sourceprocessor/factory.go
@@ -50,9 +50,9 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessorAndStabilityLevel(createTraceProcessor, stabilityLevel),
-		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, stabilityLevel),
-		component.WithLogsProcessorAndStabilityLevel(createLogsProcessor, stabilityLevel),
+		component.WithTracesProcessor(createTracesProcessor, stabilityLevel),
+		component.WithMetricsProcessor(createMetricsProcessor, stabilityLevel),
+		component.WithLogsProcessor(createLogsProcessor, stabilityLevel),
 	)
 }
 
@@ -83,7 +83,7 @@ func createDefaultConfig() config.Processor {
 }
 
 // CreateTraceProcessor creates a trace processor based on this config.
-func createTraceProcessor(
+func createTracesProcessor(
 	_ context.Context,
 	params component.ProcessorCreateSettings,
 	cfg config.Processor,

--- a/pkg/processor/sumologicschemaprocessor/factory.go
+++ b/pkg/processor/sumologicschemaprocessor/factory.go
@@ -36,9 +36,10 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, stabilityLevel),
-		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, stabilityLevel),
-		component.WithLogsProcessorAndStabilityLevel(createLogsProcessor, stabilityLevel))
+		component.WithTracesProcessor(createTracesProcessor, stabilityLevel),
+		component.WithMetricsProcessor(createMetricsProcessor, stabilityLevel),
+		component.WithLogsProcessor(createLogsProcessor, stabilityLevel),
+	)
 }
 
 func createLogsProcessor(

--- a/pkg/processor/sumologicsyslogprocessor/factory.go
+++ b/pkg/processor/sumologicsyslogprocessor/factory.go
@@ -36,7 +36,7 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithLogsProcessorAndStabilityLevel(createLogProcessor, stabilityLevel))
+		component.WithLogsProcessor(createLogProcessor, stabilityLevel))
 }
 
 func createDefaultConfig() config.Processor {

--- a/pkg/receiver/rawk8seventsreceiver/factory.go
+++ b/pkg/receiver/rawk8seventsreceiver/factory.go
@@ -37,7 +37,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithLogsReceiverAndStabilityLevel(createLogsReceiver, stabilityLevel))
+		component.WithLogsReceiver(createLogsReceiver, stabilityLevel))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/pkg/receiver/telegrafreceiver/factory.go
+++ b/pkg/receiver/telegrafreceiver/factory.go
@@ -37,7 +37,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stabilityLevel),
+		component.WithMetricsReceiver(createMetricsReceiver, stabilityLevel),
 	)
 }
 


### PR DESCRIPTION
Methods used to upgrade from 0.56 to 0.57 were deprecated in 0.57 and removed in 0.58. This commit replaces them with equivalents.