### PR TITLE
fix(scripts/install.sh): increase download timeout

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+############################ Constants
+readonly CURL_MAX_TIME=180
+
 ############################ Static variables
 
 ARG_SHORT_TOKEN='i'
@@ -928,7 +931,7 @@ function get_binary_from_branch() {
     curl_args=(
         "-fL"
         "--connect-timeout" "5"
-        "--max-time" "60"
+        "--max-time" "${CURL_MAX_TIME}"
         "--retry" "5"
         "--retry-delay" "0"
         "--retry-max-time" "150"
@@ -960,7 +963,7 @@ function get_binary_from_url() {
     curl_args=(
         "-fL"
         "--connect-timeout" "5"
-        "--max-time" "60"
+        "--max-time" "${CURL_MAX_TIME}"
         "--retry" "5"
         "--retry-delay" "0"
         "--retry-max-time" "150"


### PR DESCRIPTION
We should let people on slow Internet connections install otel too. At 180 seconds, you need around 0.6 MBps, which I think is reasonable. This also helps with GitHub hiccups.