### PR TITLE
docs: simplify Docker run instructions

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -84,7 +84,7 @@ Follow the steps for your platform below.
 1. Download the release binary:
 
     ```bash
-    curl -sLo otelcol-sumo "https://github.com/SumoLogic/sumologic-otel-collector/releases/download/v0.55.0-sumo-0/otelcol-sumo-0.55.0-sumo-0-linux_amd64"
+    curl -sLo otelcol-sumo "https://github.com/SumoLogic/sumologic-otel-collector/releases/download/v0.57.2-sumo-1/otelcol-sumo-0.57.2-sumo-1-linux_amd64"
     ```
 
 1. Install the release binary in your `PATH`:
@@ -117,7 +117,7 @@ Follow the steps for your platform below.
 1. Download the release binary:
 
     ```bash
-    curl -sLo otelcol-sumo "https://github.com/SumoLogic/sumologic-otel-collector/releases/download/v0.55.0-sumo-0/otelcol-sumo-0.55.0-sumo-0-linux_arm64"
+    curl -sLo otelcol-sumo "https://github.com/SumoLogic/sumologic-otel-collector/releases/download/v0.57.2-sumo-1/otelcol-sumo-0.57.2-sumo-1-linux_arm64"
     ```
 
 1. Install the release binary in your `PATH`:
@@ -150,7 +150,7 @@ Follow the steps for your platform below.
 1. Download the release binary:
 
     ```bash
-    curl -sLo otelcol-sumo "https://github.com/SumoLogic/sumologic-otel-collector/releases/download/v0.55.0-sumo-0/otelcol-sumo-0.55.0-sumo-0-darwin_amd64"
+    curl -sLo otelcol-sumo "https://github.com/SumoLogic/sumologic-otel-collector/releases/download/v0.57.2-sumo-1/otelcol-sumo-0.57.2-sumo-1-darwin_amd64"
     ```
 
 1. Install the release binary in your `PATH`:
@@ -183,7 +183,7 @@ Follow the steps for your platform below.
 1. Download the release binary:
 
     ```bash
-    curl -sLo otelcol-sumo "https://github.com/SumoLogic/sumologic-otel-collector/releases/download/v0.55.0-sumo-0/otelcol-sumo-0.55.0-sumo-0-darwin_arm64"
+    curl -sLo otelcol-sumo "https://github.com/SumoLogic/sumologic-otel-collector/releases/download/v0.57.2-sumo-1/otelcol-sumo-0.57.2-sumo-1-darwin_arm64"
     ```
 
 1. Install the release binary in your `PATH`:
@@ -303,7 +303,7 @@ repository.
 1. Set the release version variable:
 
    ```bash
-   export RELEASE_VERSION=0.55.0-sumo-0
+   export RELEASE_VERSION=0.57.2-sumo-1
    ```
 
 1. Prepare the configuration according to [this](Configuration.md) document and save it in `config.yaml`.
@@ -319,20 +319,9 @@ repository.
 1. Run the Sumo Logic Distribution for OpenTelemetry Collector in container, e.g.
 
     ```bash
-    $ docker run --rm -ti --name sumologic-otel-collector -v "$(pwd)/config.yaml:/etc/config.yaml" "public.ecr.aws/sumologic/sumologic-otel-collector:${RELEASE_VERSION}" --config /etc/config.yaml
-    2021-07-06T10:31:17.477Z      info      service/application.go:277      Starting otelcol-sumo-linux_amd64...    {"Version": "v0.0.10", "NumCPU": 4}
-    2021-07-06T10:31:17.477Z      info      service/application.go:185      Setting up own telemetry...
-    2021-07-06T10:31:17.478Z      info      service/telemetry.go:98 Serving Prometheus metrics      {"address": ":8888", "level": 0, "service.instance.id": "596814dd-d8ad-4a4f-b2e9-106c29c416a0"}
-    2021-07-06T10:31:17.478Z      info      service/application.go:220      Loading configuration...
-    2021-07-06T10:31:17.479Z      info      service/application.go:236      Applying configuration...
-    2021-07-06T10:31:17.479Z      info      builder/exporters_builder.go:274        Exporter was built.     {"kind": "exporter", "exporter": "sumologic"}
-    2021-07-06T10:31:17.479Z      info      builder/pipelines_builder.go:204        Pipeline was built.     {"pipeline_name": "metrics/1", "pipeline_datatype": "metrics"}
-    2021-07-06T10:31:17.479Z      info      builder/receivers_builder.go:230        Receiver was built.     {"kind": "receiver", "name": "telegraf", "datatype": "metrics"}
-    2021-07-06T10:31:17.479Z      info      service/service.go:155  Starting extensions...
-    2021-07-06T10:31:17.479Z      info      builder/extensions_builder.go:53        Extension is starting...        {"kind": "extension", "name": "sumologic"}
-    2021-07-06T10:31:17.479Z      info      sumologicextension@v0.27.0/extension.go:128     Locally stored credentials not found, registering the collector {"kind": "extension", "name": "sumologic"}
-    2021-07-06T10:31:17.480Z      info      sumologicextension@v0.27.0/credentials.go:142   Calling register API    {"kind": "extension", "name": "sumologic", "URL": "https://collectors.sumologic.com/api/v1/collector/register"}
-    ...
+    docker run --rm -ti --name sumologic-otel-collector \
+       -v "$(pwd)/config.yaml:/etc/otel/config.yaml" \
+       "public.ecr.aws/sumologic/sumologic-otel-collector:${RELEASE_VERSION}"
     ```
 
 ### Important note about local state files when using `sumologicextension`


### PR DESCRIPTION
Fixes #790

We probably don't need to show the output of the `docker run` command at all; we don't show it in other examples for running the binary either.
I have also changed the target path of the config file for simplicity and split the command into multiline lines so that it is visible in the viewport without scrolling.