### PR TITLE
refactor(scripts/install): do not expose token in sed command

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -887,6 +887,7 @@ ${indentation}sumologic:/" "${file}"
 
 # write installation token to user configuration file
 function write_installation_token() {
+    set -x
     local token
     readonly token="${1}"
 
@@ -898,12 +899,13 @@ function write_installation_token() {
 
     # ToDo: ensure we override only sumologic `install_token`
     if grep "install_token" "${file}" > /dev/null; then
-        sed -i.bak -e "s/install_token:.*$/install_token: $(escape_sed "${token}")/" "${file}"
+        echo "s/install_token:.*$/install_token: $(escape_sed "${token}")/" | sed -i.bak -f - "${file}"
     else
         # write installation token on the top of sumologic: extension
-        sed -i.bak -e "s/sumologic:/sumologic:\\
-\\${ext_indentation}install_token: $(escape_sed "${token}")/" "${file}"
+        echo "s/sumologic:/sumologic:\\
+\\${ext_indentation}install_token: $(escape_sed "${token}")/" | sed -i.bak -f - "${file}"
     fi
+    set +x
 }
 
 # write api_url to user configuration file

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -903,7 +903,7 @@ function write_installation_token() {
         echo "s/install_token:.*$/install_token: $(escape_sed "${token}")/" | sed -i.bak -f - "${file}"
     else
         # write installation token on the top of sumologic: extension
-        Do not expose token in sed command as it can be saw on processes list
+        # Do not expose token in sed command as it can be saw on processes list
         echo "s/sumologic:/sumologic:\\
 \\${ext_indentation}install_token: $(escape_sed "${token}")/" | sed -i.bak -f - "${file}"
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -899,9 +899,11 @@ function write_installation_token() {
 
     # ToDo: ensure we override only sumologic `install_token`
     if grep "install_token" "${file}" > /dev/null; then
+        # Do not expose token in sed command as it can be saw on processes list
         echo "s/install_token:.*$/install_token: $(escape_sed "${token}")/" | sed -i.bak -f - "${file}"
     else
         # write installation token on the top of sumologic: extension
+        Do not expose token in sed command as it can be saw on processes list
         echo "s/sumologic:/sumologic:\\
 \\${ext_indentation}install_token: $(escape_sed "${token}")/" | sed -i.bak -f - "${file}"
     fi


### PR DESCRIPTION
Do not expose token in sed command as it can be saw on processes list