### PR TITLE
fix: cannot create credentials directory

### DIFF
--- a/examples/sumologic.yaml
+++ b/examples/sumologic.yaml
@@ -6,7 +6,7 @@ extensions:
   ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/extension/sumologicextension
   sumologic:
     install_token: ${SUMOLOGIC_INSTALL_TOKEN}
-    collector_credentials_directory: ~/.sumologic-otel-collector
+    collector_credentials_directory: /var/lib/otelcol-sumo/credentials
 
   ## Configuration for Health Check Extension
   ## Health Check extension enables an HTTP url that can be probed to check the status of the OpenTelemetry Collector


### PR DESCRIPTION
This commit fixes the following error:
2022-10-21T12:42:08.510+0200	error	sumologicextension@v0.57.2-sumo-1/extension.go:297	Unable to store collector credentials, they will be used now but won't be re-used on next run	{"kind": "extension", "name": "sumologic", "collector_name": "mstozek-mac-7e9e719a-5903-487c-8d35-eaa51811cad9", "collector_id": "0000000000355218", "error": "mkdir ~/.otelcol-credentials: no such file or directory"}

Apparently otelcol cannot resolve ~ to home directory properly.