### PR TITLE
Added install host metrics to windows powershell install script

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -13,7 +13,10 @@ param (
     # Tags is used to specify a list of tags for the collector. Specified via a
     # hash table.
     # e.g. -Tags @{ tag1 = "foo" ; tag2 = "bar" }
-    [Hashtable] $Tags
+    [Hashtable] $Tags,
+
+    # InstallHostMetrics is used to install host metric collection.
+    [bool] $InstallHostMetrics
 )
 
 ##
@@ -456,6 +459,9 @@ try {
         })
         $tagsProperty = $tagStrs -Join ","
         $msiProperties += "TAGS=`"${tagsProperty}`""
+    }
+    if ($InstallHostMetrics -eq $true) {
+        $msiProperties += "HOSTMETRICS=1"
     }
     msiexec.exe /i "$msiPath" /passive $msiProperties
 } catch [HttpRequestException] {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -451,6 +451,7 @@ try {
 
     # Install MSI
     [string[]] $msiProperties = @()
+    [string[]] $msiAddLocal = @()
     $msiProperties += "INSTALLATIONTOKEN=${InstallationToken}"
     if ($Tags.Count -gt 0) {
         [string[]] $tagStrs = @()
@@ -461,7 +462,11 @@ try {
         $msiProperties += "TAGS=`"${tagsProperty}`""
     }
     if ($InstallHostMetrics -eq $true) {
-        $msiProperties += "HOSTMETRICS=1"
+        $msiAddLocal += "HOSTMETRICS"
+    }
+    if ($msiAddLocal.Count -gt 0) {
+        $addLocalStr = $msiAddLocal -Join ","
+        $msiProperties += "ADDLOCAL=${addLocalStr}"
     }
     msiexec.exe /i "$msiPath" /passive $msiProperties
 } catch [HttpRequestException] {


### PR DESCRIPTION
This pull-request add the `-InstallHostMetrics $True` installation flag to install host metrics collection.

For example:

```
Set-ExecutionPolicy RemoteSigned -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; $uri = "https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector/main/scripts/install.ps1"; $path="${env:TEMP}\install.ps1"; (New-Object System.Net.WebClient).DownloadFile($uri, $path); . $path -InstallationToken replace-me -Tags @{tag1 = "foo"; tag2 = "bar"} -InstallHostMetrics $True
```

Related to: https://github.com/SumoLogic/sumologic-otel-collector/pull/1034
