### PR TITLE
fix: do not send html special characters as unicode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore: update OT to v0.78.0 [#1142]
 - feat(receiver/sqlquery): add experimental logs support [#1144]
 
+### Fixed
+
+- fix: do not send html special characters as unicode [#1145]
+
 [unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.77.0-sumo-0...main
 [#1142]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1142
 [#1144]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1144
+[#1145]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1145
 
 ## [v0.77.0-sumo-0]
 

--- a/pkg/exporter/sumologicexporter/sender.go
+++ b/pkg/exporter/sumologicexporter/sender.go
@@ -372,12 +372,16 @@ func (s *sender) logToJSON(record plog.LogRecord) (string, error) {
 		}
 	}
 
-	nextLine, err := json.Marshal(record.Attributes().AsRaw())
+	nextLine := new(bytes.Buffer)
+	enc := json.NewEncoder(nextLine)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(record.Attributes().AsRaw())
+
 	if err != nil {
 		return "", err
 	}
 
-	return bytes.NewBuffer(nextLine).String(), nil
+	return strings.TrimSuffix(nextLine.String(), "\n"), nil
 }
 
 var timeZeroUTC = time.Unix(0, 0).UTC()


### PR DESCRIPTION
By default we are encoding htlm characters like `<`, `>`, `&`. It is unexpected for our customers

log:
```
{"log": "<<<<>>>>>"}
```

output to Sumo Logic
```
2023-05-31T06:01:09.357Z DEBUG [receiver_mock::router] log => {"log":"{\"log\": \"\u003c\u003c\u003c\u003c\u003e\u003e\u003e\u003e\u003e\"}","log.file.path_resolved":"/home/drosiek/projects/sumologic-otel-collector/tmp/logs/unicode.json","timestamp":1685512869155}
```