### PR TITLE
test(rawk8seventsreceiver): fix flaky test

### DIFF
--- a/pkg/receiver/rawk8seventsreceiver/receiver_test.go
+++ b/pkg/receiver/rawk8seventsreceiver/receiver_test.go
@@ -121,8 +121,8 @@ func TestProcessEventE2E(t *testing.T) {
 	assert.NoError(t, err)
 	listWatch.Add(getEvent())
 	assert.Eventually(t, func() bool {
-		return assert.Equal(t, 1, sink.LogRecordCount())
-	}, time.Second, time.Millisecond)
+		return sink.LogRecordCount() == 1
+	}, time.Second, time.Millisecond, "expected one event, got 0")
 
 	err = r.Shutdown(ctx)
 	assert.NoError(t, err)


### PR DESCRIPTION
This test was flaky because it was erroneously using an assertion inside an `assert.Eventually` call. If the inner assertion failed even once, the whole test would fail.