### PR TITLE
fix(scripts/install.sh): use correct input for user prompts

### DIFF
--- a/pkg/scripts_test/check.go
+++ b/pkg/scripts_test/check.go
@@ -19,6 +19,7 @@ import (
 type check struct {
 	test                *testing.T
 	installOptions      installOptions
+	fakeTTY             bool
 	code                int
 	err                 error
 	expectedInstallCode int

--- a/pkg/scripts_test/common.go
+++ b/pkg/scripts_test/common.go
@@ -18,6 +18,7 @@ type testSpec struct {
 	preActions        []checkFunc
 	conditionalChecks []condCheckFunc
 	installCode       int
+	fakeTTY           bool
 }
 
 // These checks always have to be true after a script execution

--- a/pkg/scripts_test/go.mod
+++ b/pkg/scripts_test/go.mod
@@ -3,6 +3,7 @@ module sumologic_scripts_tests
 go 1.18
 
 require (
+	github.com/creack/pty v1.1.18
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/pkg/scripts_test/go.sum
+++ b/pkg/scripts_test/go.sum
@@ -1,3 +1,5 @@
+github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/scripts_test/install_unix_test.go
+++ b/pkg/scripts_test/install_unix_test.go
@@ -121,6 +121,17 @@ func TestInstallScript(t *testing.T) {
 			},
 		},
 		{
+			name:    "installation token only in tty",
+			fakeTTY: true,
+			options: installOptions{
+				skipSystemd:  true,
+				installToken: installToken,
+			},
+			preChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
+			postChecks: []checkFunc{checkBinaryCreated, checkBinaryIsRunning, checkConfigCreated, checkUserConfigCreated, checkTokenInConfig,
+				checkSystemdConfigNotCreated, checkUserNotExists},
+		},
+		{
 			name: "installation token only (envs)",
 			options: installOptions{
 				skipSystemd: true,
@@ -329,6 +340,7 @@ func TestInstallScript(t *testing.T) {
 			options: installOptions{
 				uninstall: true,
 			},
+			fakeTTY:    true,
 			preActions: []checkFunc{preActionMockStructure},
 			preChecks:  []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkUserNotExists},
 			postChecks: []checkFunc{checkBinaryNotCreated, checkConfigCreated, checkUserConfigCreated},
@@ -348,10 +360,22 @@ func TestInstallScript(t *testing.T) {
 			options: installOptions{
 				uninstall: true,
 			},
+			fakeTTY:           true,
 			preActions:        []checkFunc{preActionMockSystemdStructure},
 			preChecks:         []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkSystemdConfigCreated, checkUserNotExists},
 			postChecks:        []checkFunc{checkBinaryNotCreated, checkConfigCreated, checkUserConfigCreated, checkSystemdConfigCreated, checkUserNotExists},
 			conditionalChecks: []condCheckFunc{checkSystemdAvailability},
+		},
+		{
+			name: "purge with autoconfirm",
+			options: installOptions{
+				uninstall:   true,
+				purge:       true,
+				autoconfirm: true, // tests run without a tty by default, so they need --yes
+			},
+			preActions: []checkFunc{preActionMockStructure},
+			preChecks:  []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkUserNotExists},
+			postChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated},
 		},
 		{
 			name: "purge",
@@ -359,6 +383,7 @@ func TestInstallScript(t *testing.T) {
 				uninstall: true,
 				purge:     true,
 			},
+			fakeTTY:    true,
 			preActions: []checkFunc{preActionMockStructure},
 			preChecks:  []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkUserNotExists},
 			postChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated},
@@ -366,8 +391,9 @@ func TestInstallScript(t *testing.T) {
 		{
 			name: "systemd purge",
 			options: installOptions{
-				uninstall: true,
-				purge:     true,
+				uninstall:   true,
+				purge:       true,
+				autoconfirm: true,
 			},
 			preActions:        []checkFunc{preActionMockSystemdStructure},
 			preChecks:         []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkSystemdConfigCreated, checkUserNotExists},

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -353,6 +353,16 @@ function check_dependencies() {
     fi
 }
 
+# Return an input we can use to prompt the user.
+# Normally this is just stdin, but if that is redirected, we use /dev/tty directly.
+function get_interactive_input() {
+    if tty -s; then
+        echo "/dev/stdin"
+    else
+        echo "/dev/tty"
+    fi
+}
+
 function get_latest_version() {
     local versions
     readonly versions="${1}"
@@ -487,8 +497,12 @@ function ask_to_continue() {
         return 0
     fi
 
+    local input
+    input=$(get_interactive_input)
+    echo "Getting input from ${input}"
+
     local choice
-    read -rp "Continue (y/N)? " choice
+    read -rp "Continue (y/N)?" choice < "${input}"
     case "${choice}" in
     y|Y ) ;;
     n|N | * )


### PR DESCRIPTION
The change to the script is pretty straightforward. If we do `curl -s ... | sudo bash`, then `bash` reads commands from stdin and we can't prompt the user for input using that fd. Instead, we detect if we're running in a terminal, and if we aren't, we explicitly read from `/dev/tty`. This fixes the problem.

The change to tests is more complicated. Tests do not run in a terminal, and the script would now expect input from them via `/dev/tty`. In order to test both cases, I've done the following:
1. Existing tests run with `--yes`, which sidesteps the problem.
2. A new option was added to the test runner, which wraps the test in a fake terminal and uses that for communication.
3. Added new versions of existing tests which use the fake terminal and don't use `--yes`.