### PR TITLE
chore(build): remove unnecessary replace

### DIFF
--- a/otelcolbuilder/.otelcol-builder.yaml
+++ b/otelcolbuilder/.otelcol-builder.yaml
@@ -210,12 +210,6 @@ connectors:
 
 # Replacement paths are relative to the output_path (location of source files)
 replaces:
-  # This is needed because of:
-  # failed to download go modules: exit status 1.
-  # Output: go: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver@v0.75.0 requires
-  #  github.com/open-telemetry/opentelemetry-collector-contrib/internal/stanza@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
-  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/stanza => github.com/open-telemetry/opentelemetry-collector-contrib/internal/stanza v0.75.0
-
   # ----------------------------------------------------------------------------
   # Needed for telegrafreceiver
   - github.com/influxdata/telegraf => github.com/SumoLogic/telegraf v1.24.3-sumo-4


### PR DESCRIPTION
Stanza is now a public package, so this replace doesn't do anything, and can safely be removed.