### PR TITLE
feat(scripts/install.sh): do not prompt user for confirmation

### DIFF
--- a/pkg/scripts_test/command.go
+++ b/pkg/scripts_test/command.go
@@ -13,7 +13,6 @@ import (
 
 type installOptions struct {
 	installToken     string
-	autoconfirm      bool
 	disableSystemd   bool
 	tags             map[string]string
 	skipInstallToken bool
@@ -31,10 +30,6 @@ func (io *installOptions) string() []string {
 
 	if io.installToken != "" {
 		opts = append(opts, "--installation-token", io.installToken)
-	}
-
-	if io.autoconfirm {
-		opts = append(opts, "--yes")
 	}
 
 	if io.disableSystemd {
@@ -138,38 +133,6 @@ func runScript(ch check) (int, []string, error) {
 
 		// otherwise ensure there is no error
 		require.NoError(ch.test, err)
-
-		if ch.installOptions.autoconfirm {
-			continue
-		}
-
-		if strings.Contains(strLine, "Showing full changelog") {
-			// show changelog
-			_, err = in.Write([]byte("\n"))
-			require.NoError(ch.test, err)
-
-			// accept changes and proceed with the installation
-			_, err = in.Write([]byte("y\n"))
-			require.NoError(ch.test, err)
-		}
-
-		if strings.Contains(strLine, "We are going to get and set up default configuration for you") {
-			// approve installation config
-			_, err = in.Write([]byte("y\n"))
-			require.NoError(ch.test, err)
-		}
-
-		if strings.Contains(strLine, "We are going to set up systemd service") {
-			// approve installation config
-			_, err = in.Write([]byte("y\n"))
-			require.NoError(ch.test, err)
-		}
-
-		if strings.Contains(strLine, "Going to remove") {
-			// approve installation config
-			_, err = in.Write([]byte("y\n"))
-			require.NoError(ch.test, err)
-		}
 	}
 
 	code, err := exitCode(cmd)

--- a/pkg/scripts_test/install_test.go
+++ b/pkg/scripts_test/install_test.go
@@ -11,9 +11,8 @@ func tearDown(t *testing.T) {
 	ch := check{
 		test: t,
 		installOptions: installOptions{
-			uninstall:   true,
-			purge:       true,
-			autoconfirm: true,
+			uninstall: true,
+			purge:     true,
 		},
 	}
 
@@ -66,7 +65,6 @@ func TestInstallScript(t *testing.T) {
 			name: "override default config",
 			options: installOptions{
 				skipInstallToken: true,
-				autoconfirm:      true,
 			},
 			preActions: []checkFunc{preActionMockConfig},
 			preChecks:  []checkFunc{checkBinaryNotCreated, checkConfigCreated, checkUserConfigNotCreated, checkUserNotExists},


### PR DESCRIPTION
Instead of prompting for confirmation, we should install everything by default and provide flags to disable specific features.

I'm planning to add flags to disable default config creation and systemd configuration in separate PRs.