### PR TITLE
test: enable race detection in Go tests

### DIFF
--- a/pkg/Makefile.Common
+++ b/pkg/Makefile.Common
@@ -2,7 +2,7 @@ ifeq ($(OS),Windows_NT)
 	OS=windows
 endif
 
-GOTEST=go test -count 1
+GOTEST=go test -count 1 -race
 LINT=golangci-lint
 
 .PHONY: test

--- a/pkg/processor/cascadingfilterprocessor/idbatcher/id_batcher_test.go
+++ b/pkg/processor/cascadingfilterprocessor/idbatcher/id_batcher_test.go
@@ -116,7 +116,10 @@ func concurrencyTest(t *testing.T, numBatches, newBatchesInitialCapacity, batchC
 		}
 	}()
 
-	ids := generateSequentialIds(10000)
+	// don't set this too high, we spawn a goroutine for each one, and the race detector on Windows has
+	// a limit of 8192
+	traceIdCount := 1000
+	ids := generateSequentialIds(uint64(traceIdCount))
 	wg := &sync.WaitGroup{}
 	for i := 0; i < len(ids); i++ {
 		wg.Add(1)

--- a/pkg/processor/cascadingfilterprocessor/processor_test.go
+++ b/pkg/processor/cascadingfilterprocessor/processor_test.go
@@ -103,7 +103,7 @@ func TestDecisionHistory(t *testing.T) {
 }
 
 func TestConcurrentTraceArrival(t *testing.T) {
-	traceIds, batches := generateIdsAndBatches(128)
+	traceIds, batches := generateIdsAndBatches(64)
 	tsp := buildBasicCFSP(t, uint64(2*len(traceIds)))
 
 	var wg sync.WaitGroup
@@ -153,8 +153,8 @@ func TestSequentialTraceMapSize(t *testing.T) {
 }
 
 func TestConcurrentTraceMapSize(t *testing.T) {
-	_, batches := generateIdsAndBatches(210)
-	const maxSize = 100
+	_, batches := generateIdsAndBatches(64)
+	const maxSize = 50
 	var wg sync.WaitGroup
 	tsp := buildBasicCFSP(t, uint64(maxSize))
 	for _, batch := range batches {

--- a/pkg/receiver/rawk8seventsreceiver/receiver_test.go
+++ b/pkg/receiver/rawk8seventsreceiver/receiver_test.go
@@ -416,7 +416,7 @@ func TestStorage(t *testing.T) {
 
 	// Create the second k8s event.
 	secondEvent := getEvent()
-	firstEvent.UID = types.UID("ec279341-e2d8-4b2a-b17d-6e0566481002")
+	secondEvent.UID = types.UID("ec279341-e2d8-4b2a-b17d-6e0566481002")
 	listWatch.Add(secondEvent)
 
 	// Both events should be picked up by the receiver.


### PR DESCRIPTION
I fixed a small problem in the event receiver test.

I reduced some numbers in cascading filter processor tests, as the race detector has a limit of 8192 goroutines on Windows.