### PR TITLE
feat(sourceprocessor): make container name attribute configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This release introduces the following breaking changes:
 - feat(sourceprocessor): add debug logs for source category filler [#944]
 - feat(snmpreceiver): add SNMP receiver to distro [#945]
 - feat(syslogexporter): add syslog exporter [#936]
+- feat(sourceprocessor): make container name attribute configurable [#950]
 
 ### Fixed
 
@@ -26,6 +27,7 @@ This release introduces the following breaking changes:
 [#944]: https://github.com/SumoLogic/sumologic-otel-collector/pull/944
 [#945]: https://github.com/SumoLogic/sumologic-otel-collector/pull/945
 [#936]: https://github.com/SumoLogic/sumologic-otel-collector/pull/936
+[#950]: https://github.com/SumoLogic/sumologic-otel-collector/pull/950
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.70.0-sumo-0...main
 
 ## [v0.70.0-sumo-2]

--- a/pkg/processor/sourceprocessor/README.md
+++ b/pkg/processor/sourceprocessor/README.md
@@ -66,6 +66,9 @@ processors:
       # Specifies whether container-level annotations are enabled.
       # default: false
       enabled: {true, false}
+      # Name of the attribute that contains the container name.
+      # default: "k8s.container.name"
+      container_name_key: <container_name_key>
       # List of prefixes for container-level pod annotations.
       # default: ["sumologic.com/"]
       prefixes:

--- a/pkg/processor/sourceprocessor/config.go
+++ b/pkg/processor/sourceprocessor/config.go
@@ -38,6 +38,7 @@ type Config struct {
 }
 
 type ContainerAnnotationsConfig struct {
-	Enabled  bool     `mapstructure:"enabled"`
-	Prefixes []string `mapstructure:"prefixes"`
+	Enabled          bool     `mapstructure:"enabled"`
+	ContainerNameKey string   `mapstructure:"container_name_key"`
+	Prefixes         []string `mapstructure:"prefixes"`
 }

--- a/pkg/processor/sourceprocessor/config_test.go
+++ b/pkg/processor/sourceprocessor/config_test.go
@@ -64,7 +64,8 @@ func TestLoadConfig(t *testing.T) {
 		PodTemplateHashKey: "pod_labels_pod-template-hash",
 
 		ContainerAnnotations: ContainerAnnotationsConfig{
-			Enabled: false,
+			Enabled:          false,
+			ContainerNameKey: "k8s.container.name",
 			Prefixes: []string{
 				"sumologic.com/",
 			},

--- a/pkg/processor/sourceprocessor/factory.go
+++ b/pkg/processor/sourceprocessor/factory.go
@@ -39,6 +39,7 @@ const (
 	defaultPodKey             = "k8s.pod.name"
 	defaultPodNameKey         = "k8s.pod.pod_name"
 	defaultPodTemplateHashKey = "k8s.pod.label.pod-template-hash"
+	defaultContainerNameKey   = "k8s.container.name"
 
 	stabilityLevel = component.StabilityLevelBeta
 )
@@ -72,7 +73,8 @@ func createDefaultConfig() component.Config {
 		PodTemplateHashKey: defaultPodTemplateHashKey,
 
 		ContainerAnnotations: ContainerAnnotationsConfig{
-			Enabled: false,
+			Enabled:          false,
+			ContainerNameKey: defaultContainerNameKey,
 			Prefixes: []string{
 				"sumologic.com/",
 			},

--- a/pkg/processor/sourceprocessor/source_category_filler.go
+++ b/pkg/processor/sourceprocessor/source_category_filler.go
@@ -31,6 +31,7 @@ type sourceCategoryFiller struct {
 	dashReplacement              string
 	annotationPrefix             string
 	containerAnnotationsEnabled  bool
+	containerNameKey             string
 	containerAnnotationsPrefixes []string
 }
 
@@ -48,6 +49,7 @@ func newSourceCategoryFiller(cfg *Config, logger *zap.Logger) sourceCategoryFill
 		dashReplacement:              cfg.SourceCategoryReplaceDash,
 		annotationPrefix:             cfg.AnnotationPrefix,
 		containerAnnotationsEnabled:  cfg.ContainerAnnotations.Enabled,
+		containerNameKey:             cfg.ContainerAnnotations.ContainerNameKey,
 		containerAnnotationsPrefixes: cfg.ContainerAnnotations.Prefixes,
 	}
 }
@@ -104,9 +106,10 @@ func (f *sourceCategoryFiller) getSourceCategoryFromContainerAnnotation(attribut
 		return ""
 	}
 
-	containerName, found := attributes.Get("k8s.container.name")
+	containerName, found := attributes.Get(f.containerNameKey)
 	if !found || containerName.Str() == "" {
-		f.logger.Debug("Couldn't fill source category from container annotation: k8s.container.name attribute not found.")
+		f.logger.Debug("Couldn't fill source category from container annotation: container name attribute not found.",
+			zap.String("container_name_key", f.containerNameKey))
 		return ""
 	}
 


### PR DESCRIPTION
It was hardcoded to `k8s.container.name`.
This change makes it configurable.