### PR TITLE
Revert "chore(otelcolbuilder): move deprecated CLI options to otelcol-builder.yaml"

### DIFF
--- a/otelcolbuilder/.otelcol-builder.yaml
+++ b/otelcolbuilder/.otelcol-builder.yaml
@@ -10,11 +10,6 @@ dist:
   # the path to write the output (sources and binary).
   output_path: ./cmd
 
-  # These options were formerly CLI arguments of otelcol-builder
-  # They are being set in Makefile.
-  go: $(GO)
-  version: $(VERSION)$(FIPS_SUFFIX)
-
 exporters:
   # Exporters with non-upstreamed changes:
   - gomod: "github.com/SumoLogic/sumologic-otel-collector/pkg/exporter/sumologicexporter v0.0.0-00010101000000-000000000000"

--- a/otelcolbuilder/Makefile
+++ b/otelcolbuilder/Makefile
@@ -77,7 +77,10 @@ _builder:
 # Need to specify go path because otherwise opentelemetry-collector-builder
 # uses /usr/bin/go which on Github Actions is using preinstalled 1.15.12 by default.
 	CGO_ENABLED=$(CGO_ENABLED) $(BUILDER_BIN_NAME) \
+		--go $(GO) \
+		--version "$(VERSION)$(FIPS_SUFFIX)" \
 		--config .otelcol-builder.yaml \
+		--output-path ./cmd \
 		--skip-compilation=$(SKIP_COMPILATION)
 
 .PHONY: _gobuild


### PR DESCRIPTION
This reverts commit 7b02da720c7746915815516d367a109525d58acb.

This doesn't actually work, and the version ends up as literally `$(VERSION)$(FIPS_SUFFIX)`. Need to find a different way to set these variables.