### PR TITLE
fix(otelcolbuilder): bump dependencies to v0.66.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ This release introduces the following breaking changes:
 - chore(deps): bump go-boringcrypto to 1.18.7b7 [#746]
 - feat(sourceprocessor): ensure that '_collector' is set before other source headers [#824]
 - chore(deps): upgrade Telegraf to 1.24.3-sumo-1 [#828]
-- chore: upgrade OT core to v0.66.0 [#826] [#844]
+- chore: upgrade OT core to v0.66.0 [#826] [#844] [#849]
 
 ### Removed
 
@@ -54,6 +54,7 @@ This release introduces the following breaking changes:
 [#828]: https://github.com/SumoLogic/sumologic-otel-collector/pull/828
 [#826]: https://github.com/SumoLogic/sumologic-otel-collector/pull/826
 [#844]: https://github.com/SumoLogic/sumologic-otel-collector/pull/844
+[#849]: https://github.com/SumoLogic/sumologic-otel-collector/pull/849
 [upgrade_guide_unreleased]: ./docs/upgrading.md#unreleased
 
 ## [v0.57.2-sumo-1]

--- a/otelcolbuilder/.otelcol-builder.yaml
+++ b/otelcolbuilder/.otelcol-builder.yaml
@@ -20,11 +20,11 @@ exporters:
   # Since include-code was removed we need to manually add all core components that we want to include:
   # https://github.com/open-telemetry/opentelemetry-collector/pull/4616
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector v0.64.1
+    gomod: go.opentelemetry.io/collector v0.66.0
   - import: go.opentelemetry.io/collector/exporter/otlpexporter
-    gomod: go.opentelemetry.io/collector v0.64.1
+    gomod: go.opentelemetry.io/collector v0.66.0
   - import: go.opentelemetry.io/collector/exporter/otlphttpexporter
-    gomod: go.opentelemetry.io/collector v0.64.1
+    gomod: go.opentelemetry.io/collector v0.66.0
 
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter v0.66.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.66.0"
@@ -52,9 +52,9 @@ processors:
   # Since include-code was removed we need to manually add all core components that we want to include:
   # https://github.com/open-telemetry/opentelemetry-collector/pull/4616
   - import: go.opentelemetry.io/collector/processor/batchprocessor
-    gomod: go.opentelemetry.io/collector v0.64.1
+    gomod: go.opentelemetry.io/collector v0.66.0
   - import: go.opentelemetry.io/collector/processor/memorylimiterprocessor
-    gomod: go.opentelemetry.io/collector v0.64.1
+    gomod: go.opentelemetry.io/collector v0.66.0
 
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.66.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.66.0"
@@ -89,7 +89,7 @@ receivers:
   # Since include-code was removed we need to manually add all core components that we want to include:
   # https://github.com/open-telemetry/opentelemetry-collector/pull/4616
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector v0.64.1
+    gomod: go.opentelemetry.io/collector v0.66.0
 
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.66.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver v0.66.0"
@@ -165,9 +165,9 @@ extensions:
   # Since include-code was removed we need to manually add all core components that we want to include:
   # https://github.com/open-telemetry/opentelemetry-collector/pull/4616
   - import: go.opentelemetry.io/collector/extension/zpagesextension
-    gomod: go.opentelemetry.io/collector v0.64.1
+    gomod: go.opentelemetry.io/collector v0.66.0
   - import: go.opentelemetry.io/collector/extension/ballastextension
-    gomod: go.opentelemetry.io/collector v0.64.1
+    gomod: go.opentelemetry.io/collector v0.66.0
 
   # Upstream extensions:
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension v0.66.0"


### PR DESCRIPTION
Some components were not bumped in #846, because they had version `v0.64.1` and the upgrading script omitted them.