### PR TITLE
feat(sumologicexporter): use otlp url suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - forwardconnector
   - countconnector
 
+- feat(sumologicexporter): use otlp url suffixes [#1015]
+
 [#969]: https://github.com/SumoLogic/sumologic-otel-collector/pull/969
 [#975]: https://github.com/SumoLogic/sumologic-otel-collector/pull/975
 [#980]: https://github.com/SumoLogic/sumologic-otel-collector/pull/980
@@ -43,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1011]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1011
 [#1013]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1013
 [#1016]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1016
+[#1015]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1015
 [unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.71.0-sumo-0...main
 
 ## [v0.71.0-sumo-0]

--- a/pkg/exporter/sumologicexporter/sender.go
+++ b/pkg/exporter/sumologicexporter/sender.go
@@ -324,19 +324,16 @@ func (s *sender) handleReceiverResponse(resp *http.Response) error {
 
 func (s *sender) createRequest(ctx context.Context, pipeline PipelineType, data io.Reader) (*http.Request, error) {
 	var url string
-	if s.config.HTTPClientSettings.Endpoint == "" {
-		switch pipeline {
-		case MetricsPipeline:
-			url = s.dataUrlMetrics
-		case LogsPipeline:
-			url = s.dataUrlLogs
-		case TracesPipeline:
-			url = s.dataUrlTraces
-		default:
-			return nil, fmt.Errorf("unknown pipeline type: %s", pipeline)
-		}
-	} else {
-		url = s.config.HTTPClientSettings.Endpoint
+
+	switch pipeline {
+	case MetricsPipeline:
+		url = s.dataUrlMetrics
+	case LogsPipeline:
+		url = s.dataUrlLogs
+	case TracesPipeline:
+		url = s.dataUrlTraces
+	default:
+		return nil, fmt.Errorf("unknown pipeline type: %s", pipeline)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, data)

--- a/pkg/exporter/sumologicexporter/sender_test.go
+++ b/pkg/exporter/sumologicexporter/sender_test.go
@@ -97,9 +97,9 @@ func prepareSenderTest(t *testing.T, cb []func(w http.ResponseWriter, req *http.
 			},
 			&c,
 			pf,
-			"",
-			"",
-			"",
+			testServer.URL,
+			testServer.URL,
+			testServer.URL,
 			component.ID{},
 		),
 	}
@@ -928,7 +928,7 @@ func TestLogsHandlesReceiverResponses(t *testing.T) {
 func TestInvalidEndpoint(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){})
 
-	test.s.config.HTTPClientSettings.Endpoint = ":"
+	test.s.dataUrlLogs = ":"
 
 	rls := plog.NewResourceLogs()
 	rls.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("Example log")
@@ -940,7 +940,7 @@ func TestInvalidEndpoint(t *testing.T) {
 func TestInvalidPostRequest(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){})
 
-	test.s.config.HTTPClientSettings.Endpoint = ""
+	test.s.dataUrlLogs = ""
 	rls := plog.NewResourceLogs()
 	rls.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("Example log")
 
@@ -961,7 +961,7 @@ func TestInvalidPipeline(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){})
 
 	err := test.s.send(context.Background(), "invalidPipeline", newCountingReader(0).withString(""), fields{})
-	assert.EqualError(t, err, `unexpected pipeline: invalidPipeline`)
+	assert.EqualError(t, err, `unknown pipeline type: invalidPipeline`)
 }
 
 func TestSendCompressGzip(t *testing.T) {


### PR DESCRIPTION
If the format is otlp, sumologic expoter should behave the same way as otlphttp exporter when it comes to
adding the per-signal url suffixes.