### PR TITLE
[syslogexporter] set defaults for sending_queue and retry_on_failure and fix errors reported by golangci-lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,12 @@ See the [upgrade guide][upgrade_guide_v0.74] for more details.
 ### Fixed
 
 - fix(scripts/install.ps1): treat app as not installed if otelcol-sumo.exe is missing [#1061]
+- fix(syslogexporter): set default settings for sending_queue and retry_on_failure [#1056]
 
 [#1058]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1058
 [#1055]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1055
 [#1061]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1061
+[#1056]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1056
 [upgrade_guide_v0.74]: ./docs/upgrading.md#upgrading-to-v0660-sumo-0
 [unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.73.0-sumo-0...main
 

--- a/pkg/exporter/syslogexporter/config.go
+++ b/pkg/exporter/syslogexporter/config.go
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	unsupportedPort     = errors.New("unsupported port: port is required, must be in the range 1-65535")
-	invalidEndpoint     = errors.New("invalid endpoint: endpoint is required, must be a valid FQDN or IP address")
-	unsupportedProtocol = errors.New("unsupported protocol: protocol is required, only tcp/udp supported")
-	unsupportedFormat   = errors.New("unsupported format: Only rfc5424 and rfc3164 supported")
+	errUnsupportedPort     = errors.New("unsupported port: port is required, must be in the range 1-65535")
+	errInvalidEndpoint     = errors.New("invalid endpoint: endpoint is required, must be a valid FQDN or IP address")
+	errUnsupportedProtocol = errors.New("unsupported protocol: protocol is required, only tcp/udp supported")
+	errUnsupportedFormat   = errors.New("unsupported format: Only rfc5424 and rfc3164 supported")
 )
 
 // Config defines configuration for Syslog exporter.
@@ -54,22 +54,22 @@ type Config struct {
 func (cfg *Config) Validate() error {
 	invalidFields := []error{}
 	if cfg.Port < 1 || cfg.Port > 65525 {
-		invalidFields = append(invalidFields, unsupportedPort)
+		invalidFields = append(invalidFields, errUnsupportedPort)
 	}
 
 	if !net.IsFQDN(cfg.Endpoint) && !net.IsIPAddr(cfg.Endpoint) && cfg.Endpoint != "localhost" {
-		invalidFields = append(invalidFields, invalidEndpoint)
+		invalidFields = append(invalidFields, errInvalidEndpoint)
 	}
 
 	if strings.ToLower(cfg.Protocol) != "tcp" && strings.ToLower(cfg.Protocol) != "udp" {
-		invalidFields = append(invalidFields, unsupportedProtocol)
+		invalidFields = append(invalidFields, errUnsupportedProtocol)
 	}
 
 	switch cfg.Format {
 	case formatRFC3164Str:
 	case formatRFC5424Str:
 	default:
-		invalidFields = append(invalidFields, unsupportedFormat)
+		invalidFields = append(invalidFields, errUnsupportedFormat)
 	}
 
 	if len(invalidFields) > 0 {

--- a/pkg/exporter/syslogexporter/exporter.go
+++ b/pkg/exporter/syslogexporter/exporter.go
@@ -99,7 +99,7 @@ func (se *syslogexporter) pushLogsData(ctx context.Context, ld plog.Logs) error 
 	rls := ld.ResourceLogs()
 	for i := 0; i < rls.Len(); i++ {
 		rl := rls.At(i)
-		if droppedRecords, err := se.sendSyslogs(ctx, rl); err != nil {
+		if droppedRecords, err := se.sendSyslogs(rl); err != nil {
 			dropped = append(dropped, droppedResourceRecords{
 				resource: rl.Resource(),
 				records:  droppedRecords,
@@ -124,7 +124,7 @@ func (se *syslogexporter) pushLogsData(ctx context.Context, ld plog.Logs) error 
 	return nil
 }
 
-func (se *syslogexporter) sendSyslogs(ctx context.Context, rl plog.ResourceLogs) ([]plog.LogRecord, error) {
+func (se *syslogexporter) sendSyslogs(rl plog.ResourceLogs) ([]plog.LogRecord, error) {
 	var (
 		errs           []error
 		droppedRecords []plog.LogRecord

--- a/pkg/exporter/syslogexporter/exporter_test.go
+++ b/pkg/exporter/syslogexporter/exporter_test.go
@@ -16,6 +16,7 @@ package syslogexporter
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"strconv"
@@ -174,7 +175,10 @@ func TestSyslogExportFail(t *testing.T) {
 	buffer := exampleLog(t)
 	logs := LogRecordsToLogs(buffer)
 	consumerErr := test.exp.pushLogsData(context.Background(), logs)
-	consumerLogs := consumererror.Logs.Data(consumerErr.(consumererror.Logs))
+	var consumerErrorLogs consumererror.Logs
+	ok := errors.As(consumerErr, &consumerErrorLogs)
+	assert.Equal(t, ok, true)
+	consumerLogs := consumererror.Logs.Data(consumerErrorLogs)
 	rls := consumerLogs.ResourceLogs()
 	require.Equal(t, 1, rls.Len())
 	scl := rls.At(0).ScopeLogs()

--- a/pkg/exporter/syslogexporter/factory.go
+++ b/pkg/exporter/syslogexporter/factory.go
@@ -43,10 +43,12 @@ func createDefaultConfig() component.Config {
 	qs.Enabled = false
 
 	return &Config{
-		Endpoint: DefaultEndpoint,
-		Port:     DefaultPort,
-		Format:   DefaultFormat,
-		Protocol: DefaultProtocol,
+		Endpoint:      DefaultEndpoint,
+		Port:          DefaultPort,
+		Format:        DefaultFormat,
+		Protocol:      DefaultProtocol,
+		RetrySettings: exporterhelper.NewDefaultRetrySettings(),
+		QueueSettings: qs,
 	}
 }
 

--- a/pkg/exporter/syslogexporter/go.mod
+++ b/pkg/exporter/syslogexporter/go.mod
@@ -19,7 +19,7 @@ require (
 
 require (
 	github.com/THREATINT/go-net v1.2.23
-	github.com/cenkalti/backoff/v4 v4.2.0 // indirect
+	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/pkg/exporter/syslogexporter/syslog.go
+++ b/pkg/exporter/syslogexporter/syslog.go
@@ -38,7 +38,7 @@ const version = "version"
 const hostname = "hostname"
 const app = "appname"
 const pid = "proc_id"
-const msgId = "msg_id"
+const msgID = "msg_id"
 const structuredData = "structured_data"
 const message = "message"
 
@@ -189,9 +189,9 @@ func (s *Syslog) formatRFC3164(msg map[string]any, timestamp time.Time) string {
 }
 
 func (s *Syslog) formatRFC5424(msg map[string]any, timestamp time.Time) string {
-	msgProperties := []string{priority, version, hostname, app, pid, msgId, message, structuredData}
+	msgProperties := []string{priority, version, hostname, app, pid, msgID, message, structuredData}
 	populateDefaults(msg, msgProperties)
 	s.addStructuredData(msg)
 	timestampString := timestamp.Format(time.RFC3339)
-	return fmt.Sprintf("<%d>%d %s %s %s %s %s %s %s", msg[priority], msg[version], timestampString, msg[hostname], msg[app], msg[pid], msg[msgId], msg[structuredData], msg[message])
+	return fmt.Sprintf("<%d>%d %s %s %s %s %s %s %s", msg[priority], msg[version], timestampString, msg[hostname], msg[app], msg[pid], msg[msgID], msg[structuredData], msg[message])
 }

--- a/pkg/exporter/syslogexporter/utils.go
+++ b/pkg/exporter/syslogexporter/utils.go
@@ -35,7 +35,7 @@ func deduplicateErrors(errs []error) []error {
 		for i := range errorsWithCounts {
 			if errorsWithCounts[i].err.Error() == err.Error() {
 				found = true
-				errorsWithCounts[i].count += 1
+				errorsWithCounts[i].count++
 				break
 			}
 		}
@@ -51,7 +51,7 @@ func deduplicateErrors(errs []error) []error {
 		if errorWithCount.count == 1 {
 			uniqueErrors = append(uniqueErrors, errorWithCount.err)
 		} else {
-			uniqueErrors = append(uniqueErrors, fmt.Errorf("%s (x%d)", errorWithCount.err, errorWithCount.count))
+			uniqueErrors = append(uniqueErrors, fmt.Errorf("%w (x%d)", errorWithCount.err, errorWithCount.count))
 		}
 	}
 	return uniqueErrors

--- a/pkg/exporter/syslogexporter/utils_test.go
+++ b/pkg/exporter/syslogexporter/utils_test.go
@@ -16,6 +16,7 @@ package syslogexporter
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,8 +55,8 @@ func TestDeduplicateErrors(t *testing.T) {
 				errors.New("failed sending data: 502 Bad Gateway"),
 			},
 			expected: []error{
-				errors.New("failed sending data: 502 Bad Gateway (x3)"),
-				errors.New("dial tcp 127.0.0.1:514: connect: connection refused (x4)"),
+				fmt.Errorf("%w (x3)", errors.New("failed sending data: 502 Bad Gateway")),
+				fmt.Errorf("%w (x4)", errors.New("dial tcp 127.0.0.1:514: connect: connection refused")),
 				errors.New("failed sending data: 504 Gateway Timeout"),
 			},
 		},
@@ -80,8 +81,8 @@ func TestErrorString(t *testing.T) {
 				errors.New("failed sending data: 502 Bad Gateway"),
 				errors.New("dial tcp 127.0.0.1:514: connect: connection refused"),
 			},
-			expected: []string([]string{"failed sending data: 502 Bad Gateway",
-				"dial tcp 127.0.0.1:514: connect: connection refused"}),
+			expected: []string{"failed sending data: 502 Bad Gateway",
+				"dial tcp 127.0.0.1:514: connect: connection refused"},
 		},
 	}
 


### PR DESCRIPTION
Summary of changes:

-   fix(syslogexporter): set default settings for sending_queue and retry_on_failure
    default setting are now set to defaults in exporterhelper,
    one expection - sending queue is enabled by default in syslog exporter
    
-   chore(syslogexporter): fix errors reported by golangci-lint in opentelemetry-collector-contrib repository
    
List of reported errors:
```
/Users/kkujawa/git/opentelemetry-collector-contrib/.tools/golangci-lint run --allow-parallel-runners --build-tags integration
utils.go:38:5: increment-decrement: should replace errorsWithCounts[i].count += 1 with errorsWithCounts[i].count++ (revive)
                                errorsWithCounts[i].count += 1
                                ^
config.go:28:2: error-naming: error var unsupportedPort should have name of the form errFoo (revive)
        unsupportedPort     = errors.New("unsupported port: port is required, must be in the range 1-65535")
        ^
config.go:29:2: error-naming: error var invalidEndpoint should have name of the form errFoo (revive)
        invalidEndpoint     = errors.New("invalid endpoint: endpoint is required, must be a valid FQDN or IP address")
        ^
config.go:30:2: error-naming: error var unsupportedProtocol should have name of the form errFoo (revive)
        unsupportedProtocol = errors.New("unsupported protocol: protocol is required, only tcp/udp supported")
        ^
config.go:31:2: error-naming: error var unsupportedFormat should have name of the form errFoo (revive)
        unsupportedFormat   = errors.New("unsupported format: Only rfc5424 and rfc3164 supported")
        ^
syslog.go:41:7: var-naming: const msgId should be msgID (revive)
const msgId = "msg_id"
      ^
utils_test.go:83:22: unnecessary conversion (unconvert)
                        expected: []string([]string{"failed sending data: 502 Bad Gateway",
                                          ^
exporter.go:127:39: `(*syslogexporter).sendSyslogs` - `ctx` is unused (unparam)
func (se *syslogexporter) sendSyslogs(ctx context.Context, rl plog.ResourceLogs) ([]plog.LogRecord, error) {
                                      ^
utils.go:54:63: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
                        uniqueErrors = append(uniqueErrors, fmt.Errorf("%s (x%d)", errorWithCount.err, errorWithCount.count))
                                                                                   ^
exporter_test.go:177:42: type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors (errorlint)
        consumerLogs := consumererror.Logs.Data(consumerErr.(consumererror.Logs))
                                                ^
factory.go:43:5: unusedwrite: unused write to field Enabled (govet)
        qs.Enabled = false
           ^
factory_test.go:35:5: unusedwrite: unused write to field Enabled (govet)
        qs.Enabled = false
           ^
make: *** [lint] Error 1
```