### PR TITLE
fix(sumologicexporter): Prometheus histogram metric names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Released TBA
 
+### Added
+
 - feat(sumologicschemaprocessor): add translating docker stats resource attributes [#1081]
 
+### Fixed
+
+- fix(sumologicexporter): Prometheus histogram metric names [#1087]
+
 [#1081]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1081
+[#1087]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1087
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.73.0-sumo-1...main
 
 ## [v0.73.0-sumo-1]

--- a/pkg/exporter/sumologicexporter/prometheus_formatter.go
+++ b/pkg/exporter/sumologicexporter/prometheus_formatter.go
@@ -244,6 +244,11 @@ func (f *prometheusFormatter) countMetric(name string) string {
 	return fmt.Sprintf("%s_count", name)
 }
 
+// bucketMetric returns _bucket suffixed metric name
+func (f *prometheusFormatter) bucketMetric(name string) string {
+	return fmt.Sprintf("%s_bucket", name)
+}
+
 // mergeAttributes gets two pcommon.Maps and returns new which contains values from both of them
 func (f *prometheusFormatter) mergeAttributes(attributes pcommon.Map, additionalAttributes pcommon.Map) pcommon.Map {
 	mergedAttributes := pcommon.NewMap()
@@ -358,7 +363,7 @@ func (f *prometheusFormatter) histogram2Strings(metric pmetric.Metric, attribute
 			additionalAttributes.PutDouble(prometheusLeTag, bound)
 
 			line := f.uintValueLine(
-				metric.Name(),
+				f.bucketMetric(metric.Name()),
 				cumulative,
 				dp,
 				f.mergeAttributes(attributes, additionalAttributes),
@@ -369,7 +374,7 @@ func (f *prometheusFormatter) histogram2Strings(metric pmetric.Metric, attribute
 		cumulative += dp.BucketCounts().At(explicitBounds.Len())
 		additionalAttributes.PutStr(prometheusLeTag, prometheusInfValue)
 		line := f.uintValueLine(
-			metric.Name(),
+			f.bucketMetric(metric.Name()),
 			cumulative,
 			dp,
 			f.mergeAttributes(attributes, additionalAttributes),

--- a/pkg/exporter/sumologicexporter/prometheus_formatter_test.go
+++ b/pkg/exporter/sumologicexporter/prometheus_formatter_test.go
@@ -138,20 +138,20 @@ func TestPrometheusMetricDataTypeHistogram(t *testing.T) {
 	metric, attributes := exampleHistogramMetric()
 
 	result := f.metric2String(metric, attributes)
-	expected := `histogram_metric_double_test{bar="foo",le="0.1",container="dolor",branch="sumologic"} 0 1618124444169
-histogram_metric_double_test{bar="foo",le="0.2",container="dolor",branch="sumologic"} 12 1618124444169
-histogram_metric_double_test{bar="foo",le="0.5",container="dolor",branch="sumologic"} 19 1618124444169
-histogram_metric_double_test{bar="foo",le="0.8",container="dolor",branch="sumologic"} 24 1618124444169
-histogram_metric_double_test{bar="foo",le="1",container="dolor",branch="sumologic"} 32 1618124444169
-histogram_metric_double_test{bar="foo",le="+Inf",container="dolor",branch="sumologic"} 45 1618124444169
+	expected := `histogram_metric_double_test_bucket{bar="foo",le="0.1",container="dolor",branch="sumologic"} 0 1618124444169
+histogram_metric_double_test_bucket{bar="foo",le="0.2",container="dolor",branch="sumologic"} 12 1618124444169
+histogram_metric_double_test_bucket{bar="foo",le="0.5",container="dolor",branch="sumologic"} 19 1618124444169
+histogram_metric_double_test_bucket{bar="foo",le="0.8",container="dolor",branch="sumologic"} 24 1618124444169
+histogram_metric_double_test_bucket{bar="foo",le="1",container="dolor",branch="sumologic"} 32 1618124444169
+histogram_metric_double_test_bucket{bar="foo",le="+Inf",container="dolor",branch="sumologic"} 45 1618124444169
 histogram_metric_double_test_sum{bar="foo",container="dolor",branch="sumologic"} 45.6 1618124444169
 histogram_metric_double_test_count{bar="foo",container="dolor",branch="sumologic"} 7 1618124444169
-histogram_metric_double_test{bar="foo",le="0.1",container="sit",branch="main"} 0 1608424699186
-histogram_metric_double_test{bar="foo",le="0.2",container="sit",branch="main"} 10 1608424699186
-histogram_metric_double_test{bar="foo",le="0.5",container="sit",branch="main"} 11 1608424699186
-histogram_metric_double_test{bar="foo",le="0.8",container="sit",branch="main"} 12 1608424699186
-histogram_metric_double_test{bar="foo",le="1",container="sit",branch="main"} 16 1608424699186
-histogram_metric_double_test{bar="foo",le="+Inf",container="sit",branch="main"} 22 1608424699186
+histogram_metric_double_test_bucket{bar="foo",le="0.1",container="sit",branch="main"} 0 1608424699186
+histogram_metric_double_test_bucket{bar="foo",le="0.2",container="sit",branch="main"} 10 1608424699186
+histogram_metric_double_test_bucket{bar="foo",le="0.5",container="sit",branch="main"} 11 1608424699186
+histogram_metric_double_test_bucket{bar="foo",le="0.8",container="sit",branch="main"} 12 1608424699186
+histogram_metric_double_test_bucket{bar="foo",le="1",container="sit",branch="main"} 16 1608424699186
+histogram_metric_double_test_bucket{bar="foo",le="+Inf",container="sit",branch="main"} 22 1608424699186
 histogram_metric_double_test_sum{bar="foo",container="sit",branch="main"} 54.1 1608424699186
 histogram_metric_double_test_count{bar="foo",container="sit",branch="main"} 98 1608424699186`
 	assert.Equal(t, expected, result)


### PR DESCRIPTION
For Prometheus histogram metrics, the timeseries representing buckets should have a `_bucket` suffix.

See https://prometheus.io/docs/concepts/metric_types/#histogram.