### PR TITLE
feat: keep token in env variable instead of config file

### DIFF
--- a/pkg/scripts_test/check.go
+++ b/pkg/scripts_test/check.go
@@ -188,7 +188,11 @@ func checkTokenInEnvFile(c check) {
 	envs, err := godotenv.Read(tokenEnvFilePath)
 
 	require.NoError(c.test, err)
-	require.Equal(c.test, c.installOptions.installToken, envs["SUMOLOGIC_INSTALLATION_TOKEN"], "installation token is different than expected")
+	if _, ok := envs["SUMOLOGIC_INSTALL_TOKEN"]; ok {
+		require.Equal(c.test, c.installOptions.installToken, envs["SUMOLOGIC_INSTALL_TOKEN"], "installation token is different than expected")
+	} else {
+		require.Equal(c.test, c.installOptions.installToken, envs["SUMOLOGIC_INSTALLATION_TOKEN"], "installation token is different than expected")
+	}
 }
 
 func checkDifferentTokenInEnvFile(c check) {
@@ -197,7 +201,11 @@ func checkDifferentTokenInEnvFile(c check) {
 	envs, err := godotenv.Read(tokenEnvFilePath)
 
 	require.NoError(c.test, err)
-	require.Equal(c.test, "different"+c.installOptions.installToken, envs["SUMOLOGIC_INSTALLATION_TOKEN"], "installation token is different than expected")
+	if _, ok := envs["SUMOLOGIC_INSTALL_TOKEN"]; ok {
+		require.Equal(c.test, "different"+c.installOptions.installToken, envs["SUMOLOGIC_INSTALL_TOKEN"], "installation token is different than expected")
+	} else {
+		require.Equal(c.test, "different"+c.installOptions.installToken, envs["SUMOLOGIC_INSTALLATION_TOKEN"], "installation token is different than expected")
+	}
 }
 
 func checkHostmetricsConfigCreated(c check) {
@@ -329,6 +337,14 @@ func preActionWriteDifferentTokenToEnvFile(c check) {
 	preActionMockEnvFiles(c)
 
 	content := fmt.Sprintf("SUMOLOGIC_INSTALLATION_TOKEN=different%s", c.installOptions.installToken)
+	err := os.WriteFile(tokenEnvFilePath, []byte(content), fs.FileMode(etcPathPermissions))
+	require.NoError(c.test, err)
+}
+
+func preActionWriteDifferentDeprecatedTokenToEnvFile(c check) {
+	preActionMockEnvFiles(c)
+
+	content := fmt.Sprintf("SUMOLOGIC_INSTALL_TOKEN=different%s", c.installOptions.installToken)
 	err := os.WriteFile(tokenEnvFilePath, []byte(content), fs.FileMode(etcPathPermissions))
 	require.NoError(c.test, err)
 }

--- a/pkg/scripts_test/check.go
+++ b/pkg/scripts_test/check.go
@@ -5,7 +5,6 @@ package sumologic_scripts_tests
 import (
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -330,7 +329,7 @@ func preActionWriteDifferentTokenToEnvFile(c check) {
 	preActionMockEnvFiles(c)
 
 	content := fmt.Sprintf("SUMOLOGIC_INSTALLATION_TOKEN=different%s", c.installOptions.installToken)
-	err := ioutil.WriteFile(tokenEnvFilePath, []byte(content), fs.FileMode(etcPathPermissions))
+	err := os.WriteFile(tokenEnvFilePath, []byte(content), fs.FileMode(etcPathPermissions))
 	require.NoError(c.test, err)
 }
 

--- a/pkg/scripts_test/consts.go
+++ b/pkg/scripts_test/consts.go
@@ -14,6 +14,8 @@ const (
 	confDPath                 string = etcPath + "/conf.d"
 	userConfigPath            string = confDPath + "/common.yaml"
 	hostmetricsConfigPath     string = confDPath + "/hostmetrics.yaml"
+	envDirectoryPath          string = etcPath + "/env"
+	tokenEnvFilePath          string = envDirectoryPath + "/token.env"
 
 	systemdDirectoryPath string = "/run/systemd/system"
 

--- a/pkg/scripts_test/go.mod
+++ b/pkg/scripts_test/go.mod
@@ -9,6 +9,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/joho/godotenv v1.5.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/scripts_test/go.sum
+++ b/pkg/scripts_test/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/scripts_test/install_unix_test.go
+++ b/pkg/scripts_test/install_unix_test.go
@@ -481,6 +481,17 @@ func TestInstallScript(t *testing.T) {
 			installCode:       1, // because of invalid installation token
 		},
 		{
+			name: "systemd installation if deprecated token in file",
+			options: installOptions{
+				installToken: installToken,
+			},
+			preActions:        []checkFunc{preActionWriteDifferentDeprecatedTokenToEnvFile},
+			preChecks:         []checkFunc{checkBinaryNotCreated, checkUserConfigNotCreated, checkUserNotExists},
+			postChecks:        []checkFunc{checkDifferentTokenInEnvFile, checkAbortedDueToDifferentToken},
+			conditionalChecks: []condCheckFunc{checkSystemdAvailability},
+			installCode:       1, // because of invalid installation token
+		},
+		{
 			name: "don't keep downloads",
 			options: installOptions{
 				skipInstallToken:  true,

--- a/pkg/scripts_test/install_unix_test.go
+++ b/pkg/scripts_test/install_unix_test.go
@@ -75,6 +75,7 @@ func TestInstallScript(t *testing.T) {
 				checkSystemdConfigNotCreated,
 				checkUserNotExists,
 				checkHostmetricsConfigNotCreated,
+				checkTokenEnvFileNotCreated,
 			},
 		},
 		{
@@ -306,16 +307,18 @@ func TestInstallScript(t *testing.T) {
 			options: installOptions{
 				installToken: installToken,
 			},
-			preChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
+			preChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists, checkTokenEnvFileNotCreated},
 			postChecks: []checkFunc{
 				checkBinaryCreated,
 				checkBinaryIsRunning,
 				checkConfigCreated,
 				checkConfigFilesOwnershipAndPermissions(systemUser, systemUser),
-				checkTokenInConfig,
+				checkUserConfigNotCreated,
 				checkSystemdConfigCreated,
 				checkSystemdEnvDirExists,
 				checkSystemdEnvDirPermissions,
+				checkTokenEnvFileCreated,
+				checkTokenInEnvFile,
 				checkUserExists,
 				checkVarLogACL,
 			},
@@ -323,7 +326,7 @@ func TestInstallScript(t *testing.T) {
 			installCode:       3, // because of invalid installation token
 		},
 		{
-			name: "installation token with existing user directory",
+			name: "systemd installation token with existing user directory",
 			options: installOptions{
 				installToken: installToken,
 			},
@@ -340,11 +343,41 @@ func TestInstallScript(t *testing.T) {
 				checkBinaryIsRunning,
 				checkConfigCreated,
 				checkConfigFilesOwnershipAndPermissions(systemUser, systemUser),
-				checkUserConfigCreated,
-				checkTokenInConfig,
 				checkSystemdConfigCreated,
 				checkSystemdEnvDirExists,
 				checkSystemdEnvDirPermissions,
+				checkTokenEnvFileCreated,
+				checkTokenInEnvFile,
+				checkUserExists,
+				checkVarLogACL,
+				checkOutputUserAddWarnings,
+			},
+			conditionalChecks: []condCheckFunc{checkSystemdAvailability},
+			installCode:       3, // because of invalid install token
+		},
+		{
+			name: "systemd existing installation different token env ",
+			options: installOptions{
+				installToken: installToken,
+			},
+			preActions: []checkFunc{preActionCreateHomeDirectory},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigNotCreated,
+				checkUserNotExists,
+				checkHomeDirectoryCreated,
+			},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkConfigFilesOwnershipAndPermissions(systemUser, systemUser),
+				checkSystemdConfigCreated,
+				checkSystemdEnvDirExists,
+				checkSystemdEnvDirPermissions,
+				checkTokenEnvFileCreated,
+				checkTokenInEnvFile,
 				checkUserExists,
 				checkVarLogACL,
 				checkOutputUserAddWarnings,
@@ -366,7 +399,7 @@ func TestInstallScript(t *testing.T) {
 				checkBinaryIsRunning,
 				checkConfigCreated,
 				checkUserConfigCreated,
-				checkTokenInConfig,
+				checkTokenInEnvFile,
 				checkUserExists,
 				checkHostmetricsConfigCreated,
 				checkHostmetricsOwnershipAndPermissions(systemUser, systemUser),
@@ -432,9 +465,20 @@ func TestInstallScript(t *testing.T) {
 			preActions: []checkFunc{preActionMockUserConfig, preActionWriteDifferentTokenToUserConfig, preActionWriteDefaultAPIBaseURLToUserConfig},
 			preChecks:  []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigCreated, checkUserNotExists},
 			postChecks: []checkFunc{checkBinaryCreated, checkBinaryIsRunning, checkConfigCreated, checkDifferentTokenInConfig, checkSystemdConfigCreated,
-				checkUserExists},
+				checkUserExists, checkTokenEnvFileNotCreated},
 			conditionalChecks: []condCheckFunc{checkSystemdAvailability},
 			installCode:       3, // because of invalid installation token
+		},
+		{
+			name: "systemd installation if token in file",
+			options: installOptions{
+				installToken: installToken,
+			},
+			preActions:        []checkFunc{preActionWriteDifferentTokenToEnvFile},
+			preChecks:         []checkFunc{checkBinaryNotCreated, checkUserConfigNotCreated, checkUserNotExists},
+			postChecks:        []checkFunc{checkDifferentTokenInEnvFile, checkAbortedDueToDifferentToken},
+			conditionalChecks: []condCheckFunc{checkSystemdAvailability},
+			installCode:       1, // because of invalid installation token
 		},
 		{
 			name: "don't keep downloads",

--- a/pkg/scripts_test/install_unix_test.go
+++ b/pkg/scripts_test/install_unix_test.go
@@ -356,7 +356,7 @@ func TestInstallScript(t *testing.T) {
 			installCode:       3, // because of invalid install token
 		},
 		{
-			name: "systemd existing installation different token env ",
+			name: "systemd existing installation different token env",
 			options: installOptions{
 				installToken: installToken,
 			},

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -793,6 +793,13 @@ function get_user_env_config() {
         | sed "s/^'//" \
         | sed 's/"$//' \
         | sed "s/'\$//" \
+    || grep -m 1 "${DEPRECATED_ENV_TOKEN}" "${file}" \
+        | sed "s/.*${DEPRECATED_ENV_TOKEN}=[[:blank:]]*//" \
+        | sed 's/[[:blank:]]*$//' \
+        | sed 's/^"//' \
+        | sed "s/^'//" \
+        | sed 's/"$//' \
+        | sed "s/'\$//" \
     || echo ""
 }
 
@@ -922,12 +929,20 @@ function write_installation_token_env() {
     local file
     readonly file="${2}"
 
-    # ToDo: ensure we override only ${ENV_TOKEN}" env value
-    if grep "${ENV_TOKEN}" "${file}" > /dev/null 2>&1; then
-        # Do not expose token in sed command as it can be saw on processes list
-        echo "s/${ENV_TOKEN}=.*$/${ENV_TOKEN}=$(escape_sed "${token}")/" | sed -i.bak -f - "${file}"
+    local token_name
+    if (( MAJOR_VERSION == 0 && MINOR_VERSION <= 71 )); then
+        token_name="${DEPRECATED_ENV_TOKEN}"
     else
-        echo "${ENV_TOKEN}=${token}" > "${file}"
+        token_name="${ENV_TOKEN}"
+    fi
+    readonly token_name
+
+    # ToDo: ensure we override only ${ENV_TOKEN}" env value
+    if grep "${token_name}" "${file}" > /dev/null 2>&1; then
+        # Do not expose token in sed command as it can be saw on processes list
+        echo "s/${token_name}=.*$/${token_name}=$(escape_sed "${token}")/" | sed -i.bak -f - "${file}"
+    else
+        echo "${token_name}=${token}" > "${file}"
     fi
 }
 


### PR DESCRIPTION
Install script should behave the same like we document manual steps for systemd installation