### PR TITLE
Bump telegraf to 1.25.1 for Windows arm64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ This release introduces the following breaking changes:
 
 - feat(sumologicextension): use hostname as default collector name [#918]
 
+### Changed
+
+- chore(deps): upgrade Telegraf to 1.25.1 [#828]
+
 [#918]: https://github.com/SumoLogic/sumologic-otel-collector/pull/918
+[#932]: https://github.com/SumoLogic/sumologic-otel-collector/pull/932
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.70.0-sumo-0...main
 
 ## [v0.70.0-sumo-0]

--- a/pkg/receiver/telegrafreceiver/go.mod
+++ b/pkg/receiver/telegrafreceiver/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.0
-	github.com/influxdata/telegraf v1.24.3
+	github.com/influxdata/telegraf v1.25.1
 	github.com/stretchr/testify v1.8.1
 	go.opentelemetry.io/collector v0.70.0
 	go.opentelemetry.io/collector/component v0.70.0


### PR DESCRIPTION
I was unable to build on Windows arm64. `1.25.x` fixed several of the issues.

Release notes:
- https://github.com/influxdata/telegraf/releases/tag/v1.25.0
- https://github.com/influxdata/telegraf/releases/tag/v1.25.1