### PR TITLE
test: re-enable staticcheck linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -38,6 +38,7 @@ linters:
     - typecheck
     - unused
     - gosimple
+    - staticcheck
 
 issues:
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.

--- a/pkg/exporter/sumologicexporter/compress_test.go
+++ b/pkg/exporter/sumologicexporter/compress_test.go
@@ -42,8 +42,8 @@ func (e mockedEncrypter) Close() error {
 	return e.closeError
 }
 
-func getTestCompressor(w error, c error) compressor {
-	return compressor{
+func getTestCompressor(w error, c error) *compressor {
+	return &compressor{
 		format: GZIPCompression,
 		writer: mockedEncrypter{
 			writeError: w,

--- a/pkg/exporter/sumologicexporter/exporter.go
+++ b/pkg/exporter/sumologicexporter/exporter.go
@@ -120,7 +120,7 @@ func initExporter(cfg *Config, createSettings component.ExporterCreateSettings) 
 				if err != nil {
 					return fmt.Errorf("failed to initialize compressor: %w", err)
 				}
-				return c
+				return &c
 			},
 		},
 		// NOTE: client is now set in start()
@@ -408,14 +408,14 @@ func (se *sumologicexporter) pushTracesData(ctx context.Context, td ptrace.Trace
 	return err
 }
 
-func (se *sumologicexporter) getCompressor() (compressor, error) {
+func (se *sumologicexporter) getCompressor() (*compressor, error) {
 	switch c := se.compressorPool.Get().(type) {
 	case error:
-		return compressor{}, fmt.Errorf("%v", c)
-	case compressor:
+		return &compressor{}, fmt.Errorf("%v", c)
+	case *compressor:
 		return c, nil
 	default:
-		return compressor{}, fmt.Errorf("unknown compressor type: %T", c)
+		return &compressor{}, fmt.Errorf("unknown compressor type: %T", c)
 	}
 }
 

--- a/pkg/exporter/sumologicexporter/sender.go
+++ b/pkg/exporter/sumologicexporter/sender.go
@@ -128,7 +128,7 @@ type sender struct {
 	config              *Config
 	client              *http.Client
 	sources             sourceFormats
-	compressor          compressor
+	compressor          *compressor
 	prometheusFormatter prometheusFormatter
 	jsonLogsConfig      JSONLogs
 	dataUrlMetrics      string
@@ -165,7 +165,7 @@ func newSender(
 	cfg *Config,
 	cl *http.Client,
 	s sourceFormats,
-	c compressor,
+	c *compressor,
 	pf prometheusFormatter,
 	metricsUrl string,
 	logsUrl string,

--- a/pkg/exporter/sumologicexporter/sender_test.go
+++ b/pkg/exporter/sumologicexporter/sender_test.go
@@ -99,7 +99,7 @@ func prepareSenderTest(t *testing.T, cb []func(w http.ResponseWriter, req *http.
 				category: getTestSourceFormat(t, "source_category"),
 				name:     getTestSourceFormat(t, "source_name"),
 			},
-			c,
+			&c,
 			pf,
 			"",
 			"",
@@ -154,7 +154,7 @@ func prepareOTLPSenderTest(t *testing.T, cb []func(w http.ResponseWriter, req *h
 				category: getTestSourceFormat(t, "source_category"),
 				name:     getTestSourceFormat(t, "source_name"),
 			},
-			c,
+			&c,
 			pf,
 			testServer.URL,
 			testServer.URL,
@@ -1377,7 +1377,7 @@ func TestSendCompressGzip(t *testing.T) {
 	c, err := newCompressor("gzip")
 	require.NoError(t, err)
 
-	test.s.compressor = c
+	test.s.compressor = &c
 	reader := newCountingReader(0).withString("Some example log")
 
 	err = test.s.send(context.Background(), LogsPipeline, reader, fields{})
@@ -1405,7 +1405,7 @@ func TestSendCompressDeflate(t *testing.T) {
 	c, err := newCompressor("deflate")
 	require.NoError(t, err)
 
-	test.s.compressor = c
+	test.s.compressor = &c
 	reader := newCountingReader(0).withString("Some example log")
 
 	err = test.s.send(context.Background(), LogsPipeline, reader, fields{})

--- a/pkg/extension/sumologicextension/credentials/credentialsstore_localfs.go
+++ b/pkg/extension/sumologicextension/credentials/credentialsstore_localfs.go
@@ -17,7 +17,7 @@ package credentials
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 
@@ -123,7 +123,7 @@ func (cr LocalFsStore) Get(key string) (CollectorCredentials, error) {
 		}
 		defer creds.Close()
 
-		encryptedCreds, err := ioutil.ReadAll(creds)
+		encryptedCreds, err := io.ReadAll(creds)
 		if err != nil {
 			return CollectorCredentials{}, err
 		}

--- a/pkg/extension/sumologicextension/extension.go
+++ b/pkg/extension/sumologicextension/extension.go
@@ -219,7 +219,7 @@ func (se *SumologicExtension) getHTTPClient(
 	httpClientSettings confighttp.HTTPClientSettings,
 	regInfo api.OpenRegisterResponsePayload,
 ) (*http.Client, error) {
-	httpClient, err := httpClientSettings.ToClientWithHost(
+	httpClient, err := httpClientSettings.ToClient(
 		se.host,
 		component.TelemetrySettings{},
 	)


### PR DESCRIPTION
Re-enable the staticcheck linter which was disabled during the upgrade to go 1.18. With the upgrade to golangci-lint in #715 , it can now be re-enabled. One of the main benefits of this is automated deprecation checking - particularly useful for OT core upgrades.

One of the changes in this PR isn't just syntactic, and has to do with storing pointers to compressors instead of compressors themselves in a bufferpool. I didn't see any performance impact of this, nor any test failures.