### PR TITLE
fix(config): flag parsing after core upgrade

### DIFF
--- a/otelcolbuilder/.gitignore
+++ b/otelcolbuilder/.gitignore
@@ -4,3 +4,4 @@ cmd/*
 !cmd/configprovider.go
 !cmd/main.go.patch
 !cmd/fips.go
+!cmd/flags.go

--- a/otelcolbuilder/cmd/collector_config_test.go
+++ b/otelcolbuilder/cmd/collector_config_test.go
@@ -93,8 +93,7 @@ func TestBuiltCollectorWithConfigurationFiles(t *testing.T) {
 			require.NoError(t, err)
 
 			locations := []string{tc.configFile}
-			setFlags := []string{}
-			cp, err := NewConfigProvider(locations, setFlags)
+			cp, err := NewConfigProvider(locations)
 			require.NoError(t, err)
 
 			t.Log("Creating new app...")

--- a/otelcolbuilder/cmd/configprovider.go
+++ b/otelcolbuilder/cmd/configprovider.go
@@ -16,8 +16,9 @@ package main
 
 import (
 	"errors"
+	"flag"
+	"io"
 	"os"
-	"strings"
 
 	"github.com/SumoLogic/sumologic-otel-collector/pkg/configprovider/globprovider"
 	"go.opentelemetry.io/collector/confmap"
@@ -30,47 +31,35 @@ import (
 
 // This file contains modifications to the collector settings which inject a custom config provider
 // Otherwise, it tries to be as close to the upstream defaults as defined here:
-// https://github.com/open-telemetry/opentelemetry-collector/blob/72011ca22dff6614d518768b3bb53a1193c6ad02/service/command.go#L38
+// https://github.com/open-telemetry/opentelemetry-collector/blob/65dfc325d974be8ebb7c170b90c6646f9eaef27b/service/command.go#L38
 
 func UseCustomConfigProvider(params *service.CollectorSettings) error {
-
 	// to create the provider, we need config locations passed in via the command line
 	// to get these, we take the command the service uses to start, parse the flags, and read the values
 	var err error
-	tempCmd := service.NewCommand(*params)
-	_, flags, err := tempCmd.Find(os.Args[1:])
-	if err != nil {
-		return err
-	}
+	flagset := flags()
 
-	err = tempCmd.ParseFlags(flags)
+	// drop the output from the flagset, we only want to parse
+	// by default it prints error messages to stdout :(
+	flagset.Init("", flag.ContinueOnError)
+	flagset.SetOutput(io.Discard)
+
+	// actually parse the flags and get the config locations
+	err = flagset.Parse(os.Args[1:])
 	if err != nil {
-		// either the flags are completely invalid or don't use config at all
-		// in both cases we don't need to do anything
+		// if we fail parsing, we just let the actual command logic deal with it
+		// here we only care about config locations
 		return nil
 	}
 
-	locations, err := tempCmd.Flags().GetStringArray("config")
-	if err != nil {
-		return err
-	}
+	locations := getConfigFlag(flagset)
 	if len(locations) == 0 {
 		return errors.New("at least one config flag must be provided")
 	}
-
-	setFlags, err := tempCmd.Flags().GetStringArray("set")
-	if err != nil {
-		return err
-	}
-
-	// Not sure why this is necessary, config locations other than the first have an extra space at the start
-	var cleanedLocations []string
-	for _, location := range locations {
-		cleanedLocations = append(cleanedLocations, strings.TrimSpace(location))
-	}
+	os.Exit(1)
 
 	// create the config provider using the locations
-	params.ConfigProvider, err = NewConfigProvider(cleanedLocations, setFlags)
+	params.ConfigProvider, err = NewConfigProvider(locations)
 	if err != nil {
 		return err
 	}
@@ -78,15 +67,15 @@ func UseCustomConfigProvider(params *service.CollectorSettings) error {
 	return nil
 }
 
-func NewConfigProvider(locations []string, setFlags []string) (service.ConfigProvider, error) {
-	settings := NewConfigProviderSettings(locations, setFlags)
+func NewConfigProvider(locations []string) (service.ConfigProvider, error) {
+	settings := NewConfigProviderSettings(locations)
 	return service.NewConfigProvider(settings)
 }
 
 // see https://github.com/open-telemetry/opentelemetry-collector/blob/72011ca22dff6614d518768b3bb53a1193c6ad02/service/command.go#L38
 // for the logic we're emulating here
 // we only add the glob provider, everything else should be the same
-func NewConfigProviderSettings(locations []string, setFlags []string) service.ConfigProviderSettings {
+func NewConfigProviderSettings(locations []string) service.ConfigProviderSettings {
 	return service.ConfigProviderSettings{
 		ResolverSettings: confmap.ResolverSettings{
 			URIs:       locations,

--- a/otelcolbuilder/cmd/flags.go
+++ b/otelcolbuilder/cmd/flags.go
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a copy of https://github.com/open-telemetry/opentelemetry-collector/blob/65dfc325d974be8ebb7c170b90c6646f9eaef27b/service/flags.go
+// that we maintain to be able to independently parse command line flags, until either the necessary names become public,
+// or there's a better way of customizing config providers
+
+package main // import "go.opentelemetry.io/collector/service"
+
+import (
+	"errors"
+	"flag"
+	"strings"
+
+	"go.opentelemetry.io/collector/featuregate"
+)
+
+const (
+	configFlag       = "config"
+	featureGatesFlag = "feature-gates"
+)
+
+type configFlagValue struct {
+	values []string
+	sets   []string
+}
+
+func (s *configFlagValue) Set(val string) error {
+	s.values = append(s.values, val)
+	return nil
+}
+
+func (s *configFlagValue) String() string {
+	return "[" + strings.Join(s.values, ", ") + "]"
+}
+
+func flags() *flag.FlagSet {
+	flagSet := new(flag.FlagSet)
+
+	cfgs := new(configFlagValue)
+	flagSet.Var(cfgs, configFlag, "Locations to the config file(s), note that only a"+
+		" single location can be set per flag entry e.g. `--config=file:/path/to/first --config=file:path/to/second`.")
+
+	flagSet.Func("set",
+		"Set arbitrary component config property. The component has to be defined in the config file and the flag"+
+			" has a higher precedence. Array config properties are overridden and maps are joined. Example --set=processors.batch.timeout=2s",
+		func(s string) error {
+			idx := strings.Index(s, "=")
+			if idx == -1 {
+				// No need for more context, see TestSetFlag/invalid_set.
+				return errors.New("missing equal sign")
+			}
+			cfgs.sets = append(cfgs.sets, "yaml:"+strings.TrimSpace(strings.ReplaceAll(s[:idx], ".", "::"))+": "+strings.TrimSpace(s[idx+1:]))
+			return nil
+		})
+
+	flagSet.Var(featuregate.FlagValue{}, featureGatesFlag,
+		"Comma-delimited list of feature gate identifiers. Prefix with '-' to disable the feature. '+' or no prefix will enable the feature.")
+
+	return flagSet
+}
+
+func getConfigFlag(flagSet *flag.FlagSet) []string {
+	cfv := flagSet.Lookup(configFlag).Value.(*configFlagValue)
+	return append(cfv.values, cfv.sets...)
+}


### PR DESCRIPTION
The core upgrade in #826 changed the way command line flags are parsed. Instead of trying to hack around this as before, I simply copied the `flags.go` file from upstream. We should figure out a way to make this less hacky. Making the names public would help, but there should be a simpler way of customizing config providers.