### PR TITLE
fix(install-script): clears curl cache before attempting download to prevent installation errors

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1092,7 +1092,8 @@ function get_binary_from_url() {
     if [ "${KEEP_DOWNLOADS}" == "true" ]; then
         curl_args+=("-z" "${download_path}")
     fi
-    curl "${curl_args[@]}" "${url}"
+    # ensures curl cache is cleared before attempting download
+    rm -f "${download_path}" && curl "${curl_args[@]}" "${url}"
 
     cp -f "${download_path}" "${TMPDIR}"/otelcol-sumo
 


### PR DESCRIPTION
fix(install-script): clears curl cache before attempting download to prevent installation errors