### PR TITLE
feat(sumologicschemaprocessor): add allowlist and denylist to nesting processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - feat(sumologicschemaprocessor): add nesting processor [#877]
+- feat(sumologicschemaprocessor): add allowlist and denylist to nesting processor [#880]
 
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.67.0-sumo-0...main
 [#877]: https://github.com/SumoLogic/sumologic-otel-collector/pull/877
+[#880]: https://github.com/SumoLogic/sumologic-otel-collector/pull/880
 
 ## [v0.67.0-sumo-0]
 

--- a/pkg/processor/sumologicschemaprocessor/README.md
+++ b/pkg/processor/sumologicschemaprocessor/README.md
@@ -43,6 +43,16 @@ processors:
       # Defines the string used to separate key names in attributes that are to be nested.
       # default = "."
       separator: <separator>
+
+      # Defines a list of allowed prefixes to be nested.
+      # For example, if "kubernetes." is in this list, then all "kubernetes.*" attributes will be nested.
+      # default = []
+      include: [<prefix>]
+
+      # Defines a list of prefixes not allowed to be nested.
+      # For example, if "k8s." is in this list, then all "k8s.*" attributes will not be nested.
+      # default = []
+      exclude: [<prefix>]
 ```
 
 ## Features
@@ -146,6 +156,47 @@ Should be translated into such set:
     }
   },
  "another_attr": "42"
+}
+```
+
+#### Allowlist and denylist
+
+Properties `include` and `exclude` in the config allow to define list of prefixes that are allowed or not allowed to be nested.
+
+For example, with the following config:
+
+```yaml
+nest_attributes:
+  enabled: true
+  include: ["kubernetes.host."]
+  exclude: ["kubernetes.host.naming"]
+```
+
+and following input:
+
+```json
+{
+"kubernetes.container_name": "xyz",
+"kubernetes.host.name": "the host",
+"kubernetes.host.naming_convention": "random",
+"kubernetes.host.address": "127.0.0.1",
+"kubernetes.namespace_name": "sumologic",
+}
+```
+
+The output is:
+
+```json
+{
+"kubernetes.container_name": "xyz",
+"kubernetes": {
+  "host": {
+    "name": "the host",
+    "address": "127.0.0.1"
+    }
+  },
+"kubernetes.host.naming_convention": "random",
+"kubernetes.namespace_name": "sumologic",
 }
 ```
 

--- a/pkg/processor/sumologicschemaprocessor/config.go
+++ b/pkg/processor/sumologicschemaprocessor/config.go
@@ -39,7 +39,11 @@ const (
 )
 
 // Ensure the Config struct satisfies the config.Processor interface.
-var _ component.Config = (*Config)(nil)
+var (
+	_                     component.Config = (*Config)(nil)
+	defaultNestingInclude                  = []string{}
+	defaultNestingExclude                  = []string{}
+)
 
 func createDefaultConfig() component.Config {
 	return &Config{
@@ -50,6 +54,8 @@ func createDefaultConfig() component.Config {
 		NestAttributes: &NestingProcessorConfig{
 			Separator: defaultNestingSeparator,
 			Enabled:   defaultNestingEnabled,
+			Include:   defaultNestingInclude,
+			Exclude:   defaultNestingExclude,
 		},
 	}
 }

--- a/pkg/processor/sumologicschemaprocessor/config_test.go
+++ b/pkg/processor/sumologicschemaprocessor/config_test.go
@@ -54,6 +54,8 @@ func TestLoadConfig(t *testing.T) {
 			NestAttributes: &NestingProcessorConfig{
 				Enabled:   false,
 				Separator: ".",
+				Include:   []string{},
+				Exclude:   []string{},
 			},
 		})
 
@@ -71,6 +73,8 @@ func TestLoadConfig(t *testing.T) {
 			NestAttributes: &NestingProcessorConfig{
 				Enabled:   false,
 				Separator: ".",
+				Include:   []string{},
+				Exclude:   []string{},
 			},
 		})
 
@@ -88,6 +92,8 @@ func TestLoadConfig(t *testing.T) {
 			NestAttributes: &NestingProcessorConfig{
 				Enabled:   false,
 				Separator: ".",
+				Include:   []string{},
+				Exclude:   []string{},
 			},
 		})
 
@@ -105,6 +111,8 @@ func TestLoadConfig(t *testing.T) {
 			NestAttributes: &NestingProcessorConfig{
 				Enabled:   true,
 				Separator: "!",
+				Include:   []string{"blep"},
+				Exclude:   []string{"nghu"},
 			},
 		})
 }

--- a/pkg/processor/sumologicschemaprocessor/testdata/config.yaml
+++ b/pkg/processor/sumologicschemaprocessor/testdata/config.yaml
@@ -13,6 +13,8 @@ processors:
     nest_attributes:
       enabled: true
       separator: "!"
+      include: ["blep"]
+      exclude: ["nghu"]
 
 exporters:
   nop:


### PR DESCRIPTION
Updates #865 

Nesting subprocessor has gained two config options. It now supports an allowlist and a denylist of prefixes for which the attributes should or should not be translated.