### PR TITLE
fix(sumologicexporter): fix links to upgrade docs

### DIFF
--- a/pkg/exporter/sumologicexporter/config.go
+++ b/pkg/exporter/sumologicexporter/config.go
@@ -114,26 +114,26 @@ func CreateDefaultHTTPClientSettings() confighttp.HTTPClientSettings {
 func (cfg *Config) Validate() error {
 
 	if len(cfg.MetadataAttributes) > 0 {
-		return fmt.Errorf(`metadata_attributes is not supported anymore.
-Please consult the changelog at https://github.com/SumoLogic/sumologic-otel-collector/releases/tag/v0.49.0-sumo-0`,
+		return fmt.Errorf(`the property metadata_attributes was removed in v0.49.0-sumo-0.
+See upgrade guide at https://github.com/SumoLogic/sumologic-otel-collector/blob/main/docs/upgrading.md#sumo-logic-exporter-metadata-handling`,
 		)
 	}
 
 	if cfg.TranslateTelegrafMetrics {
-		return fmt.Errorf(`translate_telegraf_attributes is not supported anymore.
-Please consult the changelog at https://github.com/SumoLogic/sumologic-otel-collector/releases/tag/v0.59.0-sumo-0`,
+		return fmt.Errorf(`the property translate_telegraf_attributes was removed in v0.66.0-sumo-0.
+See upgrade guide at https://github.com/SumoLogic/sumologic-otel-collector/blob/main/docs/upgrading.md#sumologic-exporter-drop-support-for-translating-telegraf-metric-names`,
 		)
 	}
 
 	if cfg.TranslateAttributes {
-		return fmt.Errorf(`translate_attributes is not supported anymore.
-Please consult the changelog at https://github.com/SumoLogic/sumologic-otel-collector/releases/tag/v0.59.0-sumo-0`,
+		return fmt.Errorf(`the property translate_attributes was removed in v0.66.0-sumo-0.
+See upgrade guide at https://github.com/SumoLogic/sumologic-otel-collector/blob/main/docs/upgrading.md#sumologic-exporter-drop-support-for-translating-attributes`,
 		)
 	}
 
 	if cfg.SourceCategory != "" || cfg.SourceHost != "" || cfg.SourceName != "" {
-		return fmt.Errorf(`setting source headers is not supported anymore.
-Please consult the changelog at https://github.com/SumoLogic/sumologic-otel-collector/releases/tag/v0.60.0-sumo-0`,
+		return fmt.Errorf(`the properties source_category, source_host, source_name was removed in v0.66.0-sumo-0.
+See upgrade guide at https://github.com/SumoLogic/sumologic-otel-collector/blob/main/docs/upgrading.md#sumologic-exporter-drop-support-for-source-headers`,
 		)
 	}
 

--- a/pkg/exporter/sumologicexporter/config_test.go
+++ b/pkg/exporter/sumologicexporter/config_test.go
@@ -111,8 +111,8 @@ func TestInitExporterInvalidConfiguration(t *testing.T) {
 		},
 		{
 			name: "deprecated metadata_attributes",
-			expectedError: errors.New(`metadata_attributes is not supported anymore.
-Please consult the changelog at https://github.com/SumoLogic/sumologic-otel-collector/releases/tag/v0.49.0-sumo-0`,
+			expectedError: errors.New(`the property metadata_attributes was removed in v0.49.0-sumo-0.
+See upgrade guide at https://github.com/SumoLogic/sumologic-otel-collector/blob/main/docs/upgrading.md#sumo-logic-exporter-metadata-handling`,
 			),
 			cfg: &Config{
 				MetadataAttributes: []string{"some_attribute"},


### PR DESCRIPTION
We were trying to be helpful by helping the user migrate off unsupported properties, but links that point to nowhere do not help much.
This changes the links to point straight to the upgrade docs instead of release notes.
I also point to the `main` branch of the upgrade docs, because there have been, and there might be more, changes/improvements to these docs.