### PR TITLE
[Backport v0.70.0] Revert "chore(otelcolbuilder): move deprecated CLI options to otelcol-builder.yaml"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- fix release binary versions [#943]
+
+[Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.70.0-sumo-1...release-v.0.70.0
+[#943]: https://github.com/SumoLogic/sumologic-otel-collector/pull/943
+
 ## [v0.70.0-sumo-1]
 
 ### Added

--- a/otelcolbuilder/.otelcol-builder.yaml
+++ b/otelcolbuilder/.otelcol-builder.yaml
@@ -10,11 +10,6 @@ dist:
   # the path to write the output (sources and binary).
   output_path: ./cmd
 
-  # These options were formerly CLI arguments of otelcol-builder
-  # They are being set in Makefile.
-  go: $(GO)
-  version: $(VERSION)$(FIPS_SUFFIX)
-
 exporters:
   # Exporters with non-upstreamed changes:
   - gomod: "github.com/SumoLogic/sumologic-otel-collector/pkg/exporter/sumologicexporter v0.0.0-00010101000000-000000000000"

--- a/otelcolbuilder/Makefile
+++ b/otelcolbuilder/Makefile
@@ -77,7 +77,10 @@ _builder:
 # Need to specify go path because otherwise opentelemetry-collector-builder
 # uses /usr/bin/go which on Github Actions is using preinstalled 1.15.12 by default.
 	CGO_ENABLED=$(CGO_ENABLED) $(BUILDER_BIN_NAME) \
+		--go $(GO) \
+		--version "$(VERSION)$(FIPS_SUFFIX)" \
 		--config .otelcol-builder.yaml \
+		--output-path ./cmd \
 		--skip-compilation=$(SKIP_COMPILATION)
 
 .PHONY: _gobuild


### PR DESCRIPTION
Backport of #942 to v0.70.0

The script tests failing here is expected.