### PR TITLE
Revert "test(scripts/install.sh): disable FIPS version test"

### DIFF
--- a/pkg/scripts_test/install_linux_amd64_test.go
+++ b/pkg/scripts_test/install_linux_amd64_test.go
@@ -37,7 +37,6 @@ func TestInstallScriptLinuxAmd64(t *testing.T) {
 		},
 	} {
 		t.Run(spec.name, func(t *testing.T) {
-			t.Skip("the version on the FIPS binary is not set correctly for 0.70.0-sumo-1")
 			runTest(t, &spec)
 		})
 	}


### PR DESCRIPTION
This reverts commit ca7eaed0c86a73350b1df59222eee47a83f4903b. With https://github.com/SumoLogic/sumologic-otel-collector/releases/tag/v0.70.0-sumo-2 out, this test can be enabled again.

Fixes #940 