### PR TITLE
fix(k8sprocessor): race condition when getting Pod data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ This release introduces the following breaking changes:
 
 - feat(sumologicextension): use hostname as default collector name [#918]
 
+### Fixed
+
+- fix(k8sprocessor): race condition when getting Pod data [#938]
+
 [#918]: https://github.com/SumoLogic/sumologic-otel-collector/pull/918
+[#938]: https://github.com/SumoLogic/sumologic-otel-collector/pull/938
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.70.0-sumo-0...main
 
 ## [v0.70.0-sumo-1]

--- a/pkg/processor/k8sprocessor/client_test.go
+++ b/pkg/processor/k8sprocessor/client_test.go
@@ -70,11 +70,12 @@ func newFakeClient(
 	}, nil
 }
 
-// GetPod looks up FakeClient.Pods map by the provided string,
-// which might represent either IP address or Pod UID.
-func (f *fakeClient) GetPod(identifier kube.PodIdentifier) (*kube.Pod, bool) {
+func (f *fakeClient) GetPodAttributes(identifier kube.PodIdentifier) (map[string]string, bool) {
 	p, ok := f.Pods[identifier]
-	return p, ok
+	if !ok {
+		return map[string]string{}, ok
+	}
+	return p.Attributes, ok
 }
 
 // Start is a noop for FakeClient.

--- a/pkg/processor/k8sprocessor/kube/kube.go
+++ b/pkg/processor/k8sprocessor/kube/kube.go
@@ -57,7 +57,7 @@ const (
 
 // Client defines the main interface that allows querying pods by metadata.
 type Client interface {
-	GetPod(PodIdentifier) (*Pod, bool)
+	GetPodAttributes(PodIdentifier) (map[string]string, bool)
 	Start()
 	Stop()
 }

--- a/pkg/processor/k8sprocessor/processor.go
+++ b/pkg/processor/k8sprocessor/processor.go
@@ -143,10 +143,10 @@ func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pco
 }
 
 func (kp *kubernetesprocessor) getAttributesForPod(identifier kube.PodIdentifier) map[string]string {
-	pod, ok := kp.kc.GetPod(identifier)
+	attributes, ok := kp.kc.GetPodAttributes(identifier)
 	if !ok {
 		kp.logger.Debug("No pod with given id found", zap.Any("pod_id", identifier))
 		return nil
 	}
-	return pod.Attributes
+	return attributes
 }


### PR DESCRIPTION
We had a race condition where we'd update Pod metadata in `GetPod` while only holding a read lock. In circumstances where two batches of data would arrive from the same Pod in quick succession, we'd get a panic due to concurrent map writes.

I fixed this by changing the interface to only return an attributes map and explicitly making that a copy of what's in the Pod attributes.