### PR TITLE
fix: ensure correct permissions for hostmetrics after upgrade

### DIFF
--- a/pkg/scripts_test/check.go
+++ b/pkg/scripts_test/check.go
@@ -377,6 +377,30 @@ func checkAbortedDueToDifferentTags(c check) {
 	require.Contains(c.test, c.output[len(c.output)-1], "You are trying to install with different tags than in your configuration file!")
 }
 
+// preActionCreateUser creates systemUser and then set it as owner of configPath
+func preActionCreateUser(c check) {
+	preActionMockUserConfig(c)
+
+	cmd := exec.Command("useradd", systemUser)
+	_, err := cmd.CombinedOutput()
+	require.NoError(c.test, err)
+
+	f, err := os.Open(configPath)
+	require.NoError(c.test, err)
+
+	user, err := user.Lookup(systemUser)
+	require.NoError(c.test, err)
+
+	uid, err := strconv.Atoi(user.Uid)
+	require.NoError(c.test, err)
+
+	gid, err := strconv.Atoi(user.Gid)
+	require.NoError(c.test, err)
+
+	err = f.Chown(uid, gid)
+	require.NoError(c.test, err)
+}
+
 func checkUserExists(c check) {
 	_, err := user.Lookup(systemUser)
 	require.NoError(c.test, err)

--- a/pkg/scripts_test/install_unix_test.go
+++ b/pkg/scripts_test/install_unix_test.go
@@ -353,6 +353,27 @@ func TestInstallScript(t *testing.T) {
 			installCode:       3, // because of invalid install token
 		},
 		{
+			name: "installation of hostmetrics in systemd during upgrade",
+			options: installOptions{
+				installToken:       installToken,
+				installHostmetrics: true,
+			},
+			preActions:        []checkFunc{preActionMockSystemdStructure, preActionCreateUser},
+			conditionalChecks: []condCheckFunc{checkSystemdAvailability},
+			preChecks:         []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkUserExists},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkTokenInConfig,
+				checkUserExists,
+				checkHostmetricsConfigCreated,
+				checkHostmetricsOwnershipAndPermissions(systemUser, systemUser),
+			},
+			installCode: 1, // because of invalid installation token
+		},
+		{
 			name: "uninstallation without autoconfirm fails",
 			options: installOptions{
 				uninstall: true,

--- a/pkg/scripts_test/install_unix_test.go
+++ b/pkg/scripts_test/install_unix_test.go
@@ -371,7 +371,6 @@ func TestInstallScript(t *testing.T) {
 				checkHostmetricsConfigCreated,
 				checkHostmetricsOwnershipAndPermissions(systemUser, systemUser),
 			},
-			installCode: 1, // because of invalid installation token
 		},
 		{
 			name: "uninstallation without autoconfirm fails",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1241,6 +1241,13 @@ fi
 echo 'We are going to set up a systemd service'
 
 if [[ -f "${SYSTEMD_CONFIG}" ]]; then
+    # This is required for configuration being installed after systemd setup
+    # for example first installation without hostmetrics and second with hostmetrics
+    if getent passwd "${SYSTEM_USER}" > /dev/null && [[ "${SKIP_CONFIG}" == "false" ]]; then
+        echo 'Ensuring that ownership for config and storage is correct'
+        chown -R "${SYSTEM_USER}":"${SYSTEM_USER}" "${HOME_DIRECTORY}" "${CONFIG_DIRECTORY}"/*
+        chown -R "${SYSTEM_USER}":"${SYSTEM_USER}" "${USER_ENV_DIRECTORY}"
+    fi
     echo "Configuration for systemd service (${SYSTEMD_CONFIG}) already exist. Restarting service"
     systemctl restart otelcol-sumo
     exit 0


### PR DESCRIPTION
If we install once without `--hostmetrics` and then with `hostmetrics` switch, the `hostmetrics.yaml` configuration will have invalid owner