### PR TITLE
fix(scripts/install.sh): verify install correctly if binary not in PATH

### DIFF
--- a/pkg/scripts_test/install_unix_test.go
+++ b/pkg/scripts_test/install_unix_test.go
@@ -77,6 +77,27 @@ func TestInstallScript(t *testing.T) {
 			},
 		},
 		{
+			name: "installation token only, binary not in PATH",
+			options: installOptions{
+				skipSystemd:  true,
+				installToken: installToken,
+				envs: map[string]string{
+					"PATH": "/sbin:/bin:/usr/sbin:/usr/bin",
+				},
+			},
+			preChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkConfigPathPermissions,
+				checkUserConfigCreated,
+				checkTokenInConfig,
+				checkSystemdConfigNotCreated,
+				checkUserNotExists,
+			},
+		},
+		{
 			name: "installation token only (envs)",
 			options: installOptions{
 				skipSystemd: true,

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -410,6 +410,25 @@ function get_arch_type() {
     echo "${arch_type}"
 }
 
+# Verify that the otelcol install is correct
+function verify_installation() {
+    local otel_command
+    if command -v otelcol-sumo; then
+        otel_command="otelcol-sumo"
+    else
+        echo "WARNING: ${SUMO_BINARY_PATH} is not in \$PATH"
+        otel_command="${SUMO_BINARY_PATH}"
+    fi
+    echo "Running ${otel_command} --version to verify installation"
+    OUTPUT="$(${otel_command} --version || true)"
+    readonly OUTPUT
+
+    if [[ -z "${OUTPUT}" ]]; then
+        echo "Installation failed. Please try again"
+        exit 1
+    fi
+}
+
 # Get installed version of otelcol-sumo
 function get_installed_version() {
     if [[ -f "${SUMO_BINARY_PATH}" ]]; then
@@ -1088,13 +1107,7 @@ else
     echo -e "Setting ${SUMO_BINARY_PATH} to be executable"
     chmod +x "${SUMO_BINARY_PATH}"
 
-    OUTPUT="$(otelcol-sumo --version || true)"
-    readonly OUTPUT
-
-    if [[ -z "${OUTPUT}" ]]; then
-        echo "Installation failed. Please try again"
-        exit 1
-    fi
+    verify_installation
 
     echo -e "Installation succeded:\t$(otelcol-sumo --version)"
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -286,7 +286,7 @@ function check_dependencies() {
         error=1
     fi
 
-    for cmd in echo sed curl head grep sort mv chmod envsubst getopts hostname bc touch xargs; do
+    for cmd in echo sed curl head grep sort mv chmod getopts hostname bc touch xargs; do
         if ! command -v "${cmd}" &> /dev/null; then
             echo "Command '${cmd}' not found. Please install it."
             error=1


### PR DESCRIPTION
On some systems, most notably RHEL, the PATH for `sudo` is restricted via the `secure_path` option in `sudoers`, and doesn't contain `/usr/local/bin`, where we install otel. This causes the installation verification check to fail, even if the installation may otherwise be valid.

Instead check if the binary is in the PATH, emit a warning if so, and then verify using the full path of the binary.