### PR TITLE
test(scripts/install.sh): disable FIPS version test

### DIFF
--- a/pkg/scripts_test/install_linux_amd64_test.go
+++ b/pkg/scripts_test/install_linux_amd64_test.go
@@ -37,6 +37,7 @@ func TestInstallScriptLinuxAmd64(t *testing.T) {
 		},
 	} {
 		t.Run(spec.name, func(t *testing.T) {
+			t.Skip("the version on the FIPS binary is not set correctly for 0.70.0-sumo-1")
 			runTest(t, &spec)
 		})
 	}


### PR DESCRIPTION
The version isn't set correctly for v0.70.0-sumo-1 due to commit 7b02da7. The binary itself is fine.
This should be reverted after v0.71.0 is released.