### PR TITLE
[processor/sumologicschema]: allow aggregating attributes with given name patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat(sumologicschemaprocessor): add nesting processor [#877]
 - feat(sumologicschemaprocessor): add allowlist and denylist to nesting processor [#880]
+- feat(sumologicschemaprocessor) allow aggregating attributes with given name patterns [#871]
 
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.67.0-sumo-0...main
 [#877]: https://github.com/SumoLogic/sumologic-otel-collector/pull/877
 [#880]: https://github.com/SumoLogic/sumologic-otel-collector/pull/880
+[#871]: https://github.com/SumoLogic/sumologic-otel-collector/pull/871
 
 ## [v0.67.0-sumo-0]
 

--- a/pkg/processor/sumologicschemaprocessor/README.md
+++ b/pkg/processor/sumologicschemaprocessor/README.md
@@ -53,6 +53,14 @@ processors:
       # For example, if "k8s." is in this list, then all "k8s.*" attributes will not be nested.
       # default = []
       exclude: [<prefix>]
+
+    # Specifies if attributes matching given pattern should be mapped to a common key.
+    # See "Aggregating attributes" documentation chapter from this document.
+    # default = []
+    aggregate_attributes:
+      - attribute: <attribute>
+        prefixes: [<prefix>]
+      - ...
 ```
 
 ## Features
@@ -229,3 +237,31 @@ It is not possible to predict, what will be the result. It will have the followi
 ```
 
 However, it is not possible to know a priori if the value under key `c` will be equal to `d` or `e`.
+
+### Aggregating attributes
+
+Aggregating attributes allows to map attributes with keys with given prefixes to a common key.
+For example, it is possible to map all attributes with keys with prefixes `pod_` to a key `pods`.
+The names in resulting maps are the original key names with trimmed prefix.
+
+For given input, mapping keys with prefixes `pod_` to a key `pods`:
+
+```json
+{
+  "pod_a": "x",
+  "pod_b": "y",
+  "pod_c": "z"
+}
+```
+
+The result is:
+
+```json
+{
+  "pods": {
+    "a": "x",
+    "b": "y",
+    "c": "z"
+  }
+}
+```

--- a/pkg/processor/sumologicschemaprocessor/aggregate_attributes_processor.go
+++ b/pkg/processor/sumologicschemaprocessor/aggregate_attributes_processor.go
@@ -1,0 +1,179 @@
+// Copyright 2022 Sumo Logic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sumologicschemaprocessor
+
+import (
+	"fmt"
+	"strings"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// aggregateAttributesProcessor
+type aggregateAttributesProcessor struct {
+	aggregations []*aggregation
+}
+
+type aggregation struct {
+	attribute string
+	prefixes  []string
+}
+
+func newAggregateAttributesProcessor(config []aggregationPair) (*aggregateAttributesProcessor, error) {
+	aggregations := []*aggregation{}
+
+	for i := 0; i < len(config); i++ {
+		pair := &aggregation{
+			attribute: config[i].Attribute,
+			prefixes:  config[i].Patterns,
+		}
+		aggregations = append(aggregations, pair)
+	}
+
+	return &aggregateAttributesProcessor{aggregations: aggregations}, nil
+}
+
+func (proc *aggregateAttributesProcessor) processLogs(logs plog.Logs) error {
+	for i := 0; i < logs.ResourceLogs().Len(); i++ {
+		resourceLogs := logs.ResourceLogs().At(i)
+		err := proc.processAttributes(resourceLogs.Resource().Attributes())
+		if err != nil {
+			return err
+		}
+
+		for j := 0; j < resourceLogs.ScopeLogs().Len(); j++ {
+			scopeLogs := resourceLogs.ScopeLogs().At(j)
+			for k := 0; k < scopeLogs.LogRecords().Len(); k++ {
+				err := proc.processAttributes(scopeLogs.LogRecords().At(k).Attributes())
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (proc *aggregateAttributesProcessor) processMetrics(metrics pmetric.Metrics) error {
+	for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
+		resourceMetrics := metrics.ResourceMetrics().At(i)
+		err := proc.processAttributes(resourceMetrics.Resource().Attributes())
+		if err != nil {
+			return err
+		}
+
+		for j := 0; j < resourceMetrics.ScopeMetrics().Len(); j++ {
+			scopeMetrics := resourceMetrics.ScopeMetrics().At(j)
+			for k := 0; k < scopeMetrics.Metrics().Len(); k++ {
+				err := processMetricLevelAttributes(proc, scopeMetrics.Metrics().At(k))
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (proc *aggregateAttributesProcessor) processTraces(traces ptrace.Traces) error {
+	for i := 0; i < traces.ResourceSpans().Len(); i++ {
+		resourceSpans := traces.ResourceSpans().At(i)
+		err := proc.processAttributes(resourceSpans.Resource().Attributes())
+		if err != nil {
+			return err
+		}
+
+		for j := 0; j < resourceSpans.ScopeSpans().Len(); j++ {
+			scopeSpans := resourceSpans.ScopeSpans().At(j)
+			for k := 0; k < scopeSpans.Spans().Len(); k++ {
+				err := proc.processAttributes(scopeSpans.Spans().At(k).Attributes())
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (proc *aggregateAttributesProcessor) isEnabled() bool {
+	return len(proc.aggregations) != 0
+}
+
+func (*aggregateAttributesProcessor) ConfigPropertyName() string {
+	return "aggregate_attributes"
+}
+
+func (proc *aggregateAttributesProcessor) processAttributes(attributes pcommon.Map) error {
+	for i := 0; i < len(proc.aggregations); i++ {
+		curr := proc.aggregations[i]
+		names := []string{}
+		attrs := []pcommon.Value{}
+
+		for j := 0; j < len(curr.prefixes); j++ {
+			prefix := curr.prefixes[j]
+			// Create a new map. Unused keys will be added here,
+			// so we can check them against other prefixes.
+			newMap := pcommon.NewMap()
+			newMap.EnsureCapacity(attributes.Len())
+
+			attributes.Range(func(key string, value pcommon.Value) bool {
+				ok, trimmedKey := getNewKey(key, prefix)
+				if ok {
+					// TODO: Potential name conflict to resolve, eg.:
+					// pod_* matches pod_foo
+					// pod2_* matches pod2_foo
+					// both will be renamed to foo
+					names = append(names, trimmedKey)
+					val := pcommon.NewValueEmpty()
+					value.CopyTo(val)
+					attrs = append(attrs, val)
+				} else {
+					value.CopyTo(newMap.PutEmpty(key))
+				}
+				return true
+			})
+			newMap.CopyTo(attributes)
+		}
+
+		if len(names) != len(attrs) {
+			return fmt.Errorf(
+				"internal error: number of values does not equal the number of keys; len(keys) = %d, len(values) = %d",
+				len(names),
+				len(attrs),
+			)
+		}
+
+		aggregated := attributes.PutEmptyMap(curr.attribute)
+
+		for j := 0; j < len(names); j++ {
+			attrs[j].CopyTo(aggregated.PutEmpty(names[j]))
+		}
+	}
+
+	return nil
+}
+
+// Checks if the key has given prefix and trims it if so.
+func getNewKey(key string, prefix string) (bool, string) {
+	if strings.HasPrefix(key, prefix) {
+		return true, strings.TrimPrefix(key, prefix)
+	}
+
+	return false, ""
+}

--- a/pkg/processor/sumologicschemaprocessor/aggregate_attributes_processor.go
+++ b/pkg/processor/sumologicschemaprocessor/aggregate_attributes_processor.go
@@ -159,10 +159,13 @@ func (proc *aggregateAttributesProcessor) processAttributes(attributes pcommon.M
 			)
 		}
 
-		aggregated := attributes.PutEmptyMap(curr.attribute)
+		// Add a new attribute only if there's anything that should be put under it.
+		if len(names) > 0 {
+			aggregated := attributes.PutEmptyMap(curr.attribute)
 
-		for j := 0; j < len(names); j++ {
-			attrs[j].CopyTo(aggregated.PutEmpty(names[j]))
+			for j := 0; j < len(names); j++ {
+				attrs[j].CopyTo(aggregated.PutEmpty(names[j]))
+			}
 		}
 	}
 

--- a/pkg/processor/sumologicschemaprocessor/aggregate_attributes_processor_test.go
+++ b/pkg/processor/sumologicschemaprocessor/aggregate_attributes_processor_test.go
@@ -1,0 +1,238 @@
+package sumologicschemaprocessor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+func TestAggregation(t *testing.T) {
+	testCases := []struct {
+		name         string
+		input        map[string]pcommon.Value
+		expected     map[string]pcommon.Value
+		aggregations []*aggregation
+	}{
+		{
+			name: "three values one key",
+			input: map[string]pcommon.Value{
+				"pod_first":  pcommon.NewValueStr("first"),
+				"pod_second": pcommon.NewValueStr("second"),
+				"pod_third":  pcommon.NewValueStr("third"),
+			},
+			expected: map[string]pcommon.Value{
+				"pods": mapToPcommonValue(map[string]pcommon.Value{
+					"first":  pcommon.NewValueStr("first"),
+					"second": pcommon.NewValueStr("second"),
+					"third":  pcommon.NewValueStr("third"),
+				}),
+			},
+			aggregations: []*aggregation{
+				{
+					attribute: "pods",
+					prefixes:  []string{"pod_"},
+				},
+			},
+		},
+		{
+			name: "six values two keys",
+			input: map[string]pcommon.Value{
+				"pod_first":                pcommon.NewValueStr("first"),
+				"pod_second":               pcommon.NewValueStr("second"),
+				"pod_third":                pcommon.NewValueStr("third"),
+				"sono_ichi":                pcommon.NewValueInt(1),
+				"sono_ni":                  pcommon.NewValueInt(2),
+				"a totally unrelevant key": pcommon.NewValueBool(true),
+			},
+			expected: map[string]pcommon.Value{
+				"pods": mapToPcommonValue(map[string]pcommon.Value{
+					"first":  pcommon.NewValueStr("first"),
+					"second": pcommon.NewValueStr("second"),
+					"third":  pcommon.NewValueStr("third"),
+				}),
+				"counts": mapToPcommonValue(map[string]pcommon.Value{
+					"ichi": pcommon.NewValueInt(1),
+					"ni":   pcommon.NewValueInt(2),
+				}),
+				"a totally unrelevant key": pcommon.NewValueBool(true),
+			},
+			aggregations: []*aggregation{
+				{
+					attribute: "pods",
+					prefixes:  []string{"pod_"},
+				},
+				{
+					attribute: "counts",
+					prefixes:  []string{"sono_"},
+				},
+			},
+		},
+		{
+			name: "three prefixes, one key",
+			input: map[string]pcommon.Value{
+				"A_12": pcommon.NewValueStr("A12"),
+				"A_23": pcommon.NewValueStr("A23"),
+				"C_2":  pcommon.NewValueStr("C2"),
+				"B_3":  pcommon.NewValueStr("B3"),
+				"C_88": pcommon.NewValueStr("C88"),
+				"B_53": pcommon.NewValueStr("B53"),
+			},
+			expected: map[string]pcommon.Value{
+				"id": mapToPcommonValue(map[string]pcommon.Value{
+					"2":  pcommon.NewValueStr("C2"),
+					"3":  pcommon.NewValueStr("B3"),
+					"12": pcommon.NewValueStr("A12"),
+					"23": pcommon.NewValueStr("A23"),
+					"53": pcommon.NewValueStr("B53"),
+					"88": pcommon.NewValueStr("C88"),
+				}),
+			},
+			aggregations: []*aggregation{
+				{
+					attribute: "id",
+					prefixes:  []string{"B_", "A_", "C_"},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			processor := aggregateAttributesProcessor{
+				aggregations: testCase.aggregations,
+			}
+
+			attrs := mapToPcommonMap(testCase.input)
+
+			err := processor.processAttributes(attrs)
+			require.NoError(t, err)
+
+			expected := mapToPcommonMap(testCase.expected)
+
+			require.Equal(t, expected.AsRaw(), attrs.AsRaw())
+		})
+	}
+}
+
+func TestMetrics(t *testing.T) {
+	aggregations := []*aggregation{{
+		attribute: "a",
+		prefixes:  []string{"b_"},
+	}}
+	testCases := []struct {
+		name         string
+		createMetric func() pmetric.Metric
+		test         func(pmetric.Metric)
+	}{
+		{
+			name: "empty",
+			createMetric: func() pmetric.Metric {
+				return pmetric.NewMetric()
+			},
+			test: func(m pmetric.Metric) {
+				require.Equal(t, m.Type(), pmetric.MetricTypeEmpty)
+			},
+		},
+		{
+			name: "sum",
+			createMetric: func() pmetric.Metric {
+				m := pmetric.NewMetric()
+				s := m.SetEmptySum()
+				s.DataPoints().AppendEmpty().Attributes().PutStr("b_c", "x")
+
+				return m
+			},
+			test: func(m pmetric.Metric) {
+				s := pmetric.NewMetric().SetEmptySum()
+				s.DataPoints().AppendEmpty().Attributes().PutEmptyMap("a").PutStr("c", "x")
+
+				require.Equal(t, m.Type(), pmetric.MetricTypeSum)
+				require.Equal(t, s.DataPoints().At(0).Attributes().AsRaw(), m.Sum().DataPoints().At(0).Attributes().AsRaw())
+			},
+		},
+		{
+			name: "gauge",
+			createMetric: func() pmetric.Metric {
+				m := pmetric.NewMetric()
+				s := m.SetEmptyGauge()
+				s.DataPoints().AppendEmpty().Attributes().PutStr("b_c", "x")
+
+				return m
+			},
+			test: func(m pmetric.Metric) {
+				s := pmetric.NewMetric().SetEmptyGauge()
+				s.DataPoints().AppendEmpty().Attributes().PutEmptyMap("a").PutStr("c", "x")
+
+				require.Equal(t, m.Type(), pmetric.MetricTypeGauge)
+				require.Equal(t, s.DataPoints().At(0).Attributes().AsRaw(), m.Gauge().DataPoints().At(0).Attributes().AsRaw())
+			},
+		},
+		{
+			name: "histogram",
+			createMetric: func() pmetric.Metric {
+				m := pmetric.NewMetric()
+				s := m.SetEmptyHistogram()
+				s.DataPoints().AppendEmpty().Attributes().PutStr("b_c", "x")
+
+				return m
+			},
+			test: func(m pmetric.Metric) {
+				s := pmetric.NewMetric().SetEmptyHistogram()
+				s.DataPoints().AppendEmpty().Attributes().PutEmptyMap("a").PutStr("c", "x")
+
+				require.Equal(t, m.Type(), pmetric.MetricTypeHistogram)
+				require.Equal(t, s.DataPoints().At(0).Attributes().AsRaw(), m.Histogram().DataPoints().At(0).Attributes().AsRaw())
+			},
+		},
+		{
+			name: "exponential histogram",
+			createMetric: func() pmetric.Metric {
+				m := pmetric.NewMetric()
+				s := m.SetEmptyExponentialHistogram()
+				s.DataPoints().AppendEmpty().Attributes().PutStr("b_c", "x")
+
+				return m
+			},
+			test: func(m pmetric.Metric) {
+				s := pmetric.NewMetric().SetEmptyExponentialHistogram()
+				s.DataPoints().AppendEmpty().Attributes().PutEmptyMap("a").PutStr("c", "x")
+
+				require.Equal(t, m.Type(), pmetric.MetricTypeExponentialHistogram)
+				require.Equal(t, s.DataPoints().At(0).Attributes().AsRaw(), m.ExponentialHistogram().DataPoints().At(0).Attributes().AsRaw())
+			},
+		},
+		{
+			name: "summary",
+			createMetric: func() pmetric.Metric {
+				m := pmetric.NewMetric()
+				s := m.SetEmptySummary()
+				s.DataPoints().AppendEmpty().Attributes().PutStr("b_c", "x")
+
+				return m
+			},
+			test: func(m pmetric.Metric) {
+				s := pmetric.NewMetric().SetEmptySummary()
+				s.DataPoints().AppendEmpty().Attributes().PutEmptyMap("a").PutStr("c", "x")
+
+				require.Equal(t, m.Type(), pmetric.MetricTypeSummary)
+				require.Equal(t, s.DataPoints().At(0).Attributes().AsRaw(), m.Summary().DataPoints().At(0).Attributes().AsRaw())
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			processor := aggregateAttributesProcessor{
+				aggregations: aggregations,
+			}
+
+			metric := testCase.createMetric()
+			err := processMetricLevelAttributes(&processor, metric)
+			require.NoError(t, err)
+
+			testCase.test(metric)
+		})
+	}
+}

--- a/pkg/processor/sumologicschemaprocessor/config.go
+++ b/pkg/processor/sumologicschemaprocessor/config.go
@@ -26,6 +26,12 @@ type Config struct {
 	TranslateAttributes         bool                    `mapstructure:"translate_attributes"`
 	TranslateTelegrafAttributes bool                    `mapstructure:"translate_telegraf_attributes"`
 	NestAttributes              *NestingProcessorConfig `mapstructure:"nest_attributes"`
+	AggregateAttributes         []aggregationPair       `mapstructure:"aggregate_attributes"`
+}
+
+type aggregationPair struct {
+	Attribute string   `mapstructure:"attribute"`
+	Patterns  []string `mapstructure:"prefixes"`
 }
 
 const (
@@ -36,6 +42,10 @@ const (
 	// Nesting processor default config
 	defaultNestingEnabled   = false
 	defaultNestingSeparator = "."
+)
+
+var (
+	defaultAggregateAttributes = []aggregationPair{}
 )
 
 // Ensure the Config struct satisfies the config.Processor interface.
@@ -57,6 +67,7 @@ func createDefaultConfig() component.Config {
 			Include:   defaultNestingInclude,
 			Exclude:   defaultNestingExclude,
 		},
+		AggregateAttributes: defaultAggregateAttributes,
 	}
 }
 

--- a/pkg/processor/sumologicschemaprocessor/config_test.go
+++ b/pkg/processor/sumologicschemaprocessor/config_test.go
@@ -57,6 +57,7 @@ func TestLoadConfig(t *testing.T) {
 				Include:   []string{},
 				Exclude:   []string{},
 			},
+			AggregateAttributes: []aggregationPair{},
 		})
 
 	p2 := cfg.Processors[component.NewIDWithName(typeStr, "disabled-attribute-translation")]
@@ -76,6 +77,7 @@ func TestLoadConfig(t *testing.T) {
 				Include:   []string{},
 				Exclude:   []string{},
 			},
+			AggregateAttributes: []aggregationPair{},
 		})
 
 	p3 := cfg.Processors[component.NewIDWithName(typeStr, "disabled-telegraf-attribute-translation")]
@@ -95,6 +97,7 @@ func TestLoadConfig(t *testing.T) {
 				Include:   []string{},
 				Exclude:   []string{},
 			},
+			AggregateAttributes: []aggregationPair{},
 		})
 
 	p4 := cfg.Processors[component.NewIDWithName(typeStr, "enabled-nesting")]
@@ -113,6 +116,36 @@ func TestLoadConfig(t *testing.T) {
 				Separator: "!",
 				Include:   []string{"blep"},
 				Exclude:   []string{"nghu"},
+			},
+			AggregateAttributes: []aggregationPair{},
+		})
+
+	p5 := cfg.Processors[component.NewIDWithName(typeStr, "aggregate-attributes")]
+
+	assert.Equal(t, p5,
+		&Config{
+			ProcessorSettings: config.NewProcessorSettings(component.NewIDWithName(
+				typeStr,
+				"aggregate-attributes",
+			)),
+			AddCloudNamespace:           true,
+			TranslateAttributes:         true,
+			TranslateTelegrafAttributes: true,
+			NestAttributes: &NestingProcessorConfig{
+				Enabled:   false,
+				Separator: ".",
+				Include:   []string{},
+				Exclude:   []string{},
+			},
+			AggregateAttributes: []aggregationPair{
+				{
+					Attribute: "attr1",
+					Patterns:  []string{"pattern1", "pattern2", "pattern3"},
+				},
+				{
+					Attribute: "attr2",
+					Patterns:  []string{"pattern4"},
+				},
 			},
 		})
 }

--- a/pkg/processor/sumologicschemaprocessor/processor.go
+++ b/pkg/processor/sumologicschemaprocessor/processor.go
@@ -59,11 +59,17 @@ func newSumologicSchemaProcessor(set component.ProcessorCreateSettings, config *
 		return nil, err
 	}
 
+	aggregateAttributesProcessor, err := newAggregateAttributesProcessor(config.AggregateAttributes)
+	if err != nil {
+		return nil, err
+	}
+
 	processors := []sumologicSchemaSubprocessor{
 		cloudNamespaceProcessor,
 		translateAttributesProcessor,
 		translateTelegrafMetricsProcessor,
 		nestingProcessor,
+		aggregateAttributesProcessor,
 	}
 
 	processor := &sumologicSchemaProcessor{
@@ -82,6 +88,7 @@ func (processor *sumologicSchemaProcessor) start(_ context.Context, host compone
 		zap.Bool(procs[1].ConfigPropertyName(), procs[1].isEnabled()),
 		zap.Bool(procs[2].ConfigPropertyName(), procs[2].isEnabled()),
 		zap.Bool(procs[3].ConfigPropertyName(), procs[3].isEnabled()),
+		zap.Bool(procs[4].ConfigPropertyName(), procs[4].isEnabled()),
 	)
 	return nil
 }

--- a/pkg/processor/sumologicschemaprocessor/testdata/config.yaml
+++ b/pkg/processor/sumologicschemaprocessor/testdata/config.yaml
@@ -15,17 +15,31 @@ processors:
       separator: "!"
       include: ["blep"]
       exclude: ["nghu"]
+  sumologic_schema/aggregate-attributes:
+    aggregate_attributes:
+      - attribute: "attr1"
+        prefixes: ["pattern1", "pattern2", "pattern3"]
+      - attribute: "attr2"
+        prefixes: ["pattern4"]
 
 exporters:
   nop:
 
 service:
   pipelines:
-    logs:
+    logs/1:
       receivers:
       - nop
       processors:
       - sumologic_schema/disabled-attribute-translation
+      exporters:
+      - nop
+
+    logs/2:
+      receivers:
+      - nop
+      processors:
+      - sumologic_schema/aggregate-attributes
       exporters:
       - nop
 


### PR DESCRIPTION
Updates #866

Done. This is a basic version, which supports only prefixes.