### PR TITLE
ci: fix Windows signing step

### DIFF
--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -101,7 +101,7 @@ jobs:
           tee otelcol-sumo-${{matrix.arch_os}}_modules.txt
 
       - name: Sign Windows binary
-        if: runner.os == "Windows"
+        if: runner.os == 'Windows'
         uses: skymatic/code-sign-action@v2
         with:
           certificate: '${{ secrets.MICROSOFT_CERTIFICATE }}'


### PR DESCRIPTION
Double quotes are not allowed in GHA conditional expressions.