### PR TITLE
feat(filterprocessor): drop custom changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
+
+### Removed
+
+- feat(filterprocessor): drop custom changes ([upgrade guide][upgrade_guide_v0_55_0_expr_support]) [#709]
 
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.57.2-sumo-0...main
+[#709]: https://github.com/SumoLogic/sumologic-otel-collector/pull/709
 
 ## [v0.57.2-sumo-0]
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The rest of the components in the table are pure upstream OpenTelemetry componen
 | [awscontainerinsightreceiver][awscontainerinsightreceiver] |       [cumulativetodelta][cumulativetodeltaprocessor]        | [loadbalancing][loadbalancingexporter] | [bearertokenauth][bearertokenauthextension]  |
 |  [awsecscontainermetrics][awsecscontainermetricsreceiver]  |             [deltatorate][deltatorateprocessor]              |       [logging][loggingexporter]       |           [db_storage][dbstorage]            |
 |             [awsfirehose][awsfirehosereceiver]             | [experimental_metricsgeneration][metricsgenerationprocessor] |          [otlp][otlpexporter]          |      [docker_observer][dockerobserver]       |
-|                 [awsxray][awsxrayreceiver]                 |                  [filter][filterprocessor]*                  |      [otlphttp][otlphttpexporter]      |         [ecs_observer][ecsobserver]          |
+|                 [awsxray][awsxrayreceiver]                 |                  [filter][filterprocessor]                   |      [otlphttp][otlphttpexporter]      |         [ecs_observer][ecsobserver]          |
 |                   [bigip][bigipreceiver]                   |            [groupbyattrs][groupbyattrsprocessor]             |    [`sumologic`][sumologicexporter]    |     [ecs_task_observer][ecstaskobserver]     |
 |                  [carbon][carbonreceiver]                  |            [groupbytrace][groupbytraceprocessor]             |                                        |         [file_storage][filestorage]          |
 |            [cloudfoundry][cloudfoundryreceiver]            |                 [`k8s_tagger`][k8sprocessor]                 |                                        |     [health_check][healthcheckextension]     |
@@ -192,7 +192,7 @@ The rest of the components in the table are pure upstream OpenTelemetry componen
 [deltatorateprocessor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.57.2/processor/deltatorateprocessor
 [metricsgenerationprocessor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.57.2/processor/metricsgenerationprocessor
 
-[filterprocessor]: https://github.com/SumoLogic/opentelemetry-collector-contrib/tree/v0.57.2-filterprocessor/processor/filterprocessor
+[filterprocessor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.57.2/processor/filterprocessor
 [groupbyattrsprocessor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.57.2/processor/groupbyattrsprocessor
 [groupbytraceprocessor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.57.2/processor/groupbytraceprocessor
 [k8sprocessor]: ./pkg/processor/k8sprocessor

--- a/docs/release.md
+++ b/docs/release.md
@@ -101,7 +101,7 @@ Updating OT core involves:
 
 ### Updating patched processors
 
-We currently maintain patches for three upstream processors: `resourceprocessor`, `attributesprocessor` and `filterprocessor`.
+We currently maintain patches for two upstream processors: `resourceprocessor` and `attributesprocessor`.
 The patches live in our [contrib fork repository][contrib_fork], on the `vX.X.X-filterprocessor` branch. See [comments][builder_config]
 in the builder configuration for more details.
 

--- a/otelcolbuilder/.otelcol-builder.yaml
+++ b/otelcolbuilder/.otelcol-builder.yaml
@@ -202,16 +202,9 @@ replaces:
   # Needed for telegrafreceiver
   - github.com/influxdata/telegraf => github.com/SumoLogic/telegraf v1.22.0-sumo-4
 
-  # TODO: remove this in v0.58 version, as all the following changes has been deprecated:
-  # - expr (regexp) log filtering is merged and released upstream:
-  #   PR: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5680
-  # - It contains also fix for exclusion using expr language
-  #   PR: https://github.com/SumoLogic/opentelemetry-collector-contrib/pull/5144
-  #
   # For now, cherry-picked changes are being used:
   # commit: https://github.com/SumoLogic/opentelemetry-collector-contrib/commit/049c70829f005bcd13ed4253de09afe400308df5
   # branch: https://github.com/SumoLogic/opentelemetry-collector-contrib/tree/v0.57.2-filterprocessor
-  - github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor => github.com/SumoLogic/opentelemetry-collector-contrib/processor/filterprocessor 049c70829f005bcd13ed4253de09afe400308df5
   - github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => github.com/SumoLogic/opentelemetry-collector-contrib/internal/coreinternal 049c70829f005bcd13ed4253de09afe400308df5
   - github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor => github.com/SumoLogic/opentelemetry-collector-contrib/processor/attributesprocessor 049c70829f005bcd13ed4253de09afe400308df5
   - github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor => github.com/SumoLogic/opentelemetry-collector-contrib/processor/resourceprocessor 049c70829f005bcd13ed4253de09afe400308df5


### PR DESCRIPTION
Resolves #663
Custom changes in the filter processor have been deprecated in v0.55.0-sumo-0. 

According to the discussion under https://github.com/SumoLogic/sumologic-otel-collector/pull/655, the goal was to stop using any custom changes of the `filter` processor. However, I was not sure what is the status of the contrib. It seems that the `attributes` processor also uses some related changes. I decided not to drop them.

Should we also revert the changes in our contrib fork or not?