### PR TITLE
chore(examples): add default configuration

### DIFF
--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -90,15 +90,15 @@ processors:
   ## The memory_limiter processor is used to prevent out of memory situations on the collector.
   ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor
   memory_limiter:
-  ## check_interval is the time between measurements of memory usage for the
-  ## purposes of avoiding going over the limits. Defaults to zero, so no
-  ## checks will be performed. Values below 1 second are not recommended since
-  ## it can result in unnecessary CPU consumption.
-  check_interval: 5s
-  ## Maximum amount of memory, in %, targeted to be allocated by the process heap.
-  limit_percentage: 75
-  ## Spike limit (calculated from available memory). Must be less than limit_percentage.
-  spike_limit_percentage: 20
+    ## check_interval is the time between measurements of memory usage for the
+    ## purposes of avoiding going over the limits. Defaults to zero, so no
+    ## checks will be performed. Values below 1 second are not recommended since
+    ## it can result in unnecessary CPU consumption.
+    check_interval: 5s
+    ## Maximum amount of memory, in %, targeted to be allocated by the process heap.
+    limit_percentage: 75
+    ## Spike limit (calculated from available memory). Must be less than limit_percentage.
+    spike_limit_percentage: 20
 
   ## Configuration for Batch Processor
   ## The batch processor accepts records and places them into batches grouped by node and resource

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -1,0 +1,147 @@
+extensions:
+  ## Configuration for Sumo Logic Extension
+  ## Manages registration, heartbeats and authentication to Sumo Logic
+  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/extension/sumologicextension
+  sumologic:
+    install_token: ${INSTALL_TOKEN}
+    collector_credentials_directory: ~/.sumologic-otel-collector
+    collector_name: ${COLLECTOR_NAME}
+    clobber: true
+
+  ## Configuration for Health Check Extension
+  ## Health Check extension enables an HTTP url that can be probed to check the status of the OpenTelemetry Collector
+  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension
+  health_check:
+
+  ## Configuration for File Storage Extension
+  ## The File Storage extension can persist state to the local file system
+  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage
+  file_storage:
+    directory: ${FILE_STORAGE}
+
+receivers:
+  ## Configuration for Host Metrics Receiver
+  ## The Host Metrics receiver generates metrics about the host system scraped from various sources
+  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver
+  hostmetrics:
+    collection_interval: 30s
+    scrapers:
+      cpu:
+      disk:
+      load:
+      filesystem:
+      memory:
+      network:
+      paging:
+      processes:
+      process:
+
+  ## Configuration for Filelog Receiver
+  ## Tails and parses logs from files
+  ## This instance is configured to handle syslog logs
+  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver
+  filelog/syslog:
+    start_at: beginning
+    include_file_path_resolved: true
+    include:
+      - /var/log/auth.log
+      - /var/log/syslog
+      - /var/log/daemon.log
+      - /var/log/kern.log
+
+  ## Configuration for Filelog Receiver
+  ## Tails and parses logs from files
+  ## This instance is configured to handle dpkg logs
+  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver
+  filelog/dpkg:
+    start_at: beginning
+    include_file_path_resolved: true
+    include:
+      - /var/log/dpkg.log
+
+exporters:
+  ## Configuration for Sumo Logic Exporter
+  ## This exporter supports sending logs, metrics and traces data to Sumo Logic.
+  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
+  sumologic:
+
+processors:
+  ## Configuration for Sumo Logic Schema Processor
+  ## The Sumo Logic Schema processor modifies the metadata on logs, metrics and traces sent to Sumo Logic
+  ## so that the Sumo Logic apps can make full use of the ingested data.
+  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/processor/sumologicschemaprocessor
+  sumologic_schema:
+
+  ## Configuration Sumo Logic Syslog Processor
+  ## The Sumo Logic Syslog processor can be used to create attribute with facility name based on facility code.
+  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/processor/sumologicsyslogprocessor
+  sumologic_syslog:
+
+  ## Configuration for Group by Attributes Processor
+  ## It groups records by attributes and move record attributes to resource attributes
+  ## ref: https://github.com/sumologic/opentelemetry-collector-contrib/tree/main/processor/groupbyattrsprocessor
+  groupbyattrs:
+    keys:
+      - log.file.name
+      - facility
+      - log.file.path_resolved
+
+  ## Configuration for Memory Limiter Processor
+  ## The memory_limiter processor is used to prevent out of memory situations on the collector.
+  ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor
+  memory_limiter:
+  ## check_interval is the time between measurements of memory usage for the
+  ## purposes of avoiding going over the limits. Defaults to zero, so no
+  ## checks will be performed. Values below 1 second are not recommended since
+  ## it can result in unnecessary CPU consumption.
+  check_interval: 5s
+  ## Maximum amount of memory, in %, targeted to be allocated by the process heap.
+  limit_percentage: 75
+  ## Spike limit (calculated from available memory). Must be less than limit_percentage.
+  spike_limit_percentage: 20
+
+  ## Configuration for Batch Processor
+  ## The batch processor accepts records and places them into batches grouped by node and resource
+  ## ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor
+  batch:
+    ## Number of records after which a batch will be sent regardless of time
+    send_batch_size: 1_024
+    ## Time duration after which a batch will be sent regardless of size
+    timeout: 1s
+
+service:
+  extensions:
+    - sumologic
+    - health_check
+    - file_storage
+  pipelines:
+    metrics:
+      receivers:
+        - hostmetrics
+      processors:
+        - memory_limiter
+        - sumologic_schema
+        - batch
+      exporters:
+        - sumologic
+    logs/syslog:
+      receivers:
+        - filelog/syslog
+      processors:
+        - memory_limiter
+        - sumologic_syslog
+        - groupbyattrs
+        - sumologic_schema
+        - batch
+      exporters:
+        - sumologic
+    logs/dkg:
+      receivers:
+        - filelog/dpkg
+      processors:
+        - memory_limiter
+        - groupbyattrs
+        - sumologic_schema
+        - batch
+      exporters:
+        - sumologic


### PR DESCRIPTION
It adds default configuration to examples, which:

* scrapes host metrics
* scrapes logs from the following destinations:

  * /var/log/auth.log
  * /var/log/syslog
  * /var/log/daemon.log
  * /var/log/kern.log
  * /var/log/dpkg.log

* uses file storage to buffer data