### PR TITLE
docs: change `logLevel` to `loglevel` for Logging exporter

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -106,7 +106,7 @@ receivers:
     protocol: rfc5424
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
 service:
   pipelines:
     logs:
@@ -188,7 +188,7 @@ exporters:
     ## Set Source Host to client hostname
     source_host: "%{net.peer.name}"
   logging:
-    loglevel: debug
+    verbosity: detailed
 service:
   extensions: [sumologic]
   pipelines:

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -106,7 +106,7 @@ receivers:
     protocol: rfc5424
 exporters:
   logging:
-    logLevel: debug
+    loglevel: debug
 service:
   pipelines:
     logs:
@@ -188,7 +188,7 @@ exporters:
     ## Set Source Host to client hostname
     source_host: "%{net.peer.name}"
   logging:
-    logLevel: debug
+    loglevel: debug
 service:
   extensions: [sumologic]
   pipelines:

--- a/examples/config_logging.yaml
+++ b/examples/config_logging.yaml
@@ -6,7 +6,7 @@ receivers:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
 
 service:
   pipelines:

--- a/examples/config_logging.yaml
+++ b/examples/config_logging.yaml
@@ -6,7 +6,7 @@ receivers:
 
 exporters:
   logging:
-    logLevel: debug
+    loglevel: debug
 
 service:
   pipelines:

--- a/examples/logs_json/config.yaml
+++ b/examples/logs_json/config.yaml
@@ -1,6 +1,6 @@
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
     sampling_initial: 0
     sampling_thereafter: 1
 receivers:

--- a/pkg/extension/sumologicextension/testdata/config.yaml
+++ b/pkg/extension/sumologicextension/testdata/config.yaml
@@ -17,7 +17,7 @@ processors:
 
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
 
 service:
   extensions: [sumologic]


### PR DESCRIPTION
`logLevel` only worked due to a bug in the upstream that was "fixed" in v0.71.0, breaking many configurations.