### PR TITLE
test(scripts/install.sh): fix hostmetrics test

### DIFF
--- a/pkg/scripts_test/check.go
+++ b/pkg/scripts_test/check.go
@@ -130,9 +130,9 @@ func checkHostmetricsConfigCreated(c check) {
 	require.FileExists(c.test, hostmetricsConfigPath, "hostmetrics configuration has not been created properly")
 }
 
-func checkHostmetricsOwnershipAndPermissions(owner string) func(c check) {
+func checkHostmetricsOwnershipAndPermissions(ownerName string, ownerGroup string) func(c check) {
 	return func(c check) {
-		PathHasOwner(c.test, hostmetricsConfigPath, owner, owner)
+		PathHasOwner(c.test, hostmetricsConfigPath, ownerName, ownerGroup)
 		PathHasPermissions(c.test, hostmetricsConfigPath, configPathPermissions)
 	}
 }

--- a/pkg/scripts_test/command.go
+++ b/pkg/scripts_test/command.go
@@ -25,6 +25,7 @@ type installOptions struct {
 	uninstall          bool
 	purge              bool
 	apiBaseURL         string
+	configBranch       string
 	downloadOnly       bool
 	dontKeepDownloads  bool
 	installHostmetrics bool
@@ -87,6 +88,10 @@ func (io *installOptions) string() []string {
 
 	if io.apiBaseURL != "" {
 		opts = append(opts, "--api", io.apiBaseURL)
+	}
+
+	if io.configBranch != "" {
+		opts = append(opts, "--config-branch", io.configBranch)
 	}
 
 	return opts

--- a/pkg/scripts_test/common.go
+++ b/pkg/scripts_test/common.go
@@ -3,6 +3,8 @@
 package sumologic_scripts_tests
 
 import (
+	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -69,4 +71,14 @@ func runTest(t *testing.T, spec *testSpec) {
 	for _, c := range spec.postChecks {
 		c(ch)
 	}
+}
+
+func getRootGroupName() string {
+	if runtime.GOOS == "darwin" {
+		return "wheel"
+	} else if runtime.GOOS == "linux" {
+		return "root"
+	}
+
+	panic(fmt.Sprintf("Encountered unsupported OS: %s", runtime.GOOS))
 }

--- a/pkg/scripts_test/install_unix_test.go
+++ b/pkg/scripts_test/install_unix_test.go
@@ -83,6 +83,7 @@ func TestInstallScript(t *testing.T) {
 				skipSystemd:        true,
 				installToken:       installToken,
 				installHostmetrics: true,
+				configBranch:       "main", // TODO: Remove this after v0.70.0 is released
 			},
 			preChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
 			postChecks: []checkFunc{
@@ -95,7 +96,7 @@ func TestInstallScript(t *testing.T) {
 				checkSystemdConfigNotCreated,
 				checkUserNotExists,
 				checkHostmetricsConfigCreated,
-				checkHostmetricsOwnershipAndPermissions("root"),
+				checkHostmetricsOwnershipAndPermissions("root", getRootGroupName()),
 			},
 		},
 		{


### PR DESCRIPTION
The hostmetrics configuration will only be available from v0.70.0. Right now, the test fails, and this fixes it.