### PR TITLE
fix(sumoextension): skip credentials dir check if registration is forced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Released TBA
 
+This release introduces the following breaking changes:
+
+- fix(sumologicextension)!: check credentials dir at start [#1152] [#1153]
+
+Set `force_registatrion: true` in the extension configuration if you don't want the credentials persisted at all.
+
 ### Added
 
 - feat(receiver/filestats): add File Stats receiver [#1146]
@@ -22,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - fix: do not send html special characters as unicode [#1145]
-- fix(sumologicextension): check credentials dir at start [#1152]
 
 [unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.77.0-sumo-0...main
 [#1142]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1142
@@ -31,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1146]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1146
 [#1149]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1149
 [#1152]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1152
+[#1153]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1153
 
 ## [v0.77.0-sumo-0]
 

--- a/pkg/extension/sumologicextension/credentials/credentialsstore_localfs.go
+++ b/pkg/extension/sumologicextension/credentials/credentialsstore_localfs.go
@@ -80,10 +80,6 @@ func NewLocalFsStore(opts ...LocalFsStoreOpt) (Store, error) {
 		opt(&store)
 	}
 
-	if err := ensureDir(store.collectorCredentialsDirectory); err != nil {
-		return nil, fmt.Errorf("failed to ensure the local credentials directory is writable: %w", err)
-	}
-
 	return store, err
 }
 
@@ -253,6 +249,16 @@ func (cr LocalFsStore) Delete(key string) error {
 	}
 
 	return errResult
+}
+
+// Validate checks if the store is operating correctly
+// This mostly means file permissions and the like
+func (cr LocalFsStore) Validate() error {
+	if err := ensureDir(cr.collectorCredentialsDirectory); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // ensureDir checks if the specified directory exists and has the right permissions

--- a/pkg/extension/sumologicextension/credentials/credentialsstore_localfs_test.go
+++ b/pkg/extension/sumologicextension/credentials/credentialsstore_localfs_test.go
@@ -76,7 +76,7 @@ func TestCredentialsStoreLocalFs(t *testing.T) {
 	require.EqualValues(t, fileCounter, 0)
 }
 
-func TestCredentialsStoreEnsureWritable(t *testing.T) {
+func TestCredentialsStoreValidate(t *testing.T) {
 	var expectedFileMode fs.FileMode
 	dir := filepath.Join(t.TempDir(), "store")
 	if runtime.GOOS == "windows" { // on Windows, we get 0777 for writable directories
@@ -87,7 +87,9 @@ func TestCredentialsStoreEnsureWritable(t *testing.T) {
 	err := os.Mkdir(dir, 0400)
 	require.NoError(t, err)
 
-	_, err = NewLocalFsStore(WithCredentialsDirectory(dir), WithLogger(zap.NewNop()))
+	store, err := NewLocalFsStore(WithCredentialsDirectory(dir), WithLogger(zap.NewNop()))
+	require.NoError(t, err)
+	err = store.Validate()
 	require.NoError(t, err)
 
 	stat, err := os.Stat(dir)

--- a/pkg/extension/sumologicextension/credentials/store.go
+++ b/pkg/extension/sumologicextension/credentials/store.go
@@ -48,4 +48,7 @@ type Store interface {
 
 	// Delete deletes collector credentials stored under the specified key.
 	Delete(key string) error
+
+	// Validate checks if the store is operating correctly
+	Validate() error
 }

--- a/pkg/extension/sumologicextension/extension.go
+++ b/pkg/extension/sumologicextension/extension.go
@@ -180,7 +180,16 @@ func createHashKey(conf *Config) string {
 }
 
 func (se *SumologicExtension) Start(ctx context.Context, host component.Host) error {
+	var err error
 	se.host = host
+
+	// if force registration is not enabled, verify that the store is correctly configured
+	if !se.conf.ForceRegistration {
+		err = se.credentialsStore.Validate()
+		if err != nil {
+			return err
+		}
+	}
 
 	colCreds, err := se.getCredentials(ctx)
 	if err != nil {


### PR DESCRIPTION
It's feasible that someone might want to run the collector without a writable credentials directory. In that case, we should continue running if `force_registration: true` is set, instead of failing at start time.

This PR also correctly identifies #1152 as a breaking change in the changelog.