### PR TITLE
ci: deprecation fixes

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -26,17 +26,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.19'
-
-      # As described in
-      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
-      - uses: actions/cache@v3
-        with:
-          path: |
-            /home/runner/go/pkg/mod
-            /home/runner/.cache/go-build
-          key: ${{matrix.arch_os}}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{matrix.arch_os}}-go-
+          cache-dependency-path: '**/go.sum'
 
       - uses: actions/cache@v3
         with:
@@ -83,21 +73,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.19'
-
-      # As described in
-      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
-      - uses: actions/cache@v3
-        with:
-          path: |
-            /home/runner/go/pkg/mod
-            /home/runner/.cache/go-build
-            /Users/runner/go/pkg/mod
-            /Users/runner/Library/Caches/go-build
-            /c/Users/runneradmin/go/pkg/mod
-            /c/Users/runneradmin/AppData/Local/go-build
-          key: ${{matrix.arch_os}}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{matrix.arch_os}}-go-
+          cache-dependency-path: '**/go.sum'
 
       - name: Set default BUILDER_BIN_PATH
         run: echo "BUILDER_BIN_PATH=${HOME}/bin" >> $GITHUB_ENV

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -227,7 +227,7 @@ jobs:
 
       - name: Extract tag
         id: extract_tag
-        run: echo "::set-output name=tag::$(git rev-parse HEAD)"
+        run: echo "tag=$(git rev-parse HEAD)" > $GITHUB_OUTPUT
 
       - name: Print tag
         run: echo "Running dev build for ${{ steps.extract_tag.outputs.tag }}"
@@ -285,7 +285,7 @@ jobs:
 
       - name: Extract tag
         id: extract_tag
-        run: echo "::set-output name=tag::$(git rev-parse HEAD)"
+        run: echo "tag=$(git rev-parse HEAD)" > $GITHUB_OUTPUT
 
       - name: Print tag
         run: echo "Running dev build for ${{ steps.extract_tag.outputs.tag }}"

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Check if related files changed
         id: changed-files
-        uses: tj-actions/changed-files@v13
+        uses: tj-actions/changed-files@v35
         with:
           files: |
             **/*.md
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Check if related files changed
         id: changed-files
-        uses: tj-actions/changed-files@v13
+        uses: tj-actions/changed-files@v35
         with:
           files: |
             **/*.md
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Check if related files changed
         id: changed-files
-        uses: tj-actions/changed-files@v13
+        uses: tj-actions/changed-files@v35
         with:
           files: |
             **/*.md
@@ -132,7 +132,7 @@ jobs:
 
       - name: Check if test related files changed
         id: changed-files
-        uses: tj-actions/changed-files@v13
+        uses: tj-actions/changed-files@v35
         with:
           files: |
             **/go.mod
@@ -196,7 +196,7 @@ jobs:
 
       - name: Check if test related files changed
         id: changed-files
-        uses: tj-actions/changed-files@v13
+        uses: tj-actions/changed-files@v35
         with:
           files: |
             **/go.mod
@@ -271,7 +271,7 @@ jobs:
 
       - name: Check if files changed that need linting
         id: changed-files
-        uses: tj-actions/changed-files@v13
+        uses: tj-actions/changed-files@v35
         with:
           files: |
             **/go.mod
@@ -344,7 +344,7 @@ jobs:
 
       - name: Check if build related files changed
         id: changed-files
-        uses: tj-actions/changed-files@v13
+        uses: tj-actions/changed-files@v35
         with:
           files: |
             otelcolbuilder/.gon_config.json
@@ -437,7 +437,7 @@ jobs:
 
       - name: Check if build related files changed
         id: changed-files
-        uses: tj-actions/changed-files@v13
+        uses: tj-actions/changed-files@v35
         with:
           files: |
             otelcolbuilder/.gon_config.json
@@ -523,7 +523,7 @@ jobs:
 
       - name: Check if build related files changed
         id: changed-files
-        uses: tj-actions/changed-files@v13
+        uses: tj-actions/changed-files@v35
         with:
           files: |
             **/go.mod

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -149,22 +149,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.19'
-
-      # As described in
-      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
-      - uses: actions/cache@v3
-        if: steps.changed-files.outputs.any_changed == 'true'
-        with:
-          path: |
-            /home/runner/go/pkg/mod
-            /home/runner/.cache/go-build
-            /Users/runner/go/pkg/mod
-            /Users/runner/Library/Caches/go-build
-            /c/Users/runneradmin/go/pkg/mod
-            /c/Users/runneradmin/AppData/Local/go-build
-          key: ${{matrix.arch_os}}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{matrix.arch_os}}-go-
+          cache-dependency-path: '**/go.sum'
 
       - name: Set default BUILDER_BIN_PATH
         if: steps.changed-files.outputs.any_changed == 'true'
@@ -213,20 +198,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.19'
-
-      # As described in
-      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
-      - uses: actions/cache@v3
-        if: steps.changed-files.outputs.any_changed == 'true'
-        with:
-          path: |
-            /home/runner/go/pkg/mod
-            /home/runner/.cache/go-build
-            /Users/runner/go/pkg/mod
-            /Users/runner/Library/Caches/go-build
-          key: ${{matrix.arch_os}}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{matrix.arch_os}}-go-
+          cache-dependency-path: '**/go.sum'
 
       - name: Add opentelemetry-collector-builder installation dir to PATH
         if: steps.changed-files.outputs.any_changed == 'true'
@@ -287,18 +259,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.19'
-
-      # As described in
-      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
-      - uses: actions/cache@v3
-        if: steps.changed-files.outputs.any_changed == 'true'
-        with:
-          path: |
-            /home/runner/go/pkg/mod
-            /home/runner/.cache/go-build
-          key: ${{matrix.arch_os}}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{matrix.arch_os}}-go-
+          cache-dependency-path: '**/go.sum'
 
       - uses: actions/cache@v3
         if: steps.changed-files.outputs.any_changed == 'true'
@@ -365,22 +326,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.19'
-
-      # As described in
-      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
-      - uses: actions/cache@v3
-        if: steps.changed-files.outputs.any_changed == 'true'
-        with:
-          path: |
-            /home/runner/go/pkg/mod
-            /home/runner/.cache/go-build
-            /Users/runner/go/pkg/mod
-            /Users/runner/Library/Caches/go-build
-            /c/Users/runneradmin/go/pkg/mod
-            /c/Users/runneradmin/AppData/Local/go-build
-          key: ${{matrix.arch_os}}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{matrix.arch_os}}-go-
+          cache-dependency-path: '**/go.sum'
 
       - name: Set default BUILDER_BIN_PATH
         run: echo "BUILDER_BIN_PATH=${HOME}/bin" >> $GITHUB_ENV
@@ -455,23 +401,10 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.19'
+          cache-dependency-path: '**/go.sum'
 
       - name: Fetch current branch
         run: ./ci/fetch_current_branch.sh
-
-      # As described in
-      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
-      - uses: actions/cache@v3
-        if: steps.changed-files.outputs.any_changed == 'true'
-        with:
-          path: |
-            /home/runner/go/pkg/mod
-            /home/runner/.cache/go-build
-            /Users/runner/go/pkg/mod
-            /Users/runner/Library/Caches/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: Add opentelemetry-collector-builder installation dir to PATH
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -21,10 +21,10 @@ jobs:
         with:
           files: |
             **/*.md
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         if: steps.changed-files.outputs.any_changed == 'true'
         with:
-          ruby-version: '2.7'
+          bundler-cache: true
       - name: Install markdownlint
         if: steps.changed-files.outputs.any_changed == 'true'
         run: gem install mdl

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -55,6 +55,9 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         with:
           config-file: '.markdown_link_check.json'
+          use-quiet-mode: yes
+          check-modified-files-only: yes
+          base-branch: ${{ github.base_ref }}
 
   md-links-lint:
     runs-on: ubuntu-20.04

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Extract tag
         id: extract_tag
-        run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/v})"
+        run: echo "tag=$(echo ${GITHUB_REF#refs/tags/v})" > $GITHUB_OUTPUT
 
       - name: Print tag
         run: echo "${{ steps.extract_tag.outputs.tag }}"
@@ -87,7 +87,7 @@ jobs:
 
       - name: Set filename
         id: set_filename
-        run: echo "::set-output name=filename::$(echo otelcol-sumo-${{ steps.extract_tag.outputs.tag }}-${{matrix.arch_os}})${{matrix.builder_bin_ext}}"
+        run: echo "filename=$(echo otelcol-sumo-${{ steps.extract_tag.outputs.tag }}-${{matrix.arch_os}})${{matrix.builder_bin_ext}}" > $GITHUB_OUTPUT
 
       - name: Rename to include tag in filename
         run: cp otelcol-sumo-${{matrix.arch_os}}${{matrix.builder_bin_ext}} ${{ steps.set_filename.outputs.filename }}
@@ -152,7 +152,7 @@ jobs:
 
       - name: Extract tag
         id: extract_tag
-        run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/v})"
+        run: echo "tag=$(echo ${GITHUB_REF#refs/tags/v})" > $GITHUB_OUTPUT
 
       - name: Add opentelemetry-collector-builder installation dir to PATH
         run: echo "$HOME/bin" >> $GITHUB_PATH
@@ -170,7 +170,7 @@ jobs:
 
       - name: Set filename
         id: set_filename
-        run: echo "::set-output name=filename::$(echo otelcol-sumo-${{ steps.extract_tag.outputs.tag }}-${{matrix.arch_os}})"
+        run: echo "filename=$(echo otelcol-sumo-${{ steps.extract_tag.outputs.tag }}-${{matrix.arch_os}})" > $GITHUB_OUTPUT
 
       - name: Import Code-Signing Certificates
         uses: Apple-Actions/import-codesign-certs@v2
@@ -261,7 +261,7 @@ jobs:
 
       - name: Extract tag
         id: extract_tag
-        run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/v})"
+        run: echo "tag=$(echo ${GITHUB_REF#refs/tags/v})" > $GITHUB_OUTPUT
 
       - name: Add opentelemetry-collector-builder installation dir to PATH
         run: echo "$HOME/bin" >> $GITHUB_PATH
@@ -279,7 +279,7 @@ jobs:
 
       - name: Set filename
         id: set_filename
-        run: echo "::set-output name=filename::$(echo otelcol-sumo-${{ steps.extract_tag.outputs.tag }}-fips-${{matrix.arch_os}})"
+        run: echo "filename=$(echo otelcol-sumo-${{ steps.extract_tag.outputs.tag }}-fips-${{matrix.arch_os}})" > $GITHUB_OUTPUT
 
       - name: Rename to include tag in filename
         run: cp otelcol-sumo-fips-${{matrix.arch_os}} ${{ steps.set_filename.outputs.filename }}
@@ -319,7 +319,7 @@ jobs:
 
       - name: Extract tag
         id: extract_tag
-        run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/v})"
+        run: echo "tag=$(echo ${GITHUB_REF#refs/tags/v})" > $GITHUB_OUTPUT
 
       - name: Print tag
         run: echo "${{ steps.extract_tag.outputs.tag }}"
@@ -336,11 +336,11 @@ jobs:
 
       - name: Set filename
         id: set_filename
-        run: echo "::set-output name=filename::$(echo otelcol-sumo-${{ steps.extract_tag.outputs.tag }}-${{matrix.arch_os}})"
+        run: echo "filename=$(echo otelcol-sumo-${{ steps.extract_tag.outputs.tag }}-${{matrix.arch_os}})" > $GITHUB_OUTPUT
 
       - name: Set filename for FIPS
         id: set_filename_fips
-        run: echo "::set-output name=filename_fips::$(echo otelcol-sumo-${{ steps.extract_tag.outputs.tag }}-fips-${{matrix.arch_os}})"
+        run: echo "filename_fips=$(echo otelcol-sumo-${{ steps.extract_tag.outputs.tag }}-fips-${{matrix.arch_os}})" > $GITHUB_OUTPUT
 
       - name: Login to Open Source ECR
         run: make login
@@ -383,7 +383,7 @@ jobs:
 
       - name: Extract tag
         id: extract_tag
-        run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/v})"
+        run: echo "tag=$(echo ${GITHUB_REF#refs/tags/v})" > $GITHUB_OUTPUT
 
       - name: Print tag
         run: echo "${{ steps.extract_tag.outputs.tag }}"
@@ -544,7 +544,7 @@ jobs:
     steps:
       - name: Extract tag
         id: extract_tag
-        run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/v})"
+        run: echo "tag=$(echo ${GITHUB_REF#refs/tags/v})" > $GITHUB_OUTPUT
 
       - name: Print tag
         run: echo "v${{ steps.extract_tag.outputs.tag }}"

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -43,19 +43,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.19'
-
-      # As described in
-      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
-      - uses: actions/cache@v3
-        with:
-          path: |
-            /home/runner/go/pkg/mod
-            /home/runner/.cache/go-build
-            /c/Users/runneradmin/go/pkg/mod
-            /c/Users/runneradmin/AppData/Local/go-build
-          key: ${{matrix.arch_os}}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{matrix.arch_os}}-go-
+          cache-dependency-path: '**/go.sum'
 
       - name: Set default BUILDER_BIN_PATH
         run: echo "BUILDER_BIN_PATH=${HOME}/bin" >> $GITHUB_ENV
@@ -244,20 +232,10 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.19'
+          cache-dependency-path: '**/go.sum'
 
       - name: Fetch current branch
         run: ./ci/fetch_current_branch.sh
-
-      # As described in
-      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
-      - uses: actions/cache@v3
-        with:
-          path: |
-            /home/runner/go/pkg/mod
-            /home/runner/.cache/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: Extract tag
         id: extract_tag


### PR DESCRIPTION
* Stop using `set-output` as per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.
* Upgrade external actions in relation to the above as well
* Use setup-go caching instead of our own
* Fix the markdown-link-check configuration to only check changed files and only show errors in output
