### PR TITLE
fix(sumologicextension)!: use fqdn before os.Hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Released TBA
 
+This release introduces the following breaking changes:
+
+- fix(sumologicextension)!: use fqdn before os.Hostname
+
+See the [upgrade guide][upgrade_guide_v0.74] for more details.
+
 ### Added
 
 - feat!(sumologicschemaprocessor): add translating docker stats metric names [#1055]
@@ -24,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1058]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1058
 [#1055]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1055
 [#1061]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1061
-
+[upgrade_guide_v0.74]: ./docs/upgrading.md#upgrading-to-v0660-sumo-0
 [unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.73.0-sumo-0...main
 
 ## [v0.73.0-sumo-0]

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -25,6 +25,22 @@
     - [Removing unnecessary metadata using the resourceprocessor](#removing-unnecessary-metadata-using-the-resourceprocessor)
     - [Moving record-level attributes used for metadata to the resource level](#moving-record-level-attributes-used-for-metadata-to-the-resource-level)
 
+## Upgrading to Unreleased
+
+### The default collector name for sumologic extension is now the host FQDN
+
+In an effort to make defaults consistent between [resource detection] processor and the Sumo extension,
+we've changed the default collector name and the host name it reports in its metadata to be the host
+FQDN instead of the hostname reported by the OS. This makes the value consistent with the value of the
+`host.name` attribute [resource detection] processor sets by default.
+
+This will only affect newly registered collectors. If you have local credentials on your host, the
+existing collector will be used, but if those credentials are cleared, a new collector will be created
+with a different name. If you'd like to keep using the old name, set `CollectorName` explicitly in the
+extension settings.
+
+[resource detection]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
+
 ## Upgrading to v0.66.0-sumo-0
 
 ### `filelog` receiver: has been removed from sub-parsers

--- a/pkg/exporter/sumologicexporter/go.mod
+++ b/pkg/exporter/sumologicexporter/go.mod
@@ -18,6 +18,7 @@ require (
 )
 
 require (
+	github.com/Showmax/go-fqdn v1.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect

--- a/pkg/exporter/sumologicexporter/go.sum
+++ b/pkg/exporter/sumologicexporter/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 contrib.go.opencensus.io/exporter/prometheus v0.4.2 h1:sqfsYl5GIY/L570iT+l93ehxaWJs2/OwXtiWwew3oAg=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Showmax/go-fqdn v1.0.0 h1:0rG5IbmVliNT5O19Mfuvna9LL7zlHyRfsSvBPZmF9tM=
+github.com/Showmax/go-fqdn v1.0.0/go.mod h1:SfrFBzmDCtCGrnHhoDjuvFnKsWjEQX/Q9ARZvOrJAko=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/pkg/extension/opampextension/go.mod
+++ b/pkg/extension/opampextension/go.mod
@@ -15,6 +15,7 @@ require (
 )
 
 require (
+	github.com/Showmax/go-fqdn v1.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect

--- a/pkg/extension/opampextension/go.sum
+++ b/pkg/extension/opampextension/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Showmax/go-fqdn v1.0.0 h1:0rG5IbmVliNT5O19Mfuvna9LL7zlHyRfsSvBPZmF9tM=
+github.com/Showmax/go-fqdn v1.0.0/go.mod h1:SfrFBzmDCtCGrnHhoDjuvFnKsWjEQX/Q9ARZvOrJAko=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/pkg/extension/sumologicextension/extension_test.go
+++ b/pkg/extension/sumologicextension/extension_test.go
@@ -519,7 +519,7 @@ func TestLocalFSCredentialsStore_WorkCorrectlyForMultipleExtensions(t *testing.T
 func TestRegisterEmptyCollectorName(t *testing.T) {
 	t.Parallel()
 
-	hostname, err := os.Hostname()
+	hostname, err := getHostname(zap.NewNop())
 	require.NoError(t, err)
 	srv := httptest.NewServer(func() http.HandlerFunc {
 		var reqCount int32
@@ -587,7 +587,7 @@ func TestRegisterEmptyCollectorName(t *testing.T) {
 func TestRegisterEmptyCollectorNameForceRegistration(t *testing.T) {
 	t.Parallel()
 
-	hostname, err := os.Hostname()
+	hostname, err := getHostname(zap.NewNop())
 	require.NoError(t, err)
 	srv := httptest.NewServer(func() http.HandlerFunc {
 		var reqCount int32
@@ -924,7 +924,7 @@ func TestRegisterEmptyCollectorNameWithBackoff(t *testing.T) {
 	var retriesLimit int32 = 5
 	t.Parallel()
 
-	hostname, err := os.Hostname()
+	hostname, err := getHostname(zap.NewNop())
 	require.NoError(t, err)
 	srv := httptest.NewServer(func() http.HandlerFunc {
 		var reqCount int32
@@ -998,7 +998,7 @@ func TestRegisterEmptyCollectorNameWithBackoff(t *testing.T) {
 func TestRegisterEmptyCollectorNameUnrecoverableError(t *testing.T) {
 	t.Parallel()
 
-	hostname, err := os.Hostname()
+	hostname, err := getHostname(zap.NewNop())
 	require.NoError(t, err)
 	srv := httptest.NewServer(func() http.HandlerFunc {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -1277,7 +1277,7 @@ func TestCollectorReregistersAfterHTTPUnathorizedFromHeartbeat(t *testing.T) {
 func TestRegistrationRequestPayload(t *testing.T) {
 	t.Parallel()
 
-	hostname, err := os.Hostname()
+	hostname, err := getHostname(zap.NewNop())
 	require.NoError(t, err)
 	var reqCount int32
 	srv := httptest.NewServer(func() http.HandlerFunc {

--- a/pkg/extension/sumologicextension/go.mod
+++ b/pkg/extension/sumologicextension/go.mod
@@ -3,6 +3,7 @@ module github.com/SumoLogic/sumologic-otel-collector/pkg/extension/sumologicexte
 go 1.19
 
 require (
+	github.com/Showmax/go-fqdn v1.0.0
 	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mitchellh/go-ps v1.0.0

--- a/pkg/extension/sumologicextension/go.sum
+++ b/pkg/extension/sumologicextension/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Showmax/go-fqdn v1.0.0 h1:0rG5IbmVliNT5O19Mfuvna9LL7zlHyRfsSvBPZmF9tM=
+github.com/Showmax/go-fqdn v1.0.0/go.mod h1:SfrFBzmDCtCGrnHhoDjuvFnKsWjEQX/Q9ARZvOrJAko=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=


### PR DESCRIPTION
Use FQDN before hostname for the default collector name and metadata. The value is taken from the `go-fqdn` package, which is also what resource detection processor does.