### PR TITLE
docs: remove uppercase docs files

### DIFF
--- a/docs/BestPractices.md
+++ b/docs/BestPractices.md
@@ -1,1 +1,0 @@
-Moved to [./best-practices.md](./best-practices.md)

--- a/docs/Comparison.md
+++ b/docs/Comparison.md
@@ -1,1 +1,0 @@
-Moved to [./comparison.md](./comparison.md)

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,1 +1,0 @@
-Moved to [./configuration.md](./configuration.md)

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,1 +1,0 @@
-Moved to [./installation.md](./installation.md)

--- a/docs/KnownIssues.md
+++ b/docs/KnownIssues.md
@@ -1,1 +1,0 @@
-Moved to [./known-issues.md](./known-issues.md)

--- a/docs/Migration.md
+++ b/docs/Migration.md
@@ -1,1 +1,0 @@
-Moved to [./migration.md](./migration.md)

--- a/docs/OpenTelemetryConcepts.md
+++ b/docs/OpenTelemetryConcepts.md
@@ -1,1 +1,0 @@
-Moved to [./open-telemetry-concepts.md](./open-telemetry-concepts.md)

--- a/docs/Performance.md
+++ b/docs/Performance.md
@@ -1,1 +1,0 @@
-Moved to [./performance.md](./performance.md)

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -1,1 +1,0 @@
-Moved to [./troubleshooting.md](./troubleshooting.md)

--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -1,1 +1,0 @@
-Moved to [./upgrading.md](./upgrading.md)

--- a/docs/UpstreamRelation.md
+++ b/docs/UpstreamRelation.md
@@ -1,1 +1,0 @@
-Moved to [./upstream-relation.md](./upstream-relation.md)


### PR DESCRIPTION
We've renamed docs to kebab-case in #823, and the old docs files were left containing only links to the new ones. This change removes the old files completely.