### PR TITLE
fix(build): remove enable_unstable tag

### DIFF
--- a/otelcolbuilder/Makefile
+++ b/otelcolbuilder/Makefile
@@ -87,7 +87,6 @@ _builder:
 _gobuild:
 	(cd cmd && \
 		CGO_ENABLED=$(CGO_ENABLED) go build -v \
-		-tags enable_unstable \
 		-ldflags=$(LDFLAGS) \
 		-trimpath \
 		-o ./$(BINARY_NAME)$(BUILDER_BIN_EXT) . \
@@ -98,7 +97,6 @@ _gobuild:
 _gobuild_debug:
 	(cd cmd && \
 		CGO_ENABLED=$(CGO_ENABLED) go build -v \
-		-tags enable_unstable \
 		-race \
 		-gcflags "all=-N -l" \
 		-o ./$(BINARY_NAME)-debug$(BUILDER_BIN_EXT) . \


### PR DESCRIPTION
This tag was removed in 0.58.0 and is no longer necessary to enable the persistent queue, which is now included by default.