### PR TITLE
feat(scripts/install.sh): require --yes for uninstallation

### DIFF
--- a/pkg/scripts_test/command.go
+++ b/pkg/scripts_test/command.go
@@ -170,11 +170,6 @@ func runScript(ch check) (int, []string, error) {
 			continue
 		}
 
-		if strings.Contains(strLine, "Going to remove") {
-			// approve installation config
-			_, err = in.Write([]byte("y\n"))
-			require.NoError(ch.test, err)
-		}
 	}
 
 	code, err := exitCode(cmd)

--- a/pkg/scripts_test/install_unix_test.go
+++ b/pkg/scripts_test/install_unix_test.go
@@ -325,13 +325,14 @@ func TestInstallScript(t *testing.T) {
 			installCode:       3, // because of invalid install token
 		},
 		{
-			name: "uninstallation",
+			name: "uninstallation without autoconfirm fails",
 			options: installOptions{
 				uninstall: true,
 			},
-			preActions: []checkFunc{preActionMockStructure},
-			preChecks:  []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkUserNotExists},
-			postChecks: []checkFunc{checkBinaryNotCreated, checkConfigCreated, checkUserConfigCreated},
+			installCode: 1,
+			preActions:  []checkFunc{preActionMockStructure},
+			preChecks:   []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkUserNotExists},
+			postChecks:  []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated},
 		},
 		{
 			name: "uninstallation with autoconfirm",
@@ -346,7 +347,8 @@ func TestInstallScript(t *testing.T) {
 		{
 			name: "systemd uninstallation",
 			options: installOptions{
-				uninstall: true,
+				autoconfirm: true,
+				uninstall:   true,
 			},
 			preActions:        []checkFunc{preActionMockSystemdStructure},
 			preChecks:         []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkSystemdConfigCreated, checkUserNotExists},
@@ -356,8 +358,9 @@ func TestInstallScript(t *testing.T) {
 		{
 			name: "purge",
 			options: installOptions{
-				uninstall: true,
-				purge:     true,
+				uninstall:   true,
+				purge:       true,
+				autoconfirm: true,
 			},
 			preActions: []checkFunc{preActionMockStructure},
 			preChecks:  []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkUserNotExists},
@@ -366,8 +369,9 @@ func TestInstallScript(t *testing.T) {
 		{
 			name: "systemd purge",
 			options: installOptions{
-				uninstall: true,
-				purge:     true,
+				uninstall:   true,
+				purge:       true,
+				autoconfirm: true,
 			},
 			preActions:        []checkFunc{preActionMockSystemdStructure},
 			preChecks:         []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkSystemdConfigCreated, checkUserNotExists},

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -496,15 +496,22 @@ function ask_to_continue() {
         return 0
     fi
 
-    local choice
-    read -rp "Continue (y/N)? " choice
-    case "${choice}" in
-    y|Y ) ;;
-    n|N | * )
-        echo "Aborting..."
-        exit 1
-        ;;
-    esac
+    # Just fail if we're not running in uninteractive mode
+    # TODO: Figure out a way to reliably ask for confirmation with stdin redirected
+
+    echo "Please use the --yes flag to continue"
+    exit 1
+
+    # local choice
+    # read -rp "Continue (y/N)? " choice
+    # case "${choice}" in
+    # y|Y ) ;;
+    # n|N | * )
+    #     echo "Aborting..."
+    #     exit 1
+    #     ;;
+    # esac
+
 }
 
 # Get changelog for specific version


### PR DESCRIPTION
We currently recommend to use the script by piping the content to bash. This makes it difficult to prompt the user for input in a platform-agnostic way. Require --yes for uninstallation until we figure it out.

This replaces #810 