### PR TITLE
fix(scripts/install.ps1): treat app as not installed if otelcol-sumo.exe is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - fix: fix carbon2 parser for telegrafreceiver [#1058]
 
+### Fixed
+
+- fix(scripts/install.ps1): treat app as not installed if otelcol-sumo.exe is missing [#1061]
+
 [#1058]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1058
 [#1055]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1055
+[#1061]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1061
 
 [unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.73.0-sumo-0...main
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -163,6 +163,12 @@ function Get-InstalledVersion {
 
     $installLocation = $product.InstallLocation
     $binPath = "${installLocation}bin\otelcol-sumo.exe"
+
+    if (!(Test-Path -Path $binPath -PathType Leaf)) {
+        Write-Warning "Sumo Logic OpenTelemtry Collector is installed but otelcol-sumo.exe could not be found. Continuing as if it were not installed."
+        return
+    }
+
     $version = . $binPath --version | Out-String
 
     $versionRegex = '(\d)\.(\d+)\.(\d+)(.*(\d+))'


### PR DESCRIPTION
If the Sumo Logic OpenTelemtry Collector is installed and the `otelcol-sumo.exe` binary does not exist then the `install.ps1` script will currently throw an error and not execute. This change will show a warning and continue as if no installation was detected.

<img width="892" alt="Screenshot 2023-03-10 at 14 55 07" src="https://user-images.githubusercontent.com/120659/224443398-91e42854-547c-43fc-bfca-5a01f2e0466f.png">
