### PR TITLE
Update orbs tools versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  aws-cli: circleci/aws-cli@1.3.1
-  kubernetes: circleci/kubernetes@0.11.2
+  aws-cli: circleci/aws-cli@3.1.3
+  kubernetes: circleci/kubernetes@1.3.1
 
 executors:
   golang:


### PR DESCRIPTION
Fix for:
```
error: exec plugin: invalid apiVersion "client.authentication.k8s.io/v1alpha1"
```

https://app.circleci.com/pipelines/github/SumoLogic/sumologic-otel-collector/1643/workflows/3b328231-d4c1-4d3b-b78b-332a041d705d/jobs/23