### PR TITLE
fix(k8sprocessor): keep pod's services information up to date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - fix(k8sprocessor): fix metadata enrichment [#724]
+- fix(k8sprocessor): keep pod's services information up to date [#710]
 
 ### Removed
 
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#672]: https://github.com/SumoLogic/sumologic-otel-collector/pull/672
 [#678]: https://github.com/SumoLogic/sumologic-otel-collector/pull/678
 [#709]: https://github.com/SumoLogic/sumologic-otel-collector/pull/709
+[#710]: https://github.com/SumoLogic/sumologic-otel-collector/pull/710
 [#714]: https://github.com/SumoLogic/sumologic-otel-collector/pull/714
 [#713]: https://github.com/SumoLogic/sumologic-otel-collector/pull/713
 [#724]: https://github.com/SumoLogic/sumologic-otel-collector/pull/724

--- a/pkg/processor/k8sprocessor/kube/client_test.go
+++ b/pkg/processor/k8sprocessor/kube/client_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -402,14 +403,23 @@ func TestGetPod(t *testing.T) {
 	pod.UID = "1234"
 	pod.Name = "pod_name"
 	pod.Namespace = "namespace_name"
+	pod.OwnerReferences = []meta_v1.OwnerReference{
+		metav1.OwnerReference{
+			Name: "A reference",
+		},
+		metav1.OwnerReference{
+			Name: "Another reference",
+		},
+	}
 	c.handlePodAdd(pod)
 
 	expected := &Pod{
-		Name:       "pod_name",
-		Namespace:  "namespace_name",
-		Address:    "1.1.1.1",
-		PodUID:     "1234",
-		Attributes: map[string]string{},
+		Name:            "pod_name",
+		Namespace:       "namespace_name",
+		Address:         "1.1.1.1",
+		PodUID:          "1234",
+		Attributes:      map[string]string{},
+		OwnerReferences: &pod.OwnerReferences,
 	}
 
 	got, ok := c.GetPod(PodIdentifier("1.1.1.1"))
@@ -446,6 +456,7 @@ func TestGetPodWhenNamespaceInExtractedMetadata(t *testing.T) {
 		Attributes: map[string]string{
 			"namespace": "namespace_name",
 		},
+		OwnerReferences: &pod.OwnerReferences,
 	}
 
 	got, ok := c.GetPod(PodIdentifier("1.1.1.1"))
@@ -1172,6 +1183,67 @@ func newTestClientWithRulesAndFilters(t *testing.T, e ExtractionRules, f Filters
 
 func newTestClient(t *testing.T) (*WatchClient, *observer.ObservedLogs) {
 	return newTestClientWithRulesAndFilters(t, ExtractionRules{}, Filters{})
+}
+
+func TestServiceInfoArrivesLate(t *testing.T) {
+	// Concept: we insert a pod with no service associated,
+	// then update the service in the cache,
+	// then try fetching the pod and see that it doesn't contain the service
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
+	podUID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	cache := OwnerCache{
+		objectOwners: map[string]*ObjectOwner{},
+		podServices:  map[string][]string{},
+		namespaces:   map[string]*api_v1.Namespace{},
+		logger:       logger,
+		stopCh:       make(chan struct{}),
+	}
+	cache.podServices["pod"] = []string{"firstService", "secondService"}
+
+	var client = &WatchClient{
+		logger:    logger,
+		op:        &cache,
+		delimiter: ", ",
+		Rules: ExtractionRules{
+			OwnerLookupEnabled: true,
+			ServiceName:        true,
+			Tags: ExtractionFieldTags{
+				ServiceName: "ServiceName",
+			},
+		},
+		Pods: map[PodIdentifier]*Pod{},
+	}
+
+	pod := &api_v1.Pod{}
+	pod.Name = "pod"
+	pod.Status.PodIP = "2.2.2.2"
+	pod.UID = types.UID(podUID)
+
+	client.handlePodAdd(pod)
+
+	podResult, ok := client.GetPod(PodIdentifier(podUID))
+	assert.True(t, ok)
+
+	logger.Debug("pod: ", zap.Any("pod", podResult))
+	serviceName, ok := podResult.Attributes["ServiceName"]
+	assert.True(t, ok)
+
+	// After PodAdd, there are two services:
+	assert.Equal(t, "firstService, secondService", serviceName)
+
+	cache.podServices["pod"] = []string{"firstService", "secondService", "thirdService"}
+
+	podResult, ok = client.GetPod(PodIdentifier(podUID))
+	assert.True(t, ok)
+
+	logger.Debug("pod: ", zap.Any("pod", podResult))
+	serviceName, ok = podResult.Attributes["ServiceName"]
+	assert.True(t, ok)
+
+	// Desired behavior: we get all three service names in response:
+	assert.Equal(t, "firstService, secondService, thirdService", serviceName)
 }
 
 //func newBenchmarkClient(b *testing.B) *WatchClient {

--- a/pkg/processor/k8sprocessor/kube/fake_owner.go
+++ b/pkg/processor/k8sprocessor/kube/fake_owner.go
@@ -105,7 +105,7 @@ func (op *fakeOwnerCache) Start() {}
 func (op *fakeOwnerCache) Stop() {}
 
 // GetServices fetches list of services for a given pod
-func (op *fakeOwnerCache) GetServices(pod *api_v1.Pod) []string {
+func (op *fakeOwnerCache) GetServices(podName string) []string {
 	return []string{"foo", "bar"}
 }
 
@@ -121,13 +121,13 @@ func (op *fakeOwnerCache) GetNamespace(pod *api_v1.Pod) *api_v1.Namespace {
 }
 
 // GetOwners fetches deep tree of owners for a given pod
-func (op *fakeOwnerCache) GetOwners(pod *api_v1.Pod) []*ObjectOwner {
+func (op *fakeOwnerCache) GetOwners(pod *Pod) []*ObjectOwner {
 	objectOwners := []*ObjectOwner{}
 
 	visited := map[types.UID]bool{}
 	queue := []types.UID{}
 
-	for _, or := range pod.OwnerReferences {
+	for _, or := range *pod.OwnerReferences {
 		if _, uidVisited := visited[or.UID]; !uidVisited {
 			queue = append(queue, or.UID)
 			visited[or.UID] = true

--- a/pkg/processor/k8sprocessor/kube/kube.go
+++ b/pkg/processor/k8sprocessor/kube/kube.go
@@ -84,13 +84,14 @@ type APIClientsetProvider func(config k8sconfig.APIConfig) (kubernetes.Interface
 
 // Pod represents a kubernetes pod.
 type Pod struct {
-	Attributes map[string]string
-	StartTime  *metav1.Time
-	Name       string
-	Namespace  string
-	Address    string
-	PodUID     string
-	Ignore     bool
+	Attributes      map[string]string
+	StartTime       *metav1.Time
+	Name            string
+	Namespace       string
+	Address         string
+	PodUID          string
+	Ignore          bool
+	OwnerReferences *[]metav1.OwnerReference
 }
 
 func (p Pod) GetName() string {

--- a/pkg/processor/k8sprocessor/kube/owner_test.go
+++ b/pkg/processor/k8sprocessor/kube/owner_test.go
@@ -120,7 +120,7 @@ func Test_OwnerProvider_GetOwners_ReplicaSet(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
-		owners := op.GetOwners(pod)
+		owners := op.GetOwners(&Pod{OwnerReferences: &pod.OwnerReferences})
 		if len(owners) != 1 {
 			t.Logf("owners: %v", owners)
 			return false
@@ -232,7 +232,7 @@ func Test_OwnerProvider_GetOwners_Deployment(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
-		owners := op.GetOwners(pod)
+		owners := op.GetOwners(&Pod{OwnerReferences: &pod.OwnerReferences})
 		if len(owners) != 2 {
 			t.Logf("owners: %v", owners)
 			return false
@@ -318,7 +318,7 @@ func Test_OwnerProvider_GetOwners_Statefulset(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
-		owners := op.GetOwners(pod)
+		owners := op.GetOwners(&Pod{OwnerReferences: &pod.OwnerReferences})
 		if len(owners) != 1 {
 			t.Logf("owners: %v", owners)
 			return false
@@ -404,7 +404,7 @@ func Test_OwnerProvider_GetOwners_Daemonset(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
-		owners := op.GetOwners(pod)
+		owners := op.GetOwners(&Pod{OwnerReferences: &pod.OwnerReferences})
 		if len(owners) != 1 {
 			t.Logf("owners: %v", owners)
 			return false
@@ -529,7 +529,7 @@ func Test_OwnerProvider_GetServices(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Eventually(t, func() bool {
-			services := op.GetServices(pod)
+			services := op.GetServices(pod.Name)
 			if len(services) != 2 {
 				t.Logf("services: %v", services)
 				return false
@@ -544,7 +544,7 @@ func Test_OwnerProvider_GetServices(t *testing.T) {
 			Delete(context.Background(), endpoints1.Name, metav1.DeleteOptions{})
 		require.NoError(t, err)
 		assert.Eventually(t, func() bool {
-			services := op.GetServices(pod)
+			services := op.GetServices(pod.Name)
 			if len(services) != 1 {
 				t.Logf("services: %v", services)
 				return false
@@ -558,7 +558,7 @@ func Test_OwnerProvider_GetServices(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Eventually(t, func() bool {
-			services := op.GetServices(pod)
+			services := op.GetServices(pod.Name)
 			if len(services) != 0 {
 				t.Logf("services: %v", services)
 				return false
@@ -640,7 +640,7 @@ func Test_OwnerProvider_GetOwners_Job(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
-		owners := op.GetOwners(pod)
+		owners := op.GetOwners(&Pod{OwnerReferences: &pod.OwnerReferences})
 		if len(owners) != 1 {
 			t.Logf("owners: %v", owners)
 			return false
@@ -752,7 +752,7 @@ func Test_OwnerProvider_GetOwners_CronJob(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
-		owners := op.GetOwners(pod)
+		owners := op.GetOwners(&Pod{OwnerReferences: &pod.OwnerReferences})
 		if len(owners) != 2 {
 			t.Logf("owners: %v", owners)
 			return false


### PR DESCRIPTION
Information about pod's services can arrive late, i.e. after the pod has been marked as ready. If that happens, the data won't be marked with this information until another update of that pod.
This PR changes this behavior - information about services is no longer cached and is recalculated every time when `GetPod` is called.
This is a less intrusive solution for this problem - an alternative is to remove the whole `map[string]*Pod` from `WatchClient` and recalculate all the attributes every time.

cc: @swiatekm-sumo 