### PR TITLE
Fix metadata api update call, 204 is expected

### DIFF
--- a/pkg/extension/sumologicextension/extension.go
+++ b/pkg/extension/sumologicextension/extension.go
@@ -717,6 +717,7 @@ func (se *SumologicExtension) updateMetadataWithHTTPClient(ctx context.Context, 
 
 	case http.StatusUnauthorized:
 		return errUnauthorizedMetadata
+	case http.StatusNoContent:
 	case http.StatusOK:
 	}
 


### PR DESCRIPTION
The metadata API now returns an HTTP 204 response.