### PR TITLE
feat(k8sprocessor): support otel semantic convention in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Released TBA
 
+### Added
+
+- feat(k8sprocessor): support otel semantic convention in config [#1122]
+
 ### Fixed
 
 - fix(sumologicexporter): avoid allocations in compressor [#1118]
 
 [#1118]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1118
+[#1122]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1122
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.76.1-sumo-0...main
 
 ## [0.76.1-sumo-0]

--- a/pkg/processor/k8sprocessor/README.md
+++ b/pkg/processor/k8sprocessor/README.md
@@ -49,22 +49,22 @@ processors:
       # See "Extracting metadata" documentation section below for details.
       # default: []
       metadata:
-      - containerId
-      - containerImage
-      - containerName
-      - cronJobName
-      - daemonSetName
-      - deploymentName
-      - hostName
-      - jobName
-      - namespace
-      - nodeName
-      - podId
-      - podName
-      - replicaSetName
-      - serviceName
-      - startTime
-      - statefulSetName
+      - container.id
+      - container.image
+      - container.name
+      - k8s.cronjob.name
+      - k8s.daemonset.name
+      - k8s.deployment.name
+      - host.name
+      - k8s.job.name
+      - k8s.namespace.name
+      - k8s.node.name
+      - k8s.pod.uid
+      - k8s.pod.name
+      - k8s.replicaset.name
+      - k8s.service.name
+      - k8s.statefulset.name
+      - k8s.pod.startTime
 
       # List of rules to extract namespace labels into attributes.
       # See the "Field extract config" documentation section below for details on how to use it.
@@ -148,16 +148,57 @@ The `extract` configuration section allows to specify rules to extract metadata 
 The `extract.metadata` section defines which metadata should be retrieved.
 The `extract.tags` section defines the names of the attributes that the metadata will be put in.
 
+#### Specifying metadata attributes
+
+The attributes are specified using the [Otel Resource Semantic Conventions for Kubernetes][k8s_semconv].
+The following attributes are supported:
+
+- `container.id`
+- `container.image`
+- `container.name`
+- `k8s.cronjob.name`
+- `k8s.daemonset.name`
+- `k8s.deployment.name`
+- `host.name`
+- `k8s.job.name`
+- `k8s.namespace.name`
+- `k8s.node.name`
+- `k8s.pod.uid`
+- `k8s.pod.name`
+- `k8s.replicaset.name`
+- `k8s.service.name`
+- `k8s.statefulset.name`
+- `k8s.pod.startTime`
+
 Some of the metadata is only extracted when the `owner_lookup_enabled` property is set to `true`.
 The attributes that require this are:
 
+- `k8s.cronjob.name`
+- `k8s.daemonset.name`
+- `k8s.deployment.name`
+- `k8s.job.name`
+- `k8s.replicaset.name`
+- `k8s.service.name`
+- `k8s.statefulset.name`
+
+It's also possible to use the following legacy attribute names, though they will be deprecated at some point in the future:
+
+- `containerId`
+- `containerImage`
+- `containerName`
 - `cronJobName`
 - `daemonSetName`
 - `deploymentName`
+- `hostName`
 - `jobName`
+- `namespace`
+- `nodeName`
+- `podId`
+- `podName`
 - `replicaSetName`
 - `serviceName`
 - `statefulSetName`
+- `startTime`
 
 ### Field Extract Config
 
@@ -421,3 +462,5 @@ The processor does not support detecting containers from the same pods when runn
 as a sidecar. While this can be done, we think it is simpler to just use the kubernetes
 downward API to inject environment variables into the pods and directly use their values
 as tags.
+
+[k8s_semconv]: https://opentelemetry.io/docs/specification/otel/resource/semantic_conventions/k8s/

--- a/pkg/processor/k8sprocessor/config_test.go
+++ b/pkg/processor/k8sprocessor/config_test.go
@@ -59,11 +59,11 @@ func TestLoadConfig(t *testing.T) {
 			OwnerLookupEnabled: true,
 			Extract: ExtractConfig{
 				Metadata: []string{
-					"podName",
-					"podUID",
-					"deployment",
-					"namespace",
-					"node",
+					"k8s.pod.name",
+					"k8s.pod.uid",
+					"k8s.deployment.name",
+					"k8s.namespace.name",
+					"k8s.node.name",
 					"startTime",
 				},
 				Annotations: []FieldExtractConfig{

--- a/pkg/processor/k8sprocessor/go.mod
+++ b/pkg/processor/k8sprocessor/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/stretchr/testify v1.8.2
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/collector v0.76.1
-	go.opentelemetry.io/collector/model v0.50.0
+	go.opentelemetry.io/collector/semconv v0.76.1
 	go.uber.org/zap v1.24.0
 	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.26.3
@@ -17,6 +17,7 @@ require (
 require (
 	go.opentelemetry.io/collector/component v0.76.1
 	go.opentelemetry.io/collector/consumer v0.76.1
+	go.opentelemetry.io/collector/model v0.50.0
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0011
 )
 
@@ -78,7 +79,6 @@ require (
 	go.opentelemetry.io/collector/exporter v0.76.1 // indirect
 	go.opentelemetry.io/collector/featuregate v0.76.1 // indirect
 	go.opentelemetry.io/collector/receiver v0.76.1 // indirect
-	go.opentelemetry.io/collector/semconv v0.76.1 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.15.0 // indirect
 	go.opentelemetry.io/otel v1.14.0 // indirect
 	go.opentelemetry.io/otel/bridge/opencensus v0.37.0 // indirect

--- a/pkg/processor/k8sprocessor/go.sum
+++ b/pkg/processor/k8sprocessor/go.sum
@@ -259,6 +259,7 @@ github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdv
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=

--- a/pkg/processor/k8sprocessor/options.go
+++ b/pkg/processor/k8sprocessor/options.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"strings"
 
+	conventions "go.opentelemetry.io/collector/semconv/v1.18.0"
 	"k8s.io/apimachinery/pkg/selection"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
@@ -49,7 +50,9 @@ const (
 	metadataStartTime       = "startTime"
 	metadataStatefulSetName = "statefulSetName"
 
-	deprecatedMetadataClusterName = "clusterName"
+	metadataOtelSemconvServiceName = "k8s.service.name"  // no semantic convention for service name as of right now, but this is reasonable
+	metadataOtelPodStartTime       = "k8s.pod.startTime" // no semantic convention for this, but keeping a similar format for consistency
+	deprecatedMetadataClusterName  = "clusterName"
 )
 
 // Option represents a configuration option that can be passes.
@@ -106,39 +109,39 @@ func WithExtractMetadata(fields ...string) Option {
 		}
 		for _, field := range fields {
 			switch field {
-			case metadataContainerID:
+			case metadataContainerID, conventions.AttributeContainerID:
 				p.rules.ContainerID = true
-			case metadataContainerImage:
+			case metadataContainerImage, conventions.AttributeContainerImageName:
 				p.rules.ContainerImage = true
-			case metadataContainerName:
+			case metadataContainerName, conventions.AttributeContainerName:
 				p.rules.ContainerName = true
-			case metadataCronJobName:
+			case metadataCronJobName, conventions.AttributeK8SCronJobName:
 				p.rules.CronJobName = true
-			case metadataDaemonSetName:
+			case metadataDaemonSetName, conventions.AttributeK8SDaemonSetName:
 				p.rules.DaemonSetName = true
-			case metadataDeploymentName:
+			case metadataDeploymentName, conventions.AttributeK8SDeploymentName:
 				p.rules.DeploymentName = true
-			case metadataHostName:
+			case metadataHostName, conventions.AttributeHostName:
 				p.rules.HostName = true
-			case metadataJobName:
+			case metadataJobName, conventions.AttributeK8SJobName:
 				p.rules.JobName = true
-			case metadataNamespace:
+			case metadataNamespace, conventions.AttributeK8SNamespaceName:
 				p.rules.Namespace = true
-			case metadataNodeName:
+			case metadataNodeName, conventions.AttributeK8SNodeName:
 				p.rules.NodeName = true
-			case metadataPodID:
+			case metadataPodID, conventions.AttributeK8SPodUID:
 				p.rules.PodUID = true
-			case metadataPodName:
+			case metadataPodName, conventions.AttributeK8SPodName:
 				p.rules.PodName = true
-			case metadataReplicaSetName:
+			case metadataReplicaSetName, conventions.AttributeK8SReplicaSetName:
 				p.rules.ReplicaSetName = true
-			case metadataServiceName:
+			case metadataServiceName, metadataOtelSemconvServiceName:
 				p.rules.ServiceName = true
-			case metadataStartTime:
+			case metadataStartTime, metadataOtelPodStartTime:
 				p.rules.StartTime = true
-			case metadataStatefulSetName:
+			case metadataStatefulSetName, conventions.AttributeK8SStatefulSetName:
 				p.rules.StatefulSetName = true
-			case deprecatedMetadataClusterName:
+			case deprecatedMetadataClusterName, conventions.AttributeK8SClusterName:
 				p.logger.Warn("clusterName metadata field has been deprecated and will be removed soon")
 			default:
 				return fmt.Errorf("\"%s\" is not a supported metadata field", field)

--- a/pkg/processor/k8sprocessor/options_test.go
+++ b/pkg/processor/k8sprocessor/options_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	conventions "go.opentelemetry.io/collector/semconv/v1.18.0"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
@@ -283,6 +284,45 @@ func TestWithExtractMetadata(t *testing.T) {
 	assert.False(t, p.rules.StartTime)
 	assert.False(t, p.rules.DeploymentName)
 	assert.False(t, p.rules.NodeName)
+}
+
+func TestWithExtractMetadataSemanticConventions(t *testing.T) {
+	p := &kubernetesprocessor{}
+	fields := []string{
+		conventions.AttributeContainerID,
+		conventions.AttributeContainerImageName,
+		conventions.AttributeContainerName,
+		conventions.AttributeK8SCronJobName,
+		conventions.AttributeK8SDaemonSetName,
+		conventions.AttributeK8SDeploymentName,
+		conventions.AttributeHostName,
+		conventions.AttributeK8SJobName,
+		conventions.AttributeK8SNamespaceName,
+		conventions.AttributeK8SNodeName,
+		conventions.AttributeK8SPodUID,
+		conventions.AttributeK8SPodName,
+		conventions.AttributeK8SReplicaSetName,
+		metadataOtelSemconvServiceName,
+		conventions.AttributeK8SStatefulSetName,
+		metadataOtelPodStartTime,
+	}
+	assert.NoError(t, WithExtractMetadata(fields...)(p))
+	assert.True(t, p.rules.ContainerID)
+	assert.True(t, p.rules.ContainerImage)
+	assert.True(t, p.rules.ContainerName)
+	assert.True(t, p.rules.CronJobName)
+	assert.True(t, p.rules.DaemonSetName)
+	assert.True(t, p.rules.DeploymentName)
+	assert.True(t, p.rules.HostName)
+	assert.True(t, p.rules.JobName)
+	assert.True(t, p.rules.Namespace)
+	assert.True(t, p.rules.NodeName)
+	assert.True(t, p.rules.PodName)
+	assert.True(t, p.rules.PodUID)
+	assert.True(t, p.rules.ReplicaSetName)
+	assert.True(t, p.rules.ServiceName)
+	assert.True(t, p.rules.StatefulSetName)
+	assert.True(t, p.rules.StartTime)
 }
 
 func TestWithExtractMetadataDeprecatedOption(t *testing.T) {

--- a/pkg/processor/k8sprocessor/testdata/config.yaml
+++ b/pkg/processor/k8sprocessor/testdata/config.yaml
@@ -10,11 +10,11 @@ processors:
     extract:
       metadata:
         # extract the following well-known metadata fields
-        - podName
-        - podUID
-        - deployment
-        - namespace
-        - node
+        - k8s.pod.name
+        - k8s.pod.uid
+        - k8s.deployment.name
+        - k8s.namespace.name
+        - k8s.node.name
         - startTime
       tags:
         # It is possible to provide your custom key names for each of the extracted metadata:


### PR DESCRIPTION
Make it possible to specify metadata fields for k8sprocessor using the otel semantic convention. This will make it easier to migrate to the upstream processor in the future. The older format is still supported, though all the examples use the newer one.