### PR TITLE
fix(examples): don't bind to 0.0.0.0 by default

### DIFF
--- a/examples/sumologic-windows.yaml
+++ b/examples/sumologic-windows.yaml
@@ -26,9 +26,9 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: 0.0.0.0:4317
+        endpoint: localhost:4317
       http:
-        endpoint: 0.0.0.0:4318
+        endpoint: localhost:4318
 
 exporters:
   ## Configuration for Sumo Logic Exporter

--- a/examples/sumologic.yaml
+++ b/examples/sumologic.yaml
@@ -26,9 +26,9 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: 0.0.0.0:4317
+        endpoint: localhost:4317
       http:
-        endpoint: 0.0.0.0:4318
+        endpoint: localhost:4318
 
 exporters:
   ## Configuration for Sumo Logic Exporter

--- a/packaging/msi/SumoLogic.wixext/SumoLogicTests/TestData/with-extensions-block.yaml
+++ b/packaging/msi/SumoLogic.wixext/SumoLogicTests/TestData/with-extensions-block.yaml
@@ -26,9 +26,9 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: 0.0.0.0:4317
+        endpoint: localhost:4317
       http:
-        endpoint: 0.0.0.0:4318
+        endpoint: localhost:4318
 
 exporters:
   ## Configuration for Sumo Logic Exporter

--- a/packaging/msi/SumoLogic.wixext/SumoLogicTests/TestData/without-extensions-block.yaml
+++ b/packaging/msi/SumoLogic.wixext/SumoLogicTests/TestData/without-extensions-block.yaml
@@ -7,9 +7,9 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: 0.0.0.0:4317
+        endpoint: localhost:4317
       http:
-        endpoint: 0.0.0.0:4318
+        endpoint: localhost:4318
 
 exporters:
   ## Configuration for Sumo Logic Exporter


### PR DESCRIPTION
We shouldn't be accepting connections from outside by default. The assumption is that these configurations are supposed to serve local applications. If the user wants to receive data from the network, they should explicitly make that choice.