### PR TITLE
feat(sumologicschemaprocessor): add squashing single values in nesting processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat(sumologicschemaprocessor): add nesting processor [#877]
 - feat(sumologicschemaprocessor): add allowlist and denylist to nesting processor [#880]
 - feat(sumologicschemaprocessor) allow aggregating attributes with given name patterns [#871]
+- feat(sumologicschemaprocessor): add squashing single values in nesting processor [#881]
 
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.67.0-sumo-0...main
 [#877]: https://github.com/SumoLogic/sumologic-otel-collector/pull/877
 [#880]: https://github.com/SumoLogic/sumologic-otel-collector/pull/880
 [#871]: https://github.com/SumoLogic/sumologic-otel-collector/pull/871
+[#881]: https://github.com/SumoLogic/sumologic-otel-collector/pull/881
 
 ## [v0.67.0-sumo-0]
 

--- a/pkg/processor/sumologicschemaprocessor/README.md
+++ b/pkg/processor/sumologicschemaprocessor/README.md
@@ -54,6 +54,12 @@ processors:
       # default = []
       exclude: [<prefix>]
 
+      # If enabled, then maps that would have only one value will be squashed.
+      # For example,{"k8s": {"pods": {"a": "A", "b": "B"}}}
+      # will be squashed to {"k8s.pods": {"a": "A", "b": "B"}}
+      # default = false
+      squash_single_values: {true, false}
+
     # Specifies if attributes matching given pattern should be mapped to a common key.
     # See "Aggregating attributes" documentation chapter from this document.
     # default = []

--- a/pkg/processor/sumologicschemaprocessor/config.go
+++ b/pkg/processor/sumologicschemaprocessor/config.go
@@ -40,8 +40,9 @@ const (
 	defaultTranslateTelegrafAttributes = true
 
 	// Nesting processor default config
-	defaultNestingEnabled   = false
-	defaultNestingSeparator = "."
+	defaultNestingEnabled            = false
+	defaultNestingSeparator          = "."
+	defaultNestingSquashSingleValues = false
 )
 
 var (
@@ -62,10 +63,11 @@ func createDefaultConfig() component.Config {
 		TranslateAttributes:         defaultTranslateAttributes,
 		TranslateTelegrafAttributes: defaultTranslateTelegrafAttributes,
 		NestAttributes: &NestingProcessorConfig{
-			Separator: defaultNestingSeparator,
-			Enabled:   defaultNestingEnabled,
-			Include:   defaultNestingInclude,
-			Exclude:   defaultNestingExclude,
+			Separator:          defaultNestingSeparator,
+			Enabled:            defaultNestingEnabled,
+			Include:            defaultNestingInclude,
+			Exclude:            defaultNestingExclude,
+			SquashSingleValues: defaultNestingSquashSingleValues,
 		},
 		AggregateAttributes: defaultAggregateAttributes,
 	}

--- a/pkg/processor/sumologicschemaprocessor/config_test.go
+++ b/pkg/processor/sumologicschemaprocessor/config_test.go
@@ -52,10 +52,11 @@ func TestLoadConfig(t *testing.T) {
 			TranslateAttributes:         true,
 			TranslateTelegrafAttributes: true,
 			NestAttributes: &NestingProcessorConfig{
-				Enabled:   false,
-				Separator: ".",
-				Include:   []string{},
-				Exclude:   []string{},
+				Enabled:            false,
+				Separator:          ".",
+				Include:            []string{},
+				Exclude:            []string{},
+				SquashSingleValues: false,
 			},
 			AggregateAttributes: []aggregationPair{},
 		})
@@ -72,10 +73,11 @@ func TestLoadConfig(t *testing.T) {
 			TranslateAttributes:         false,
 			TranslateTelegrafAttributes: true,
 			NestAttributes: &NestingProcessorConfig{
-				Enabled:   false,
-				Separator: ".",
-				Include:   []string{},
-				Exclude:   []string{},
+				Enabled:            false,
+				Separator:          ".",
+				Include:            []string{},
+				Exclude:            []string{},
+				SquashSingleValues: false,
 			},
 			AggregateAttributes: []aggregationPair{},
 		})
@@ -92,10 +94,11 @@ func TestLoadConfig(t *testing.T) {
 			TranslateAttributes:         true,
 			TranslateTelegrafAttributes: false,
 			NestAttributes: &NestingProcessorConfig{
-				Enabled:   false,
-				Separator: ".",
-				Include:   []string{},
-				Exclude:   []string{},
+				Enabled:            false,
+				Separator:          ".",
+				Include:            []string{},
+				Exclude:            []string{},
+				SquashSingleValues: false,
 			},
 			AggregateAttributes: []aggregationPair{},
 		})
@@ -112,10 +115,11 @@ func TestLoadConfig(t *testing.T) {
 			TranslateAttributes:         true,
 			TranslateTelegrafAttributes: true,
 			NestAttributes: &NestingProcessorConfig{
-				Enabled:   true,
-				Separator: "!",
-				Include:   []string{"blep"},
-				Exclude:   []string{"nghu"},
+				Enabled:            true,
+				Separator:          "!",
+				Include:            []string{"blep"},
+				Exclude:            []string{"nghu"},
+				SquashSingleValues: true,
 			},
 			AggregateAttributes: []aggregationPair{},
 		})
@@ -132,10 +136,11 @@ func TestLoadConfig(t *testing.T) {
 			TranslateAttributes:         true,
 			TranslateTelegrafAttributes: true,
 			NestAttributes: &NestingProcessorConfig{
-				Enabled:   false,
-				Separator: ".",
-				Include:   []string{},
-				Exclude:   []string{},
+				Enabled:            false,
+				Separator:          ".",
+				Include:            []string{},
+				Exclude:            []string{},
+				SquashSingleValues: false,
 			},
 			AggregateAttributes: []aggregationPair{
 				{

--- a/pkg/processor/sumologicschemaprocessor/testdata/config.yaml
+++ b/pkg/processor/sumologicschemaprocessor/testdata/config.yaml
@@ -15,6 +15,7 @@ processors:
       separator: "!"
       include: ["blep"]
       exclude: ["nghu"]
+      squash_single_values: true
   sumologic_schema/aggregate-attributes:
     aggregate_attributes:
       - attribute: "attr1"


### PR DESCRIPTION
Updates #865 

This PR adds a feature to nesting processor that squashes maps that have only one key-value pair. For example:
```
{
"k8s": {
  "pods": {
    "a" : "A",
    "b": "B"
    }
  }
}
```
gets squashed into
```
{
"k8s.pods": {
    "a" : "A",
    "b": "B"
    }
}
```

This feature is **disabled** by default. 

Two things to note:
- Perhaps this implementation contains too much map copying, but I wanted to finish this before Christmas and eventually fix later. 
- I tried to create an algorithm that does this while doing the initial nesting, but I found it to be too complex and not necessarily faster.