### PR TITLE
feat(receiver/sqlquery): add experimental logs support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - chore: update OT to v0.78.0 [#1142]
+- feat(receiver/sqlquery): add experimental logs support [#1144]
 
 [unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.77.0-sumo-0...main
 [#1142]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1142
+[#1144]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1144
 
 ## [v0.77.0-sumo-0]
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ The rest of the components in the table are pure upstream OpenTelemetry componen
 [snmpreceiver]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.78.0/receiver/snmpreceiver
 [solacereceiver]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.78.0/receiver/solacereceiver
 [splunkhecreceiver]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.78.0/receiver/splunkhecreceiver
-[sqlqueryreceiver]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.78.0/receiver/sqlqueryreceiver
+[sqlqueryreceiver]: https://github.com/dmolenda-sumo/opentelemetry-collector-contrib/tree/sqlquery-receiver-add-logs-v0.78.0/receiver/sqlqueryreceiver
 [sqlserverreceiver]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.78.0/receiver/sqlserverreceiver
 [sshcheckreceiver]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.78.0/receiver/sshcheckreceiver
 [statsdreceiver]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.78.0/receiver/statsdreceiver

--- a/otelcolbuilder/.otelcol-builder.yaml
+++ b/otelcolbuilder/.otelcol-builder.yaml
@@ -228,4 +228,4 @@ replaces:
 
   # lokireceiver does a replace for this, so we need to as well
   - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki => github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki v0.78.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver => github.com/dmolenda-sumo/opentelemetry-collector-contrib/receiver/sqlqueryreceiver sqlquery-receiver-add-logs
+  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver => github.com/dmolenda-sumo/opentelemetry-collector-contrib/receiver/sqlqueryreceiver sqlquery-receiver-add-logs-v0.78.0

--- a/otelcolbuilder/.otelcol-builder.yaml
+++ b/otelcolbuilder/.otelcol-builder.yaml
@@ -228,3 +228,4 @@ replaces:
 
   # lokireceiver does a replace for this, so we need to as well
   - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki => github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki v0.78.0
+  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver => github.com/dmolenda-sumo/opentelemetry-collector-contrib/receiver/sqlqueryreceiver sqlquery-receiver-add-logs


### PR DESCRIPTION
This adds experimental logs support to the SQL Query receiver.

This feature is currently under review in the OpenTelemetry Collector Contrib repository:
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/20730