### PR TITLE
Install script, do not hang on systemctl status

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1214,4 +1214,4 @@ systemctl start otelcol-sumo
 
 echo 'Waiting 10s before checking status'
 sleep 10
-systemctl status otelcol-sumo
+systemctl status otelcol-sumo --no-pager


### PR DESCRIPTION
Update the installation script to not hang on `systemctl status` (https://jira.kumoroku.com/jira/browse/SUMO-206497).

This pull-request makes use of `--no-pager          Do not pipe output into a pager`.