### PR TITLE
test: run install script tests separately

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -163,9 +163,44 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         run: echo "$BUILDER_BIN_PATH" >> $GITHUB_PATH
 
-      - name: Run tests
+      - name: Run package tests
         if: steps.changed-files.outputs.any_changed == 'true'
         run: make gotest
+
+  test-install-script:
+    name: Test Install Script
+    runs-on: ${{ matrix.runs_on }}
+    strategy:
+      matrix:
+        include:
+          - arch_os: linux_amd64
+            runs_on: ubuntu-20.04
+          - arch_os: darwin_amd64
+            runs_on: macos-latest
+          - arch_os: windows_amd64
+            runs_on: windows-2022
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check if test related files changed
+        id: changed-files
+        uses: tj-actions/changed-files@v35
+        with:
+          files: |
+            pkg/scripts_test/*
+            scripts/install.sh
+
+      - name: Setup go
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.19'
+          cache-dependency-path: 'pkg/scripts_test/go.sum'
+
+      - name: Run install script tests
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: make test-install-script
+
 
   # pipeline to test using Go+BoringCrypto
   test-go-boringcrypto:

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ pre-commit-check:
 # ALL_MODULES includes ./* dirs (excludes . dir and example with go code)
 ALL_MODULES := $(shell find ./pkg -type f -name "go.mod" -exec dirname {} \; | sort | egrep  '^./' )
 ALL_MODULES += ./otelcolbuilder
+ALL_MODULES_WITHOUT_SCRIPT_TESTS := $(filter-out ./pkg/scripts_test,$(ALL_MODULES))
 
 ALL_EXPORTABLE_MODULES += $(shell find ./pkg -type f -name "go.mod" ! -path "*pkg/test/*" -exec dirname {} \; | sort )
 
@@ -58,7 +59,11 @@ list-modules:
 
 .PHONY: gotest
 gotest:
-	@$(MAKE) for-all CMD="make test"
+	@$(MAKE) for-all CMD="make test" ALL_MODULES=$(ALL_MODULES_WITHOUT_SCRIPT_TESTS)
+
+.PHONY: test-install-script
+test-install-script:
+	cd ./pkg/scripts_test && $(MAKE) test
 
 .PHONY: golint
 golint:

--- a/pkg/scripts_test/Makefile
+++ b/pkg/scripts_test/Makefile
@@ -4,6 +4,10 @@ ifneq ($(OS),windows)
 	GOTESTPREFIX ?= sudo env PATH="${PATH}"
 endif
 
+GOTESTBINARY=sumologic_scripts_tests.test
+
+# We build the test binary separately to avoid downloading modules as root
 .PHONY: test
 test:
-	$(GOTESTPREFIX) $(GOTEST) ./...
+	$(GOTEST) -c
+	$(GOTESTPREFIX) ./$(GOTESTBINARY)


### PR DESCRIPTION
Install script tests require root and modify the environment. For convenience, they shouldn't run with the rest of package tests. Building the tests as root also causes intermittent permission issues with the mod cache.