### PR TITLE
feat: enable `extension.sumologic.updateCollectorMetadata` feature gate by default

### DIFF
--- a/otelcolbuilder/cmd/configprovider.go
+++ b/otelcolbuilder/cmd/configprovider.go
@@ -17,6 +17,7 @@ package main
 import (
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"os"
 
@@ -26,6 +27,7 @@ import (
 	"go.opentelemetry.io/collector/confmap/provider/envprovider"
 	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
 	"go.opentelemetry.io/collector/confmap/provider/yamlprovider"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/otelcol"
 )
 
@@ -34,7 +36,12 @@ import (
 // https://github.com/open-telemetry/opentelemetry-collector/blob/65dfc325d974be8ebb7c170b90c6646f9eaef27b/service/command.go#L38
 
 func UseCustomConfigProvider(params *otelcol.CollectorSettings) error {
-	var err error
+	// feature flags, which are enabled by default in our distro
+	err := featuregate.GlobalRegistry().Set("extension.sumologic.updateCollectorMetadata", true)
+
+	if err != nil {
+		return fmt.Errorf("setting feature gate flags failed: %s", err)
+	}
 	// to create the provider, we need config locations passed in via the command line
 	// to get these, we take the command the service uses to start, parse the flags, and read the values
 	flagset := flags()


### PR DESCRIPTION
This feature is nowhere to be found in the documentation, so I omitted adding any additional documentation steps to not cause confusion.