### PR TITLE
feat: rename install_token to installation token

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -171,7 +171,7 @@ For example, with the following configuration:
 ```yaml
 extensions:
   sumologic:
-    install_token: <token>
+    installation_token: <token>
 receivers:
   tcplog:
     listen_address: "0.0.0.0:54526"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,7 +42,7 @@ The primary components that make it easy to send data to Sumo Logic are
 the [Sumo Logic Exporter][sumologicexporter_docs]
 and the [Sumo Logic Extension][sumologicextension_configuration].
 
-To create the `install_token` please follow [this documenation][sumologic_docs_install_token].
+To create the `installation_token` please follow [this documenation][sumologic_docs_installation_token].
 
 Here's a starting point for the configuration file that you will want to use:
 
@@ -52,7 +52,7 @@ exporters:
 
 extensions:
   sumologic:
-    install_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
+    installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
 
 receivers:
   ... # fill in receiver configurations here
@@ -91,7 +91,7 @@ and after that let's put that all together.
 > chmod 640 config.yaml
 > ```
 
-[sumologic_docs_install_token]: https://help.sumologic.com/docs/manage/security/installation-tokens
+[sumologic_docs_installation_token]: https://help.sumologic.com/docs/manage/security/installation-tokens
 
 ### Basic configuration for logs
 
@@ -110,7 +110,7 @@ extensions:
   file_storage:
     directory: .
   sumologic:
-    install_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
+    installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
 
 receivers:
   filelog:
@@ -152,7 +152,7 @@ exporters:
 
 extensions:
   sumologic:
-    install_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
+    installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
 
 receivers:
   telegraf:
@@ -185,7 +185,7 @@ exporters:
 
 extensions:
   sumologic:
-    install_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
+    installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
 
 receivers:
   otlp:
@@ -217,7 +217,7 @@ extensions:
   file_storage:
     directory: .
   sumologic:
-    install_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
+    installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
 
 receivers:
   filelog:
@@ -269,7 +269,7 @@ the [Host Metrics Receiver][hostmetricsreceiver] and send them to Sumo Logic:
 ```yaml
 extensions:
   sumologic:
-    install_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
+    installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
     collector_name: ${MY_COLLECTOR_NAME}
 
 receivers:
@@ -321,11 +321,11 @@ Example:
 ```yaml
 extensions:
   sumologic/custom_auth1:
-    install_token: ${SUMOLOGIC_INSTALLATION_TOKEN_1}
+    installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN_1}
     collector_name: <COLLECTOR_NAME_1>
 
   sumologic/custom_auth2:
-    install_token: ${SUMOLOGIC_INSTALLATION_TOKEN_2}
+    installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN_2}
     collector_name: <COLLECTOR_NAME_2>
 
 receivers:
@@ -378,7 +378,7 @@ extensions:
   file_storage:
     directory: .
   sumologic:
-    install_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
+    installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
 
 receivers:
   hostmetrics:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,7 +31,7 @@ To run it as a standalone process you only need to run the binary file downloade
 
 ### Installation using script
 
-1. Get your [installation token][sumologic_docs_install_token] if you don't have it already and assign it to environment variable:
+1. Get your [installation token][sumologic_docs_installation_token] if you don't have it already and assign it to environment variable:
 
    ```bash
    export SUMOLOGIC_INSTALLATION_TOKEN=<TOKEN>
@@ -302,7 +302,7 @@ for potential breaking changes that would require manual migration steps.
        directory: .
      sumologic:
        collector_name: sumologic-demo
-       install_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
+       installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
 
    receivers:
      filelog:
@@ -322,7 +322,7 @@ for potential breaking changes that would require manual migration steps.
 
    Please save this configuration as `config.yaml`.
 
-1. In order to send data to Sumo you will also need an [installation token][sumologic_docs_install_token].
+1. In order to send data to Sumo you will also need an [installation token][sumologic_docs_installation_token].
 
    If you have an installation token, you can run otelcol with the example configuration:
 
@@ -343,7 +343,7 @@ for potential breaking changes that would require manual migration steps.
 
    ![live_tail_image](../images/live_tail.png)
 
-[sumologic_docs_install_token]: https://help.sumologic.com/docs/manage/security/installation-tokens
+[sumologic_docs_installation_token]: https://help.sumologic.com/docs/manage/security/installation-tokens
 [live_tail]: https://help.sumologic.com/docs/search/live-tail/about-live-tail#start-a-live-tail-session
 
 ## Container image

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -97,7 +97,7 @@ Let's consider the following example:
 ```yaml
 extensions:
   sumologic:
-    install_token: <install_token>
+    installation_token: <installation_token>
 
 receivers:
   filelog:
@@ -160,7 +160,7 @@ Collector name can be specified by setting the `collector_name` option:
 ```yaml
 extensions:
   sumologic:
-    install_token: <install_token>
+    installation_token: <installation_token>
     collector_name: my_collector
 ```
 
@@ -171,7 +171,7 @@ To set a description, use the `collector_description` option:
 ```yaml
 extensions:
   sumologic:
-    install_token: <install_token>
+    installation_token: <installation_token>
     collector_name: my_collector
     collector_description: This is my and only my collector
 ```
@@ -184,7 +184,7 @@ The exporter will set the host name for every record sent to Sumo Logic:
 ```yaml
 extensions:
   sumologic:
-    install_token: <install_token>
+    installation_token: <installation_token>
     collector_name: my_collector
     collector_description: This is my and only my collector
 exporters:
@@ -199,7 +199,7 @@ To set a Collector category, use the `collector_category` option:
 ```yaml
 extensions:
   sumologic:
-    install_token: <install_token>
+    installation_token: <installation_token>
     collector_name: my_collector
     collector_description: This is my and only my collector
     collector_category: example
@@ -217,7 +217,7 @@ you could use the following configuration:
 ```yaml
 extensions:
   sumologic:
-    install_token: <install_token>
+    installation_token: <installation_token>
     collector_name: my_collector
     collector_description: This is my and only my collector
     collector_category: example
@@ -244,7 +244,7 @@ For example, the following examples sets the time zone to `America/Tijuana`:
 ```yaml
 extensions:
   sumologic:
-    install_token: <install_token>
+    installation_token: <installation_token>
     collector_name: my_collector
     collector_description: This is my and only my collector
     collector_category: example
@@ -285,7 +285,7 @@ Below is an example of an OpenTelemetry configuration for a Local File Source.
 ```yaml
 extensions:
   sumologic:
-    install_token: <install_token>
+    installation_token: <installation_token>
     ## Time Zone is a substitute of Installed Collector `Time Zone`
     ## with `Use time zone from log file. If none is detected use:` option.
     ## This is used only if `clear_logs_timestamp` is set to `true` in sumologic exporter.
@@ -770,7 +770,7 @@ Below is an example of an OpenTelemetry configuration for a Syslog Source.
 ```yaml
 extensions:
   sumologic:
-    install_token: <install_token>
+    installation_token: <installation_token>
     ## Time Zone is a substitute of Installed Collector `Time Zone`
     ## with `Use time zone from log file. If none is detected use:` option.
     ## This is used only if `clear_logs_timestamp` is set to `true` in sumologic exporter.
@@ -1160,7 +1160,7 @@ Below is an example of an OpenTelemetry configuration for a Streaming Metrics So
 ```yaml
 extensions:
   sumologic:
-    install_token: <install_token>
+    installation_token: <installation_token>
     ## Time Zone is a substitute of Installed Collector `Time Zone`
     ## Full list of time zones is available on wikipedia:
     ## https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
@@ -1381,7 +1381,7 @@ Below is an example of an OpenTelemetry configuration for a Host Metrics Source.
 ```yaml
 extensions:
   sumologic:
-    install_token: <install_token>
+    installation_token: <installation_token>
     ## Time Zone is a substitute of Installed Collector `Time Zone`
     ## Full list of time zones is available on wikipedia:
     ## https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
@@ -1979,8 +1979,8 @@ The following table shows the equivalent [user.properties][user.properties] for 
 | user.properties key                           | The OpenTelemetry Collector Key                            |
 |-----------------------------------------------|------------------------------------------------------------|
 | `wrapper.java.command=JRE Bin Location`       | N/A                                                        |
-| ~~`accessid=accessId`~~                       | N/A, use `extensions.sumologic.install_token`              |
-| ~~`accesskey=accessKey`~~                     | N/A, use `extensions.sumologic.install_token`              |
+| ~~`accessid=accessId`~~                       | N/A, use `extensions.sumologic.installation_token`         |
+| ~~`accesskey=accessKey`~~                     | N/A, use `extensions.sumologic.installation_token`         |
 | `category=category`                           | [extensions.sumologic.collector_category](#category)       |
 | `clobber=true/false`                          | `extensions.sumologic.clobber`                             |
 | `description=description`                     | [extensions.sumologic.collector_description](#description) |

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -50,7 +50,7 @@ extensions:
     directory: .
   sumologic:
     collector_name: sumologic-demo
-    install_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
+    installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
 ```
 
 ### `apache` receiver: turn on feature gates for resource attributes

--- a/examples/config_cpu_load_metrics.yaml
+++ b/examples/config_cpu_load_metrics.yaml
@@ -1,6 +1,6 @@
 extensions:
   sumologic:
-    install_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
+    installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
     collector_name: ${SUMOLOGIC_COLLECTOR_NAME}
 
 receivers:

--- a/examples/sumologic-windows.yaml
+++ b/examples/sumologic-windows.yaml
@@ -5,7 +5,7 @@ extensions:
   ## Manages registration, heartbeats and authentication to Sumo Logic
   ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/extension/sumologicextension
   sumologic:
-    install_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
+    installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
     collector_credentials_directory: ${PROGRAMDATA}\Sumo Logic\OpenTelemetry Collector\data\credentials
 
   ## Configuration for Health Check Extension

--- a/examples/sumologic.yaml
+++ b/examples/sumologic.yaml
@@ -5,7 +5,7 @@ extensions:
   ## Manages registration, heartbeats and authentication to Sumo Logic
   ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/extension/sumologicextension
   sumologic:
-    install_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
+    installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
     collector_credentials_directory: /var/lib/otelcol-sumo/credentials
 
   ## Configuration for Health Check Extension

--- a/examples/verify_installation.yaml
+++ b/examples/verify_installation.yaml
@@ -10,7 +10,7 @@ extensions:
     directory: .
   sumologic:
     collector_name: sumologic-demo
-    install_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
+    installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
 
 receivers:
   filelog:

--- a/packaging/msi/SumoLogic.wixext/SumoLogic.wixext/ConfigUpdater.cs
+++ b/packaging/msi/SumoLogic.wixext/SumoLogic.wixext/ConfigUpdater.cs
@@ -38,8 +38,8 @@ namespace SumoLogic.wixext
 
             if (config.InstallationToken != "")
             {
-                EnsureScalarKey(sumologic, "install_token");
-                sumologic.Children["install_token"] = config.InstallationToken;
+                EnsureScalarKey(sumologic, "installation_token");
+                sumologic.Children["installation_token"] = config.InstallationToken;
             }
 
             if (config.CollectorFields.Count > 0)

--- a/packaging/msi/SumoLogic.wixext/SumoLogic.wixext/CustomAction.cs
+++ b/packaging/msi/SumoLogic.wixext/SumoLogic.wixext/CustomAction.cs
@@ -14,6 +14,7 @@ namespace SumoLogic.wixext
         // WiX property names
         private const string pCommonConfigPath = "CommonConfigPath";
         private const string pInstallationToken = "InstallationToken";
+        private const string pInstallToken = "InstallToken";
         private const string pTags = "Tags";
 
         [CustomAction]
@@ -28,7 +29,7 @@ namespace SumoLogic.wixext
                 showErrorMessage(session, ecMissingCustomActionData, pCommonConfigPath);
                 return ActionResult.Failure;
             }
-            if (!session.CustomActionData.ContainsKey(pInstallationToken))
+            if (!session.CustomActionData.ContainsKey(pInstallToken) && !session.CustomActionData.ContainsKey(pInstallationToken))
             {
                 showErrorMessage(session, ecMissingCustomActionData, pInstallationToken);
                 return ActionResult.Failure;
@@ -40,8 +41,14 @@ namespace SumoLogic.wixext
             }
 
             var commonConfigPath = session.CustomActionData[pCommonConfigPath];
-            var installationToken = session.CustomActionData[pInstallationToken];
             var tags = session.CustomActionData[pTags];
+
+            var installationToken = "";
+            if (session.CustomActionData.ContainsKey(pInstallationToken) && session.CustomActionData[pInstallationToken] != "") {
+                installationToken = session.CustomActionData[pInstallationToken];
+            } else if (session.CustomActionData.ContainsKey(pInstallToken)){
+                installationToken = session.CustomActionData[pInstallToken];
+            }
 
             // Load config from disk and replace values
             Config config = new Config();

--- a/packaging/msi/SumoLogic.wixext/SumoLogicTests/ConfigUpdaterTests.cs
+++ b/packaging/msi/SumoLogic.wixext/SumoLogicTests/ConfigUpdaterTests.cs
@@ -25,9 +25,9 @@ namespace SumoLogicTests
             Assert.AreEqual(YamlNodeType.Mapping, extensions.Children["sumologic"].NodeType);
             var sumologic = (YamlMappingNode)extensions.Children["sumologic"];
 
-            Assert.IsTrue(sumologic.Children.ContainsKey("install_token"));
-            Assert.AreEqual(YamlNodeType.Scalar, sumologic.Children["install_token"].NodeType);
-            Assert.AreEqual(config.InstallationToken, sumologic.Children["install_token"].ToString());
+            Assert.IsTrue(sumologic.Children.ContainsKey("installation_token"));
+            Assert.AreEqual(YamlNodeType.Scalar, sumologic.Children["installation_token"].NodeType);
+            Assert.AreEqual(config.InstallationToken, sumologic.Children["installation_token"].ToString());
 
             Assert.IsTrue(sumologic.Children.ContainsKey("collector_fields"));
             Assert.AreEqual(YamlNodeType.Mapping, sumologic.Children["collector_fields"].NodeType);

--- a/packaging/msi/SumoLogic.wixext/SumoLogicTests/TestData/with-extensions-block.yaml
+++ b/packaging/msi/SumoLogic.wixext/SumoLogicTests/TestData/with-extensions-block.yaml
@@ -5,7 +5,7 @@ extensions:
   ## Manages registration, heartbeats and authentication to Sumo Logic
   ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/extension/sumologicextension
   sumologic:
-    install_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
+    installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
     collector_credentials_directory: ${PROGRAMDATA}\Sumo Logic\otelcol-sumo\data\credentials
 
   ## Configuration for Health Check Extension

--- a/packaging/msi/wix/assets/common.yaml
+++ b/packaging/msi/wix/assets/common.yaml
@@ -1,3 +1,3 @@
 extensions:
   sumologic:
-    install_token:
+    installation_token:

--- a/packaging/msi/wix/package.wxs
+++ b/packaging/msi/wix/package.wxs
@@ -57,6 +57,7 @@
         Determine the INSTALLATIONTOKEN of a previous installation (if one exists)
         If not, INSTALLATIONTOKEN stays empty
     -->
+    <Property Id="INSTALLTOKEN" Hidden="yes" />
     <Property Id="INSTALLATIONTOKEN" Hidden="yes" />
     <!-- TODO: fix permissions to allow securely storing secrets in the registry -->
     <!-- <Property Id="INSTALLATIONTOKEN"> -->
@@ -81,7 +82,7 @@
 
     <Binary Id="SumoLogicDll" SourceFile="$(SumoLogic.TargetDir)\SumoLogic.wixext.CA.dll" />
     <CustomAction Id="UpdateConfigAction" BinaryRef="SumoLogicDll" DllEntry="UpdateConfig" Execute="deferred" Return="check" Impersonate="no" />
-    <CustomAction Id="UpdateConfigActionData" Property="UpdateConfigAction" Value="CommonConfigPath=[ConfigFragmentsFolder]common.yaml;InstallationToken=[INSTALLATIONTOKEN];Tags=[TAGS]" />
+    <CustomAction Id="UpdateConfigActionData" Property="UpdateConfigAction" Value="CommonConfigPath=[ConfigFragmentsFolder]common.yaml;InstallToken=[INSTALLTOKEN];InstallationToken=[INSTALLATIONTOKEN];Tags=[TAGS]" />
 
     <!-- Execute Sequence -->
     <InstallExecuteSequence>

--- a/pkg/scripts_test/config.go
+++ b/pkg/scripts_test/config.go
@@ -18,6 +18,7 @@ type extensions struct {
 
 type sumologicExtension struct {
 	InstallToken string            `yaml:"install_token"`
+	InstallationToken string       `yaml:"installation_token"`
 	Tags         map[string]string `yaml:"collector_fields"`
 	APIBaseURL   string            `yaml:"api_base_url"`
 }

--- a/pkg/scripts_test/config.go
+++ b/pkg/scripts_test/config.go
@@ -17,10 +17,10 @@ type extensions struct {
 }
 
 type sumologicExtension struct {
-	InstallToken string            `yaml:"install_token"`
-	InstallationToken string       `yaml:"installation_token"`
-	Tags         map[string]string `yaml:"collector_fields"`
-	APIBaseURL   string            `yaml:"api_base_url"`
+	InstallToken      string            `yaml:"install_token"`
+	InstallationToken string            `yaml:"installation_token"`
+	Tags              map[string]string `yaml:"collector_fields"`
+	APIBaseURL        string            `yaml:"api_base_url"`
 }
 
 func getConfig(path string) (config, error) {

--- a/pkg/scripts_test/config.go
+++ b/pkg/scripts_test/config.go
@@ -17,8 +17,8 @@ type extensions struct {
 }
 
 type sumologicExtension struct {
-	InstallToken      string            `yaml:"install_token"`
-	InstallationToken string            `yaml:"installation_token"`
+	InstallToken      string            `yaml:"install_token,omitempty"`
+	InstallationToken string            `yaml:"installation_token,omitempty"`
 	Tags              map[string]string `yaml:"collector_fields"`
 	APIBaseURL        string            `yaml:"api_base_url"`
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,7 +60,7 @@ readonly DEPRECATED_ARG_LONG_TOKEN DEPRECATED_ENV_TOKEN DEPRECATED_ARG_LONG_SKIP
 
 ############################ Variables (see set_defaults function for default values)
 
-# Support providing install_token as env
+# Support providing installation_token as env
 set +u
 if [[ -z "${SUMOLOGIC_INSTALLATION_TOKEN}" && -z "${SUMOLOGIC_INSTALL_TOKEN}" ]]; then
     SUMOLOGIC_INSTALLATION_TOKEN=""
@@ -766,8 +766,16 @@ function get_user_config() {
         return
     fi
 
-    # extract install_token and strip quotes
-    grep -m 1 install_token "${file}" \
+    # extract installation_token and strip quotes
+    # fallback to deprecated install_token
+    grep -m 1 installation_token "${file}" \
+        | sed 's/.*installation_token:[[:blank:]]*//' \
+        | sed 's/[[:blank:]]*$//' \
+        | sed 's/^"//' \
+        | sed "s/^'//" \
+        | sed 's/"$//' \
+        | sed "s/'\$//" \
+    || grep -m 1 install_token "${file}" \
         | sed 's/.*install_token:[[:blank:]]*//' \
         | sed 's/[[:blank:]]*$//' \
         | sed 's/^"//' \


### PR DESCRIPTION
This is continuation of #969

ToDo:

- support for windows both install_token and installation_token
  - [x] As I understand, we are not comparing installation tokens (previous and current installation) right now, so skipping this point
  - [x] Supporting to run in poershell with both `INSTALLTOKEN` and `INSTALLATIONTOKEN`
- update scripts_tests
  - [x] updated
  - [x] tested