### PR TITLE
docs(contributing.md): update proposed go.work file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,9 @@ use (
         ./pkg/processor/sumologicschemaprocessor
         ./pkg/processor/sumologicsyslogprocessor
         ./pkg/receiver/telegrafreceiver
+        ./pkg/configprovider/globprovider
+        ./pkg/scripts_test
+        ./pkg/tools/udpdemux
 )
 ```
 


### PR DESCRIPTION
The proposed `go.work` file did not contain all necessary directories, which caused `make golint` to fail.