### PR TITLE
docs(sumologicexporter): add info about batching for otlp source

### DIFF
--- a/pkg/exporter/sumologicexporter/README.md
+++ b/pkg/exporter/sumologicexporter/README.md
@@ -19,6 +19,9 @@ exporters:
     # Compression encoding format, empty string means no compression, default = gzip
     compress_encoding: {gzip, deflate, ""}
     # max HTTP request body size in bytes before compression (if applied),
+    # NOTE: this limit does not apply to data sent in otlp format,
+    #   to limit size of otlp requests, please use the batch processor:
+    #   https://github.com/open-telemetry/opentelemetry-collector/tree/v0.69.0/processor/batchprocessor
     # default = 1_048_576 (1MB)
     max_request_body_size: <max_request_body_size>
 


### PR DESCRIPTION
Added a note that `max_body_request_size` config option does not apply for otlp data.