### PR TITLE
fix(examples): don't bind health check endpoint to 0.0.0.0

### DIFF
--- a/examples/sumologic.yaml
+++ b/examples/sumologic.yaml
@@ -12,6 +12,7 @@ extensions:
   ## Health Check extension enables an HTTP url that can be probed to check the status of the OpenTelemetry Collector
   ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension
   health_check:
+    endpoint: localhost:13133
 
   ## Configuration for File Storage Extension
   ## The File Storage extension can persist state to the local file system


### PR DESCRIPTION
With this change, we aren't binding to 0.0.0.0 by default anywhere.