### PR TITLE
test: cache test results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ list-modules:
 
 .PHONY: gotest
 gotest:
-	@$(MAKE) for-all CMD="make test" ALL_MODULES=$(ALL_MODULES_WITHOUT_SCRIPT_TESTS)
+	@$(MAKE) for-all CMD="make test" ALL_MODULES="$(ALL_MODULES_WITHOUT_SCRIPT_TESTS)"
 
 .PHONY: test-install-script
 test-install-script:

--- a/otelcolbuilder/cmd/Makefile
+++ b/otelcolbuilder/cmd/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 test:
-	go test $(FLAGS) -trimpath -count 1 -parallel 1 ./...
+	go test $(FLAGS) -trimpath -parallel 1 ./...
 
 .PHONY: test-v
 test-v:

--- a/pkg/Makefile.Common
+++ b/pkg/Makefile.Common
@@ -2,7 +2,7 @@ ifeq ($(OS),Windows_NT)
 	OS=windows
 endif
 
-GOTEST=go test -count 1 -race
+GOTEST=go test -race
 LINT=golangci-lint
 
 .PHONY: test

--- a/pkg/receiver/rawk8seventsreceiver/receiver_test.go
+++ b/pkg/receiver/rawk8seventsreceiver/receiver_test.go
@@ -343,8 +343,8 @@ func TestNoStorage(t *testing.T) {
 
 	// Both events should be picked up by the receiver.
 	assert.Eventually(t, func() bool {
-		return assert.Equal(t, 2, logsSink.LogRecordCount())
-	}, 100*time.Millisecond, 10*time.Millisecond)
+		return logsSink.LogRecordCount() == 2
+	}, 100*time.Millisecond, 10*time.Millisecond, "expected two events")
 
 	// Shutdown the receiver.
 	assert.NoError(t, receiver.Shutdown(ctx))
@@ -372,8 +372,8 @@ func TestNoStorage(t *testing.T) {
 	// Since the receiver has no storage, it should pick up events from last minute on start
 	// which means it should get all three events.
 	assert.Eventually(t, func() bool {
-		return assert.Equal(t, 3, logsSink.LogRecordCount())
-	}, 100*time.Millisecond, 10*time.Millisecond)
+		return logsSink.LogRecordCount() == 3
+	}, 100*time.Millisecond, 10*time.Millisecond, "expected 3 events")
 }
 
 func TestStorage(t *testing.T) {
@@ -422,8 +422,8 @@ func TestStorage(t *testing.T) {
 	// Both events should be picked up by the receiver.
 	// The last resource version processed should be saved in storage.
 	assert.Eventually(t, func() bool {
-		return assert.Equal(t, 2, logsSink.LogRecordCount())
-	}, 100*time.Millisecond, 10*time.Millisecond)
+		return logsSink.LogRecordCount() == 2
+	}, 100*time.Millisecond, 10*time.Millisecond, "expected 2 events")
 
 	// Shutdown the receiver.
 	require.NoError(t, receiver.Shutdown(ctx))
@@ -452,8 +452,8 @@ func TestStorage(t *testing.T) {
 	// The receiver should only pick up the third event,
 	// as it is the only one with newer resource version.
 	assert.Eventually(t, func() bool {
-		return assert.Equal(t, 1, logsSink.LogRecordCount())
-	}, 100*time.Millisecond, 10*time.Millisecond)
+		return logsSink.LogRecordCount() == 1
+	}, 100*time.Millisecond, 10*time.Millisecond, "expected one event")
 }
 
 func getEvent() *corev1.Event {


### PR DESCRIPTION
The `-count 1` parameter explicitly causes test results to not be cached. Remove it.

Fix an issue with the make test command only running for the first package. Just make and bash things.

This also turned up some remaining flaky tests in rawk8sevents receiver, which were leftover from #919.