### PR TITLE
feat(sourceprocessor): add debug logs for source category filler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,17 @@ This release introduces the following breaking changes:
 
 - feat(sumologicextension): use hostname as default collector name [#918]
 
+### Added
+
+- feat(sourceprocessor): add debug logs for source category filler [#944]
+
 ### Fixed
 
 - fix(k8sprocessor): race condition when getting Pod data [#938]
 
 [#918]: https://github.com/SumoLogic/sumologic-otel-collector/pull/918
 [#938]: https://github.com/SumoLogic/sumologic-otel-collector/pull/938
+[#944]: https://github.com/SumoLogic/sumologic-otel-collector/pull/944
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.70.0-sumo-0...main
 
 ## [v0.70.0-sumo-1]

--- a/pkg/processor/sourceprocessor/factory.go
+++ b/pkg/processor/sourceprocessor/factory.go
@@ -89,7 +89,7 @@ func createTracesProcessor(
 
 	oCfg := cfg.(*Config)
 
-	sp := newSourceProcessor(oCfg)
+	sp := newSourceProcessor(params, oCfg)
 
 	return processorhelper.NewTracesProcessor(
 		ctx,
@@ -110,7 +110,7 @@ func createMetricsProcessor(
 ) (processor.Metrics, error) {
 	oCfg := cfg.(*Config)
 
-	sp := newSourceProcessor(oCfg)
+	sp := newSourceProcessor(params, oCfg)
 	return processorhelper.NewMetricsProcessor(
 		ctx,
 		params,
@@ -130,7 +130,7 @@ func createLogsProcessor(
 ) (processor.Logs, error) {
 	oCfg := cfg.(*Config)
 
-	sp := newSourceProcessor(oCfg)
+	sp := newSourceProcessor(params, oCfg)
 	return processorhelper.NewLogsProcessor(
 		ctx,
 		params,

--- a/pkg/processor/sourceprocessor/source_processor.go
+++ b/pkg/processor/sourceprocessor/source_processor.go
@@ -26,6 +26,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/processor"
+	"go.uber.org/zap"
 
 	"github.com/SumoLogic/sumologic-otel-collector/pkg/processor/sourceprocessor/observability"
 )
@@ -45,6 +47,7 @@ type dockerLog struct {
 }
 
 type sourceProcessor struct {
+	logger               *zap.Logger
 	collector            string
 	sourceCategoryFiller sourceCategoryFiller
 	sourceNameFiller     attributeFiller
@@ -85,7 +88,7 @@ func compileRegex(regex string) *regexp.Regexp {
 	return re
 }
 
-func newSourceProcessor(cfg *Config) *sourceProcessor {
+func newSourceProcessor(set processor.CreateSettings, cfg *Config) *sourceProcessor {
 	keys := sourceKeys{
 		annotationPrefix:   cfg.AnnotationPrefix,
 		podKey:             cfg.PodKey,
@@ -101,10 +104,11 @@ func newSourceProcessor(cfg *Config) *sourceProcessor {
 	}
 
 	return &sourceProcessor{
+		logger:               set.Logger,
 		collector:            cfg.Collector,
 		keys:                 keys,
 		sourceHostFiller:     createSourceHostFiller(cfg),
-		sourceCategoryFiller: newSourceCategoryFiller(cfg),
+		sourceCategoryFiller: newSourceCategoryFiller(cfg, set.Logger),
 		sourceNameFiller:     createSourceNameFiller(cfg),
 		exclude:              exclude,
 	}


### PR DESCRIPTION
They proved useful when debugging why the source category filler wasn't working.