### PR TITLE
docs(syslogexporter) change stability level in README.md

### DIFF
--- a/pkg/exporter/syslogexporter/README.md
+++ b/pkg/exporter/syslogexporter/README.md
@@ -1,6 +1,6 @@
 # Syslog Exporter
 
-**Stability level**: Experimental
+**Stability level**: Alpha
 
 ## About The Exporter
 


### PR DESCRIPTION
Stability level is set to alpha in the code: https://github.com/SumoLogic/sumologic-otel-collector/blob/69be5da95556afbbf50c2265d698c7b116e5cc19/pkg/exporter/syslogexporter/factory.go#L29