### PR TITLE
fix(scripts/install.sh): don't use sudo

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -37,7 +37,7 @@ To run it as a standalone process you only need to run the binary file downloade
 1. Run installation script:
 
     ```bash
-    bash <(curl -s https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector/main/scripts/install.sh) --installation-token "${SUMOLOGIC_INSTALL_TOKEN}"
+    sudo bash <(curl -s https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector/main/scripts/install.sh) --installation-token "${SUMOLOGIC_INSTALL_TOKEN}"
     ```
 
     It is going to perform the following operations:


### PR DESCRIPTION
Don't use sudo in the script and have it exit if it's not run as root. This way the user has much better control over what it does, and won't be surprised by the script trying to run commands as root quietly.

I haven't added a test for this because it's a major pain to manage Linux users in Go, and the change is simple enough. Existing tests pass because they run as root to begin with.