### PR TITLE
fix: decrease display-workflow-run-url-interval

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -403,6 +403,7 @@ jobs:
           ref: main
           wait-for-completion: false
           display-workflow-run-url: true
+          display-workflow-run-url-interval: 1s
           inputs: |-
             {
               "workflow_id": "${{ github.run_id }}",


### PR DESCRIPTION
The `display-workflow-run-url-interval` is the interval between API calls to attempt to determine a remotely triggered Workflow Run ID. As the packaging workflow requires the Dev Build workflow to be complete I changed the interval to 1 second from the default of 1 minute. This is a short enough time but if we start to run into issues then we'll need to add a job step to the packaging workflow that waits for the completion of the corresponding Dev Build workflow.