### PR TITLE
feat(scripts/install.sh): don't pass install token via command line

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -39,14 +39,14 @@ To run it as a standalone process you only need to run the binary file downloade
     Either by piping `curl` straight into `bash`:
 
     ```bash
-    curl -s https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector/main/scripts/install.sh | sudo -E bash -s -- --installation-token "${SUMOLOGIC_INSTALL_TOKEN}"
+    curl -s https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector/main/scripts/install.sh | sudo -E bash -s
     ```
 
     or by first downloading the script, inspecting its contents for security, and then running it:
 
    ```bash
    curl -o install-otelcol-sumo.sh https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector/main/scripts/install.sh
-   sudo -E bash ./install-otelcol-sumo.sh --installation-token "${SUMOLOGIC_INSTALL_TOKEN}"
+   sudo -E bash ./install-otelcol-sumo.sh
    ```
 
    The `-E` argument to `sudo` is needed to preserve the `SUMOLOGIC_INSTALL_TOKEN` environment variable in `sudo` session.
@@ -69,7 +69,6 @@ The following arguments can be passed to the script:
 
 | long name                        | short name | description                                                                                                                                                                  | takes value                |
 |----------------------------------|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------|
-| `--installation-token`           | `i`        | Installation token. It has precedence over `SUMOLOGIC_INSTALL_TOKEN` env variable.                                                                                           | yes                        |
 | `--skip-install-token`           | `k`        | Skips requirement for installation token. This option do not disable default configuration creation.                                                                         | no                         |
 | `--tag`                          | `t`        | Sets tag for collector. This argument can be use multiple times. One per tag.                                                                                                | yes, in `key=value` format |
 | `--download-only`                | `w`        | Download new binary only and skip configuration part.                                                                                                                        | no                         |
@@ -86,7 +85,7 @@ The following env variables can be used along with script:
 
 | name                      | description                                                                  |
 |---------------------------|------------------------------------------------------------------------------|
-| `SUMOLOGIC_INSTALL_TOKEN` | Installation token. It can be overridden by `--installation-token` argument. |
+| `SUMOLOGIC_INSTALL_TOKEN` | Installation token                                                           |
 
 ### Manual installation
 

--- a/examples/ansible/install_sumologic_otel_collector.yaml
+++ b/examples/ansible/install_sumologic_otel_collector.yaml
@@ -12,8 +12,7 @@
         mode: 0755
     - name: Create install script argument list
       ansible.builtin.set_fact:
-        install_script_args:
-          - "--installation-token {{ install_token | mandatory }}"
+        install_script_args: []
     - name: Add tags to install script argument list
       ansible.builtin.set_fact:
         install_script_args: "{{ install_script_args + [ '--tag ' ~ item.key ~ '=' ~ item.value ] }}"
@@ -31,6 +30,8 @@
         install_script_args: "{{ install_script_args + ['--skip-systemd'] }}"
       when: not systemd_service
     - name: Run install script
+      environment:
+        SUMOLOGIC_INSTALL_TOKEN: "{{ install_token | mandatory }}"
       ansible.builtin.command: "bash /tmp/install.sh {{ install_script_args | join(' ') }}"
       changed_when: true
     - name: "Copy configuration files to /etc/otelcol-sumo/conf.d"

--- a/examples/chef/sumologic-otel-collector/resources/default.rb
+++ b/examples/chef/sumologic-otel-collector/resources/default.rb
@@ -27,6 +27,7 @@ action :default do
   install_command = get_install_script_command(new_resource)
   execute INSTALL_SCRIPT_PATH do
     command install_command
+    environment ({"SUMOLOGIC_INSTALL_TOKEN" => resource.install_token})
   end
   run_action :prepare_config
   if new_resource.systemd_service
@@ -58,7 +59,7 @@ end
 
 
 def get_install_script_command(resource)
-  command_parts = ["bash", INSTALL_SCRIPT_PATH, "--installation-token #{resource.install_token}"]
+  command_parts = ["bash", INSTALL_SCRIPT_PATH]
   command_parts += resource.collector_tags.map { |key, value| "--tag #{key}=#{value}" }
   if property_is_set?(:version)
      command_parts.push("--version #{resource.version}")

--- a/examples/puppet/modules/install_otel_collector/manifests/init.pp
+++ b/examples/puppet/modules/install_otel_collector/manifests/init.pp
@@ -47,9 +47,7 @@ class install_otel_collector (
   } else {
     $systemd_command_args = ['--skip-systemd']
   }
-  $install_command_args = [
-    "--installation-token ${install_token}",
-  ] + $tags_command_args + $version_command_args + $api_command_args + $systemd_command_args
+  $install_command_args = $tags_command_args + $version_command_args + $api_command_args + $systemd_command_args
 
   file { 'download the install script':
     source => $install_script_url,
@@ -59,9 +57,10 @@ class install_otel_collector (
   $install_command_parts = ['bash', $install_script_path] + $install_command_args
   $install_command = join($install_command_parts, ' ')
   exec { 'run the installation script':
-    command => $install_command,
-    path    => ['/usr/local/bin/', '/usr/bin', '/usr/sbin', '/bin'],
-    user    => 'root',
+    command     => $install_command,
+    path        => ['/usr/local/bin/', '/usr/bin', '/usr/sbin', '/bin'],
+    user        => 'root',
+    environment => ["SUMOLOGIC_INSTALL_TOKEN=${install_token}"]
   }
 
   file { '/etc/otelcol-sumo/conf.d':

--- a/pkg/scripts_test/check.go
+++ b/pkg/scripts_test/check.go
@@ -143,16 +143,6 @@ func checkDifferentTokenInConfig(c check) {
 	require.Equal(c.test, "different"+c.installOptions.installToken, conf.Extensions.Sumologic.InstallToken, "install token is different than expected")
 }
 
-func checkEnvTokenInConfig(c check) {
-	conf, err := getConfig(userConfigPath)
-	require.NoError(c.test, err, "error while reading configuration")
-
-	token, ok := c.installOptions.envs["SUMOLOGIC_INSTALL_TOKEN"]
-	require.True(c.test, ok, "SUMOLOGIC_INSTALL_TOKEN env hash not been set")
-
-	require.Equal(c.test, token, conf.Extensions.Sumologic.InstallToken, "install token is different than expected")
-}
-
 func checkHostmetricsConfigCreated(c check) {
 	require.FileExists(c.test, hostmetricsConfigPath, "hostmetrics configuration has not been created properly")
 }
@@ -269,7 +259,7 @@ func checkAbortedDueToDifferentToken(c check) {
 
 func checkAbortedDueToNoToken(c check) {
 	require.Greater(c.test, len(c.output), 1)
-	require.Contains(c.test, c.output[len(c.output)-2], "Install token has not been provided. Please use '--installation-token <token>' or 'SUMOLOGIC_INSTALL_TOKEN' env.")
+	require.Contains(c.test, c.output[len(c.output)-2], "Install token has not been provided. Please set the 'SUMOLOGIC_INSTALL_TOKEN' environment variable.")
 	require.Contains(c.test, c.output[len(c.output)-1], "You can ignore this requirement by adding '--skip-install-token argument.")
 }
 

--- a/pkg/scripts_test/command.go
+++ b/pkg/scripts_test/command.go
@@ -36,10 +36,6 @@ func (io *installOptions) string() []string {
 		scriptPath,
 	}
 
-	if io.installToken != "" {
-		opts = append(opts, "--installation-token", io.installToken)
-	}
-
 	if io.autoconfirm {
 		opts = append(opts, "--yes")
 	}
@@ -102,6 +98,10 @@ func (io *installOptions) buildEnvs() []string {
 
 	for k, v := range io.envs {
 		e = append(e, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	if io.installToken != "" {
+		e = append(e, fmt.Sprintf("%s=%s", installTokenEnv, io.installToken))
 	}
 
 	return e

--- a/pkg/scripts_test/consts.go
+++ b/pkg/scripts_test/consts.go
@@ -17,8 +17,9 @@ const (
 
 	systemdDirectoryPath string = "/run/systemd/system"
 
-	installToken string = "token"
-	apiBaseURL   string = "https://open-collectors.sumologic.com"
+	installToken    string = "token"
+	installTokenEnv string = "SUMOLOGIC_INSTALL_TOKEN"
+	apiBaseURL      string = "https://open-collectors.sumologic.com"
 
 	systemUser string = "otelcol-sumo"
 )

--- a/pkg/scripts_test/install_unix_test.go
+++ b/pkg/scripts_test/install_unix_test.go
@@ -121,26 +121,6 @@ func TestInstallScript(t *testing.T) {
 			},
 		},
 		{
-			name: "installation token only (envs)",
-			options: installOptions{
-				skipSystemd: true,
-				envs: map[string]string{
-					"SUMOLOGIC_INSTALL_TOKEN": installToken,
-				},
-			},
-			preChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated},
-			postChecks: []checkFunc{
-				checkBinaryCreated,
-				checkBinaryIsRunning,
-				checkConfigCreated,
-				checkConfigFilesOwnershipAndPermissions("root", getRootGroupName()),
-				checkUserConfigCreated,
-				checkEnvTokenInConfig,
-				checkSystemdConfigNotCreated,
-				checkUserNotExists,
-			},
-		},
-		{
 			name: "same installation token",
 			options: installOptions{
 				skipSystemd:  true,

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -138,7 +138,7 @@ Supported arguments:
   -${ARG_SHORT_HELP}, --${ARG_LONG_HELP}                            Prints this help and usage.
 
 Supported env variables:
-  ${ENV_TOKEN}=<token>       Installation token. It can be overridden by '--installation-token' argument.'
+  ${ENV_TOKEN}=<token>       Installation token.'
 EOF
 }
 
@@ -1072,7 +1072,7 @@ readonly USER_TOKEN
 
 # Exit if install token is not set and there is no user configuration
 if [[ -z "${SUMOLOGIC_INSTALL_TOKEN}" && "${SKIP_TOKEN}" != "true" && -z "${USER_TOKEN}" && -z "${DOWNLOAD_ONLY}" ]]; then
-    echo "Install token has not been provided. Please use '--${ARG_LONG_TOKEN} <token>' or '${ENV_TOKEN}' env."
+    echo "Install token has not been provided. Please set the '${ENV_TOKEN}' environment variable."
     echo "You can ignore this requirement by adding '--${ARG_LONG_SKIP_TOKEN} argument."
     exit 1
 fi


### PR DESCRIPTION
I'm leaving the actual option in, as it's currently still displayed in the UI, but I'm removing it from documentation and manifests for Chef, Puppet and Ansible.