### PR TITLE
chore(sumologicexporter): rename config errors

### DIFF
--- a/pkg/exporter/sumologicexporter/config.go
+++ b/pkg/exporter/sumologicexporter/config.go
@@ -127,19 +127,19 @@ func CreateDefaultHTTPClientSettings() confighttp.HTTPClientSettings {
 func (cfg *Config) Validate() error {
 
 	if len(cfg.MetadataAttributes) > 0 {
-		return fmt.Errorf(`*Deprecation warning*: metadata_attributes is not supported anymore.
+		return fmt.Errorf(`metadata_attributes is not supported anymore.
 Please consult the changelog at https://github.com/SumoLogic/sumologic-otel-collector/releases/tag/v0.49.0-sumo-0`,
 		)
 	}
 
 	if cfg.TranslateTelegrafMetrics {
-		return fmt.Errorf(`*Deprecation warning*: translate_telegraf_attributes is not supported anymore.
-		Please consult the changelog at https://github.com/SumoLogic/sumologic-otel-collector/releases/tag/v0.59.0-sumo-0`,
+		return fmt.Errorf(`translate_telegraf_attributes is not supported anymore.
+Please consult the changelog at https://github.com/SumoLogic/sumologic-otel-collector/releases/tag/v0.59.0-sumo-0`,
 		)
 	}
 
 	if cfg.TranslateAttributes {
-		return fmt.Errorf(`*Deprecation warning*: translate_attributes is not supported anymore.
+		return fmt.Errorf(`translate_attributes is not supported anymore.
 Please consult the changelog at https://github.com/SumoLogic/sumologic-otel-collector/releases/tag/v0.59.0-sumo-0`,
 		)
 	}

--- a/pkg/exporter/sumologicexporter/config_test.go
+++ b/pkg/exporter/sumologicexporter/config_test.go
@@ -110,7 +110,7 @@ func TestInitExporterInvalidConfiguration(t *testing.T) {
 		},
 		{
 			name: "deprecated metadata_attributes",
-			expectedError: errors.New(`*Deprecation warning*: metadata_attributes is not supported anymore.
+			expectedError: errors.New(`metadata_attributes is not supported anymore.
 Please consult the changelog at https://github.com/SumoLogic/sumologic-otel-collector/releases/tag/v0.49.0-sumo-0`,
 			),
 			cfg: &Config{


### PR DESCRIPTION
A follow-up to the discussion: https://github.com/SumoLogic/sumologic-otel-collector/pull/686#discussion_r978684183

The warnings about removed config options should not be called `deprecation_warning`