### PR TITLE
feat(scripts/install.sh): increase download timeout

### DIFF
--- a/examples/ansible/install_sumologic_otel_collector.yaml
+++ b/examples/ansible/install_sumologic_otel_collector.yaml
@@ -12,7 +12,7 @@
         mode: 0755
     - name: Create install script argument list
       ansible.builtin.set_fact:
-        install_script_args: []
+        install_script_args: ['--download-timeout 300']
     - name: Add tags to install script argument list
       ansible.builtin.set_fact:
         install_script_args: "{{ install_script_args + [ '--tag ' ~ item.key ~ '=' ~ item.value ] }}"

--- a/examples/chef/sumologic-otel-collector/resources/default.rb
+++ b/examples/chef/sumologic-otel-collector/resources/default.rb
@@ -17,6 +17,7 @@ property :version, String
 # path to a directory with config files for Sumo Logic Distribution for OpenTelemetry Collector
 property :src_config_path, String
 
+DOWNLOAD_TIMEOUT = 300
 BINARY_PATH = '/usr/local/bin/otelcol-sumo'
 BINARY_CONFIG = '/etc/otelcol-sumo/conf.d'
 INSTALL_SCRIPT_PATH = "/tmp/install.sh"
@@ -60,7 +61,7 @@ end
 
 
 def get_install_script_command(resource)
-  command_parts = ["bash", INSTALL_SCRIPT_PATH]
+  command_parts = ["bash", INSTALL_SCRIPT_PATH, "--download-timeout 300"]
   command_parts += resource.collector_tags.map { |key, value| "--tag #{key}=#{value}" }
   if property_is_set?(:version)
      command_parts.push("--version #{resource.version}")

--- a/examples/puppet/modules/install_otel_collector/manifests/init.pp
+++ b/examples/puppet/modules/install_otel_collector/manifests/init.pp
@@ -29,6 +29,7 @@ class install_otel_collector (
 ) {
   $install_script_url = 'https://github.com/SumoLogic/sumologic-otel-collector/releases/latest/download/install.sh'
   $install_script_path = '/tmp/install.sh'
+  $download_timeout = 300
 
   # construct the install command arguments from class parameters
   $tags_command_args = $collector_tags.map |$key, $value| { "--tag ${key}=${value}" }
@@ -47,7 +48,7 @@ class install_otel_collector (
   } else {
     $systemd_command_args = ['--skip-systemd']
   }
-  $install_command_args = $tags_command_args + $version_command_args + $api_command_args + $systemd_command_args
+  $install_command_args = ["--download_timeout ${download_timeout}"] + $tags_command_args + $version_command_args + $api_command_args + $systemd_command_args
 
   file { 'download the install script':
     source => $install_script_url,
@@ -60,7 +61,7 @@ class install_otel_collector (
     command     => $install_command,
     path        => ['/usr/local/bin/', '/usr/bin', '/usr/sbin', '/bin'],
     user        => 'root',
-    environment => ["SUMOLOGIC_INSTALLATION_TOKEN=${installation_token}"]
+    environment => ["SUMOLOGIC_INSTALLATION_TOKEN=${installation_token}"],
   }
 
   file { '/etc/otelcol-sumo/conf.d':

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -106,7 +106,7 @@ BINARY_BRANCH=""
 
 KEEP_DOWNLOADS=false
 
-CURL_MAX_TIME=300
+CURL_MAX_TIME=1800
 
 # set by check_dependencies therefore cannot be set by set_defaults
 SYSTEMD_DISABLED=false


### PR DESCRIPTION
The download timeout is not really useful for interactive installs. Increased it to 1800, but that's basically a way of disabling it without adding conditionals to the code. I've set it to the current default of 300 for Ansible, Puppet and Chef.