### PR TITLE
feat(scripts/install.sh): add flag to keep downloads

### DIFF
--- a/pkg/scripts_test/command.go
+++ b/pkg/scripts_test/command.go
@@ -12,16 +12,17 @@ import (
 )
 
 type installOptions struct {
-	installToken     string
-	autoconfirm      bool
-	disableSystemd   bool
-	tags             map[string]string
-	skipInstallToken bool
-	envs             map[string]string
-	uninstall        bool
-	purge            bool
-	apiBaseURL       string
-	downloadOnly     bool
+	installToken      string
+	autoconfirm       bool
+	disableSystemd    bool
+	tags              map[string]string
+	skipInstallToken  bool
+	envs              map[string]string
+	uninstall         bool
+	purge             bool
+	apiBaseURL        string
+	downloadOnly      bool
+	dontKeepDownloads bool
 }
 
 func (io *installOptions) string() []string {
@@ -55,6 +56,10 @@ func (io *installOptions) string() []string {
 
 	if io.downloadOnly {
 		opts = append(opts, "--download-only")
+	}
+
+	if !io.dontKeepDownloads {
+		opts = append(opts, "--keep-downloads")
 	}
 
 	if len(io.tags) > 0 {

--- a/pkg/scripts_test/install_test.go
+++ b/pkg/scripts_test/install_test.go
@@ -314,6 +314,15 @@ func TestInstallScript(t *testing.T) {
 			conditionalChecks: []condCheckFunc{checkSystemdAvailability},
 			installCode:       3, // because of invalid install token
 		},
+		{
+			name: "don't keep downloads",
+			options: installOptions{
+				skipInstallToken:  true,
+				dontKeepDownloads: true,
+			},
+			preChecks:  []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
+			postChecks: []checkFunc{checkBinaryCreated, checkBinaryIsRunning, checkConfigCreated, checkUserConfigNotCreated, checkSystemdConfigNotCreated},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ch := check{


### PR DESCRIPTION
Add a private flag to keep downloaded OT binaries between install script runs. This uses the `-z` curl flag which only downloads the binary if it was changed more recently than the existing file on disk. This is enabled in all tests with the exception of one, which was newly added, and results in significant test speed up (~5 minutes to ~2 minutes).

Looking at the curl changes, we should factor out the common parameters, but I'd like to do that in a separate PR.