### PR TITLE
fix(otelcolbuilder): use correct upstream modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.66.0-sumo-0...main
 
+### Fixed
+
+- fix(otelcolbuilder): use correct upstream modules [#864]
+
+[#864]: https://github.com/SumoLogic/sumologic-otel-collector/pull/864
+
 ## [v0.66.0-sumo-0]
 
 ### Released 2022-12-08

--- a/otelcolbuilder/.otelcol-builder.yaml
+++ b/otelcolbuilder/.otelcol-builder.yaml
@@ -19,12 +19,9 @@ exporters:
 
   # Since include-code was removed we need to manually add all core components that we want to include:
   # https://github.com/open-telemetry/opentelemetry-collector/pull/4616
-  - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector v0.66.0
-  - import: go.opentelemetry.io/collector/exporter/otlpexporter
-    gomod: go.opentelemetry.io/collector v0.66.0
-  - import: go.opentelemetry.io/collector/exporter/otlphttpexporter
-    gomod: go.opentelemetry.io/collector v0.66.0
+  - gomod: "go.opentelemetry.io/collector/exporter/loggingexporter v0.66.0"
+  - gomod: "go.opentelemetry.io/collector/exporter/otlpexporter v0.66.0"
+  - gomod: "go.opentelemetry.io/collector/exporter/otlphttpexporter v0.66.0"
 
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter v0.66.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.66.0"
@@ -51,10 +48,8 @@ processors:
 
   # Since include-code was removed we need to manually add all core components that we want to include:
   # https://github.com/open-telemetry/opentelemetry-collector/pull/4616
-  - import: go.opentelemetry.io/collector/processor/batchprocessor
-    gomod: go.opentelemetry.io/collector v0.66.0
-  - import: go.opentelemetry.io/collector/processor/memorylimiterprocessor
-    gomod: go.opentelemetry.io/collector v0.66.0
+  - gomod: "go.opentelemetry.io/collector/processor/batchprocessor v0.66.0"
+  - gomod: "go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.66.0"
 
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.66.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.66.0"
@@ -88,8 +83,7 @@ receivers:
 
   # Since include-code was removed we need to manually add all core components that we want to include:
   # https://github.com/open-telemetry/opentelemetry-collector/pull/4616
-  - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector v0.66.0
+  - gomod: "go.opentelemetry.io/collector/receiver/otlpreceiver v0.66.0"
 
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.66.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver v0.66.0"
@@ -164,10 +158,8 @@ extensions:
 
   # Since include-code was removed we need to manually add all core components that we want to include:
   # https://github.com/open-telemetry/opentelemetry-collector/pull/4616
-  - import: go.opentelemetry.io/collector/extension/zpagesextension
-    gomod: go.opentelemetry.io/collector v0.66.0
-  - import: go.opentelemetry.io/collector/extension/ballastextension
-    gomod: go.opentelemetry.io/collector v0.66.0
+  - gomod: "go.opentelemetry.io/collector/extension/zpagesextension v0.66.0"
+  - gomod: "go.opentelemetry.io/collector/extension/ballastextension v0.66.0"
 
   # Upstream extensions:
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension v0.66.0"


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

The import paths for most upstream Go modules are not a part of the `go.opentelemetry.io/collector` module. Version pinning was not working due to the mismatch.

The issue can be reproduced by running `make build` from the `otelcolbuilder` directory and then checking `./cmd/go.mod` for `v0.67.0` which should not be pulled in.