### PR TITLE
docs: update install command

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -37,7 +37,7 @@ To run it as a standalone process you only need to run the binary file downloade
 1. Run installation script:
 
     ```bash
-    sudo bash <(curl -s https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector/main/scripts/install.sh) --installation-token "${SUMOLOGIC_INSTALL_TOKEN}"
+    curl -s https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector/main/scripts/install.sh | sudo bash -s -- --installation-token "${SUMOLOGIC_INSTALL_TOKEN}"
     ```
 
     It is going to perform the following operations:


### PR DESCRIPTION
The install script needs to explicitly be run with sudo, and this makes process substitution annoying, as sudo closes any descriptors other than the standard ones. Use a pipe from curl instead.

This was broken in #795. As it, it would result in the following error:
```bash
bash: /dev/fd/63: No such file or directory
```