### PR TITLE
Added unzip to installer script check dependencies

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -290,7 +290,7 @@ function check_dependencies() {
         error=1
     fi
 
-    for cmd in echo sed curl head grep sort mv chmod getopts hostname bc touch xargs; do
+    for cmd in echo sed curl head grep sort mv chmod getopts hostname bc touch xargs unzip; do
         if ! command -v "${cmd}" &> /dev/null; then
             echo "Command '${cmd}' not found. Please install it."
             error=1


### PR DESCRIPTION
Ensure the `unzip` command/tool is available before proceeding with OT collector install.