### PR TITLE
chore: upgrade Go to 1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   golang:
     docker:
-      - image: cimg/go:1.19
+      - image: cimg/go:1.20
   machine:
     machine:
       image: ubuntu-1604:201903-01

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -10,6 +10,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  GO_VERSION: "1.20"
+
 jobs:
 
   # Add lint to dev builds as that's the only way for cache to be shared across branches.
@@ -25,7 +28,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: '**/go.sum'
 
       - uses: actions/cache@v3
@@ -72,7 +75,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: '**/go.sum'
 
       - name: Set default BUILDER_BIN_PATH
@@ -133,7 +136,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Fetch current branch
         run: ./ci/fetch_current_branch.sh

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -9,6 +9,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  GO_VERSION: "1.20"
+
 jobs:
 
   markdownlint:
@@ -148,7 +151,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: '**/go.sum'
 
       - name: Set default BUILDER_BIN_PATH
@@ -194,7 +197,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: 'pkg/scripts_test/go.sum'
 
       - name: Run install script tests
@@ -232,7 +235,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: '**/go.sum'
 
       - name: Add opentelemetry-collector-builder installation dir to PATH
@@ -293,7 +296,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: '**/go.sum'
 
       - uses: actions/cache@v3
@@ -360,7 +363,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: '**/go.sum'
 
       - name: Set default BUILDER_BIN_PATH
@@ -435,7 +438,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: '**/go.sum'
 
       - name: Fetch current branch

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -17,6 +17,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  GO_VERSION: "1.20"
+
 jobs:
 
   build:
@@ -42,7 +45,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: '**/go.sum'
 
       - name: Set default BUILDER_BIN_PATH
@@ -125,7 +128,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: ${{ env.GO_VERSION }}
 
       # As described in
       # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
@@ -231,7 +234,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: '**/go.sum'
 
       - name: Fetch current branch

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,14 +8,14 @@ linters-settings:
     check-blank: true
 
   gosimple:
-    go: "1.19"
+    go: "1.20"
 
   maligned:
     # print struct with more effective memory layout or not, false by default
     suggest-new: true
 
   unused:
-    go: "1.19"
+    go: "1.20"
 
   lll:
     # max line length, lines longer will be reported. Default is 120.

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -16,7 +16,7 @@ RUN apt update && apt install -y systemd
 # h stands for dereference of symbolic links
 RUN tar czhf journalctl.tar.gz /bin/journalctl $(ldd /bin/journalctl | grep -oP "\/.*? ")
 
-FROM golang:1.19.9
+FROM golang:1.20.5
 ARG BUILD_TAG=latest
 ENV TAG $BUILD_TAG
 ARG USER_UID=10001

--- a/Dockerfile_local
+++ b/Dockerfile_local
@@ -1,4 +1,4 @@
-FROM golang:1.19.9-alpine as builder
+FROM golang:1.20.5-alpine as builder
 ADD . /src
 WORKDIR /src/otelcolbuilder/
 ENV CGO_ENABLED=0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOLANGCI_LINT_VERSION ?= v1.49
+GOLANGCI_LINT_VERSION ?= v1.53.2
 SHELL := /usr/bin/env bash
 
 ifeq ($(OS),Windows_NT)

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export GO_VERSION="1.19.9"
+export GO_VERSION="1.20.5"
 
 sudo apt update -y
 sudo apt install -y \


### PR DESCRIPTION
Upstream releases are built with 1.20, so we should follow suit. I've also cut down on duplication in the CI while at it.