### PR TITLE
Upgrade `sumologicextension` version in the exporter

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -99,7 +99,7 @@ Updating OT core involves:
 
 [milestone]: https://github.com/SumoLogic/sumologic-otel-collector/milestones
 
-### Updating patched processors
+### Updating patched components
 
 We currently maintain patches for the following upstream components:
 

--- a/pkg/exporter/sumologicexporter/go.mod
+++ b/pkg/exporter/sumologicexporter/go.mod
@@ -3,7 +3,7 @@ module github.com/SumoLogic/sumologic-otel-collector/pkg/exporter/sumologicexpor
 go 1.18
 
 require (
-	github.com/SumoLogic/sumologic-otel-collector/pkg/extension/sumologicextension v0.0.54-beta.0
+	github.com/SumoLogic/sumologic-otel-collector/pkg/extension/sumologicextension v0.57.2-sumo-1
 	github.com/klauspost/compress v1.15.11
 	github.com/stretchr/testify v1.8.0
 	go.opencensus.io v0.23.0


### PR DESCRIPTION
The problem: the version of `sumologicextension` in `go.mod` in the `sumologicexporter` is set to a very old one (`v0.0.54-beta`). This doesn't break the build of the collector, because both in the exporter and in `otelcol-builder` the source of this extension is explicitly replaced with relative path in the repository. However, if we use the exporter in some other project (in my case: a test using `testbed` framework from the upstream), the extension is fetched as an indirect dependency with version `v0.0.54-beta`. Many breaking changes have occurred since then, so the project does not compile.

Technically it would be the best to upgrade this regularly, but because of our version naming convention, I think that adding this to the upgrading script might overcomplicate the release process (we would have to introduce another `make` option). Additionally, this is not extremely important, I'm mainly pointing out that the problem exists. As for now, I'm just changing the version to the current one.