### PR TITLE
ci: refactor PR and dev workflows

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -48,6 +48,23 @@ jobs:
       - name: Run golangci-lint
         run: make golint
 
+  test:
+    name: Test
+    uses: ./.github/workflows/workflow-test.yml
+    strategy:
+      matrix:
+        include:
+          - arch_os: linux_amd64
+            runs-on: ubuntu-20.04
+          - arch_os: darwin_amd64
+            runs-on: macos-latest
+          - arch_os: windows_amd64
+            runs-on: windows-2022
+    with:
+      arch_os: ${{ matrix.arch_os }}
+      runs-on: ${{ matrix.runs-on }}
+      save-cache: true
+
   build:
     name: Build
     runs-on: ${{ matrix.runs_on }}

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -71,6 +71,9 @@ jobs:
         include:
           - arch_os: linux_amd64
             runs-on: ubuntu-20.04
+          - arch_os: linux_amd64
+            runs-on: ubuntu-20.04
+            boringcrypto: true
           - arch_os: darwin_amd64
             runs-on: macos-latest
           - arch_os: windows_amd64
@@ -79,6 +82,7 @@ jobs:
       arch_os: ${{ matrix.arch_os }}
       runs-on: ${{ matrix.runs-on }}
       save-cache: true
+      boringcrypto: ${{ matrix.boringcrypto == true }}
 
   build:
     name: Build

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -25,19 +25,34 @@ jobs:
         arch_os: [ 'linux_amd64' ]
     steps:
       - uses: actions/checkout@v3
+
       - name: Setup go
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
+          cache: false
+
+      - name: Get GOCACHE and GOMODCACHE
+        run: |
+          echo "GOMODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_ENV"
+          echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+
+      - uses: actions/cache/restore@v3
+        with:
+          path: |
+            ${{ env.GOMODCACHE }}/cache
+            ${{ env.GOCACHE }}
+          key: go-test-${{ env.GO_VERSION }}-${{matrix.arch_os}}-${{ hashFiles('pkg/**/go.sum', 'otelcolbuilder/.otelcol-builder.yaml') }}
+          restore-keys: |
+            go-test-${{ env.GO_VERSION }}-${{matrix.arch_os}}-
 
       - uses: actions/cache@v3
         with:
           path: |
             /home/runner/.cache/golangci-lint
-          key: ${{matrix.arch_os}}-golangcilint-${{ hashFiles('**/go.sum') }}
+          key: golangci-lint-${{ env.GO_VERSION }}-${{matrix.arch_os}}-${{ hashFiles('pkg/**/go.sum', 'otelcolbuilder/.otelcol-builder.yaml') }}
           restore-keys: |
-            ${{matrix.arch_os}}-golangcilint-
+            golangci-lint-${{ env.GO_VERSION }}-${{matrix.arch_os}}-
 
       - name: Install golangci-lint
         run: make install-golangci-lint

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -11,7 +11,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: "1.20"
+  GO_VERSION: "1.20.5"
 
 jobs:
 

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -67,78 +67,24 @@ jobs:
 
   build:
     name: Build
-    runs-on: ${{ matrix.runs_on }}
+    uses: ./.github/workflows/workflow-build.yml
     strategy:
       matrix:
         include:
           - arch_os: linux_amd64
-            runs_on: ubuntu-20.04
+            runs-on: ubuntu-20.04
           - arch_os: linux_arm64
-            runs_on: ubuntu-20.04
+            runs-on: ubuntu-20.04
           - arch_os: darwin_amd64
-            runs_on: macos-latest
+            runs-on: macos-latest
           - arch_os: darwin_arm64
-            runs_on: macos-latest
+            runs-on: macos-latest
           - arch_os: windows_amd64
-            runs_on: windows-2022
-            builder_bin_path: '${RUNNER_TEMP}\bin'
-            builder_bin_ext: .exe
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Fetch current branch
-        run: ./ci/fetch_current_branch.sh
-
-      - name: Setup go
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-
-      - name: Set default BUILDER_BIN_PATH
-        run: echo "BUILDER_BIN_PATH=${HOME}/bin" >> $GITHUB_ENV
-
-      - name: Override BUILDER_BIN_PATH if set in matrix
-        run: echo "BUILDER_BIN_PATH=${{matrix.builder_bin_path}}" >> $GITHUB_ENV
-        if: matrix.builder_bin_path != ''
-
-      - name: Add opentelemetry-collector-builder installation dir to PATH
-        run: echo "$BUILDER_BIN_PATH" >> $GITHUB_PATH
-
-      - name: Install opentelemetry-collector-builder
-        run: make install-builder
-        working-directory: ./otelcolbuilder
-
-      - name: Build
-        run: make otelcol-sumo-${{matrix.arch_os}}
-        working-directory: ./otelcolbuilder
-
-      - name: Show included modules
-        working-directory: ./otelcolbuilder/cmd
-        run: |
-          go version -m otelcol-sumo-${{matrix.arch_os}}${{matrix.builder_bin_ext}} | \
-          grep -E "/(receiver|exporter|processor|extension)/" | \
-          tee otelcol-sumo-${{matrix.arch_os}}_modules.txt
-
-      # TODO:
-      # Move that out to a separate job and run on a corresponding's OS runner.
-      # - name: Run the binary
-      #   run: ./otelcol-sumo-${{matrix.arch_os}} --version
-      #   working-directory: ./otelcolbuilder/cmd/
-
-      - name: Store binary as action artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: otelcol-sumo-${{matrix.arch_os}}
-          path: ./otelcolbuilder/cmd/otelcol-sumo-${{matrix.arch_os}}${{matrix.builder_bin_ext}}
-          if-no-files-found: error
-
-      - name: Store list of included modules as action artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: otelcol-sumo-${{matrix.arch_os}}_modules.txt
-          path: ./otelcolbuilder/cmd/otelcol-sumo-${{matrix.arch_os}}_modules.txt
-          if-no-files-found: error
+            runs-on: windows-2022
+    with:
+      arch_os: ${{ matrix.arch_os }}
+      runs-on: ${{ matrix.runs-on }}
+      save-cache: true
 
   # pipeline to build FIPS compliance binary on Go+BoringCrypto
   build-fips:

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -73,6 +73,9 @@ jobs:
         include:
           - arch_os: linux_amd64
             runs-on: ubuntu-20.04
+          - arch_os: linux_amd64
+            runs-on: ubuntu-20.04
+            fips: true
           - arch_os: linux_arm64
             runs-on: ubuntu-20.04
           - arch_os: darwin_amd64
@@ -84,83 +87,14 @@ jobs:
     with:
       arch_os: ${{ matrix.arch_os }}
       runs-on: ${{ matrix.runs-on }}
+      fips: ${{ matrix.fips == true }}
       save-cache: true
-
-  # pipeline to build FIPS compliance binary on Go+BoringCrypto
-  build-fips:
-    name: Build
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        arch_os: [ 'linux_amd64']
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup go
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Fetch current branch
-        run: ./ci/fetch_current_branch.sh
-
-      # As described in
-      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
-      - uses: actions/cache@v3
-        with:
-          path: |
-            /home/runner/go/pkg/mod
-            /home/runner/.cache/go-build
-            /Users/runner/go/pkg/mod
-            /Users/runner/Library/Caches/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Add opentelemetry-collector-builder installation dir to PATH
-        run: echo "$HOME/bin" >> $GITHUB_PATH
-
-      - name: Install opentelemetry-collector-builder
-        run: make install-builder
-        working-directory: ./otelcolbuilder
-
-      - name: Build
-        run: make otelcol-sumo-${{matrix.arch_os}} FIPS_SUFFIX="-fips" CGO_ENABLED=1
-        working-directory: ./otelcolbuilder
-
-      - name: Show included modules
-        working-directory: ./otelcolbuilder/cmd
-        run: |
-          go version -m otelcol-sumo-fips-${{matrix.arch_os}} | \
-          grep -E "/(receiver|exporter|processor|extension)/" | \
-          tee otelcol-sumo-fips-${{matrix.arch_os}}_modules.txt
-
-      - name: Show BoringSSL symbols
-        working-directory: ./otelcolbuilder/cmd
-        run: |
-          go tool nm otelcol-sumo-fips-${{matrix.arch_os}} | \
-          grep "_Cfunc__goboringcrypto_"
-
-      - name: Store binary as action artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: otelcol-sumo-fips-${{matrix.arch_os}}
-          path: ./otelcolbuilder/cmd/otelcol-sumo-fips-${{matrix.arch_os}}
-          if-no-files-found: error
-
-      - name: Store list of included modules as action artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: otelcol-sumo-fips-${{matrix.arch_os}}_modules.txt
-          path: ./otelcolbuilder/cmd/otelcol-sumo-fips-${{matrix.arch_os}}_modules.txt
-          if-no-files-found: error
 
   build-container-images:
     name: Build container
     runs-on: ubuntu-20.04
     needs:
       - build
-      - build-fips
     strategy:
       matrix:
         arch_os: [ 'linux_amd64', 'linux_arm64' ]

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -118,57 +118,20 @@ jobs:
 
   test:
     name: Test
-    runs-on: ${{ matrix.runs_on }}
+    uses: ./.github/workflows/workflow-test.yml
     strategy:
       matrix:
         include:
           - arch_os: linux_amd64
-            runs_on: ubuntu-20.04
+            runs-on: ubuntu-20.04
           - arch_os: darwin_amd64
-            runs_on: macos-latest
+            runs-on: macos-latest
           - arch_os: windows_amd64
-            runs_on: windows-2022
-            builder_bin_path: '${RUNNER_TEMP}\bin'
-            builder_bin_ext: .exe
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Check if test related files changed
-        id: changed-files
-        uses: tj-actions/changed-files@v35
-        with:
-          files: |
-            **/go.mod
-            **/go.sum
-            **/*.go
-            **/*.yaml
-            **/*.yml
-            **/Makefile
-            **/Makefile.common
-            scripts/install.sh
-
-      - name: Setup go
-        if: steps.changed-files.outputs.any_changed == 'true'
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-
-      - name: Set default BUILDER_BIN_PATH
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: echo "BUILDER_BIN_PATH=${HOME}/bin" >> $GITHUB_ENV
-
-      - name: Override BUILDER_BIN_PATH if set in matrix
-        if: matrix.builder_bin_path != '' && steps.changed-files.outputs.any_changed == 'true'
-        run: echo "BUILDER_BIN_PATH=${{matrix.builder_bin_path}}" >> $GITHUB_ENV
-
-      - name: Add opentelemetry-collector-builder installation dir to PATH
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: echo "$BUILDER_BIN_PATH" >> $GITHUB_PATH
-
-      - name: Run package tests
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: make gotest
+            runs-on: windows-2022
+    with:
+      arch_os: ${{ matrix.arch_os }}
+      runs-on: ${{ matrix.runs-on }}
+      only-if-changed: true
 
   test-install-script:
     name: Test Install Script

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -124,6 +124,9 @@ jobs:
         include:
           - arch_os: linux_amd64
             runs-on: ubuntu-20.04
+          - arch_os: linux_amd64
+            runs-on: ubuntu-20.04
+            boringcrypto: true
           - arch_os: darwin_amd64
             runs-on: macos-latest
           - arch_os: windows_amd64
@@ -132,6 +135,7 @@ jobs:
       arch_os: ${{ matrix.arch_os }}
       runs-on: ${{ matrix.runs-on }}
       only-if-changed: true
+      boringcrypto: ${{ matrix.boringcrypto == true }}
 
   test-install-script:
     name: Test Install Script
@@ -166,48 +170,6 @@ jobs:
       - name: Run install script tests
         if: steps.changed-files.outputs.any_changed == 'true'
         run: make test-install-script
-
-
-  # pipeline to test using Go+BoringCrypto
-  test-go-boringcrypto:
-    name: Test BoringCrypto
-    runs-on: ${{ matrix.runs_on }}
-    strategy:
-      matrix:
-        include:
-          - arch_os: linux_amd64
-            runs_on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Check if test related files changed
-        id: changed-files
-        uses: tj-actions/changed-files@v35
-        with:
-          files: |
-            **/go.mod
-            **/go.sum
-            **/*.go
-            **/*.yaml
-            **/*.yml
-            **/Makefile
-            **/Makefile.common
-            scripts/install.sh
-
-      - name: Setup go
-        if: steps.changed-files.outputs.any_changed == 'true'
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-
-      - name: Add opentelemetry-collector-builder installation dir to PATH
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: echo "$HOME/bin" >> $GITHUB_PATH
-
-      - name: Run tests
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: make gotest CGO_ENABLED=1 GOEXPERIMENT=boringcrypto
 
   test-wixext:
     name: Test (SumoLogic.wixext)

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -10,7 +10,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: "1.20"
+  GO_VERSION: "1.20.5"
 
 jobs:
 

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -285,91 +285,24 @@ jobs:
 
   build:
     name: Build
-    runs-on: ${{ matrix.runs_on }}
+    uses: ./.github/workflows/workflow-build.yml
     strategy:
       matrix:
         include:
           - arch_os: linux_amd64
-            runs_on: ubuntu-20.04
+            runs-on: ubuntu-20.04
           - arch_os: linux_arm64
-            runs_on: ubuntu-20.04
+            runs-on: ubuntu-20.04
           - arch_os: darwin_amd64
-            runs_on: macos-latest
+            runs-on: macos-latest
           - arch_os: darwin_arm64
-            runs_on: macos-latest
+            runs-on: macos-latest
           - arch_os: windows_amd64
-            runs_on: windows-2022
-            builder_bin_path: '${RUNNER_TEMP}\bin'
-            builder_bin_ext: .exe
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Check if build related files changed
-        id: changed-files
-        uses: tj-actions/changed-files@v35
-        with:
-          files: |
-            otelcolbuilder/.gon_config.json
-            **/go.mod
-            **/go.sum
-            **/*.go
-            **/*.yaml
-            **/*.yml
-            **/Makefile
-            **/Makefile.common
-            **/Dockerfile*
-
-      - name: Fetch current branch
-        run: ./ci/fetch_current_branch.sh
-
-      - name: Setup go
-        if: steps.changed-files.outputs.any_changed == 'true'
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-
-      - name: Set default BUILDER_BIN_PATH
-        run: echo "BUILDER_BIN_PATH=${HOME}/bin" >> $GITHUB_ENV
-
-      - name: Override BUILDER_BIN_PATH if set in matrix
-        run: echo "BUILDER_BIN_PATH=${{matrix.builder_bin_path}}" >> $GITHUB_ENV
-        if: matrix.builder_bin_path != ''
-
-      - name: Add opentelemetry-collector-builder installation dir to PATH
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: echo "$BUILDER_BIN_PATH" >> $GITHUB_PATH
-
-      - name: Install opentelemetry-collector-builder
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: make install-builder
-        working-directory: ./otelcolbuilder
-
-      - name: Build
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: make otelcol-sumo-${{matrix.arch_os}}
-        working-directory: ./otelcolbuilder
-
-      # TODO:
-      # Move that out to a separate job and run on a corresponding's OS runner.
-      # - name: Run the binary
-      #   run: ./otelcol-sumo-${{matrix.arch_os}} --version
-      #   working-directory: ./otelcolbuilder/cmd/
-
-      - name: Show included modules
-        if: steps.changed-files.outputs.any_changed == 'true'
-        working-directory: ./otelcolbuilder/cmd
-        run: |
-          go version -m otelcol-sumo-${{matrix.arch_os}}${{matrix.builder_bin_ext}} | \
-          grep -E "/(receiver|exporter|processor|extension)/"
-
-      - name: Store binary as action artifact
-        if: steps.changed-files.outputs.any_changed == 'true'
-        uses: actions/upload-artifact@v3
-        with:
-          name: otelcol-sumo-${{matrix.arch_os}}
-          path: ./otelcolbuilder/cmd/otelcol-sumo-${{matrix.arch_os}}${{matrix.builder_bin_ext}}
-          if-no-files-found: error
+            runs-on: windows-2022
+    with:
+      arch_os: ${{ matrix.arch_os }}
+      runs-on: ${{ matrix.runs-on }}
+      only-if-changed: true
 
   # pipeline to build FIPS compliance binary on Go+BoringCrypto for linux
   build-fips:

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -291,6 +291,9 @@ jobs:
         include:
           - arch_os: linux_amd64
             runs-on: ubuntu-20.04
+          - arch_os: linux_amd64
+            runs-on: ubuntu-20.04
+            fips: true
           - arch_os: linux_arm64
             runs-on: ubuntu-20.04
           - arch_os: darwin_amd64
@@ -302,86 +305,14 @@ jobs:
     with:
       arch_os: ${{ matrix.arch_os }}
       runs-on: ${{ matrix.runs-on }}
+      fips: ${{ matrix.fips == true }}
       only-if-changed: true
-
-  # pipeline to build FIPS compliance binary on Go+BoringCrypto for linux
-  build-fips:
-    name: Build
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        arch_os: [ 'linux_amd64']
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Check if build related files changed
-        id: changed-files
-        uses: tj-actions/changed-files@v35
-        with:
-          files: |
-            otelcolbuilder/.gon_config.json
-            **/go.mod
-            **/go.sum
-            **/*.go
-            **/*.yaml
-            **/*.yml
-            **/Makefile
-            **/Makefile.common
-            **/Dockerfile*
-
-      - name: Setup go
-        if: steps.changed-files.outputs.any_changed == 'true'
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-
-      - name: Fetch current branch
-        run: ./ci/fetch_current_branch.sh
-
-      - name: Add opentelemetry-collector-builder installation dir to PATH
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: echo "$HOME/bin" >> $GITHUB_PATH
-
-      - name: Install opentelemetry-collector-builder
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: make install-builder
-        working-directory: ./otelcolbuilder
-
-      - name: Build
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: make otelcol-sumo-${{matrix.arch_os}} FIPS_SUFFIX="-fips" CGO_ENABLED=1
-        working-directory: ./otelcolbuilder
-
-      - name: Show included modules
-        if: steps.changed-files.outputs.any_changed == 'true'
-        working-directory: ./otelcolbuilder/cmd
-        run: |
-          go version -m otelcol-sumo-fips-${{matrix.arch_os}} | \
-          grep -E "/(receiver|exporter|processor|extension)/"
-
-      - name: Show BoringSSL symbols
-        if: steps.changed-files.outputs.any_changed == 'true'
-        working-directory: ./otelcolbuilder/cmd
-        run: |
-          go tool nm otelcol-sumo-fips-${{matrix.arch_os}} | \
-          grep "_Cfunc__goboringcrypto_"
-
-      - name: Store binary as action artifact
-        if: steps.changed-files.outputs.any_changed == 'true'
-        uses: actions/upload-artifact@v3
-        with:
-          name: otelcol-sumo-fips-${{matrix.arch_os}}
-          path: ./otelcolbuilder/cmd/otelcol-sumo-fips-${{matrix.arch_os}}
-          if-no-files-found: error
 
   build-and-test-container-images:
     name: Build container
     runs-on: ubuntu-20.04
     needs:
       - build
-      - build-fips
     strategy:
       matrix:
         arch_os: [ 'linux_amd64', 'linux_arm64']

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -260,16 +260,31 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
+          cache: false
 
-      - uses: actions/cache@v3
+      - name: Get GOCACHE and GOMODCACHE
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          echo "GOMODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_ENV"
+          echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+
+      - uses: actions/cache/restore@v3
         if: steps.changed-files.outputs.any_changed == 'true'
         with:
           path: |
-            /home/runner/.cache/golangci-lint
-          key: ${{matrix.arch_os}}-golangcilint-${{ hashFiles('**/go.sum') }}
+            ${{ env.GOMODCACHE }}/cache
+            ${{ env.GOCACHE }}
+          key: go-test-${{ env.GO_VERSION }}-${{matrix.arch_os}}-${{ hashFiles('pkg/**/go.sum', 'otelcolbuilder/.otelcol-builder.yaml') }}
           restore-keys: |
-            ${{matrix.arch_os}}-golangcilint-
+            go-test-${{ env.GO_VERSION }}-${{matrix.arch_os}}-
+
+      - uses: actions/cache/restore@v3
+        with:
+          path: |
+            /home/runner/.cache/golangci-lint
+          key: golangci-lint-${{ env.GO_VERSION }}-${{matrix.arch_os}}-${{ hashFiles('pkg/**/go.sum', 'otelcolbuilder/.otelcol-builder.yaml') }}
+          restore-keys: |
+            golangci-lint-${{ env.GO_VERSION }}-${{matrix.arch_os}}-
 
       - name: Install golangci-lint
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -18,7 +18,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: "1.20"
+  GO_VERSION: "1.20.5"
 
 jobs:
 

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -7,6 +7,10 @@ on:
         description: Architecture and OS in the form "{arch}_{os}". See GOARCH and GOOS for accepted values.
         default: linux_amd64
         type: string
+      fips:
+        description: Build binary with FIPS support
+        default: false
+        type: boolean
       runs-on:
         default: ubuntu-20.04
         type: string
@@ -32,6 +36,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     env:
       OTELCOL_BINARY_EXTENSION: ${{ contains(inputs.arch_os, 'windows') && '.exe' || '' }}
+      OTELCOL_FIPS_SUFFIX: ${{ inputs.fips && '-fips' || '' }}
     steps:
       - uses: actions/checkout@v3
 
@@ -71,8 +76,8 @@ jobs:
         id: get-cache-key
         if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
         run: |
-          echo "cache-key=go-build-${{ env.GO_VERSION }}-${{inputs.arch_os}}${OTELCOL_FIPS_SUFFIX}-${{ hashFiles('pkg/**/go.sum', 'otelcolbuilder/.otelcol-builder.yaml') }}" >> $GITHUB_OUTPUT
-          echo "restore-keys=go-build-${{ env.GO_VERSION }}-${{inputs.arch_os}}${OTELCOL_FIPS_SUFFIX}-" >> $GITHUB_OUTPUT
+          echo "cache-key=go-build-${{ env.GO_VERSION }}${OTELCOL_FIPS_SUFFIX}-${{inputs.arch_os}}-${{ hashFiles('pkg/**/go.sum', 'otelcolbuilder/.otelcol-builder.yaml') }}" >> $GITHUB_OUTPUT
+          echo "restore-keys=go-build-${{ env.GO_VERSION }}${OTELCOL_FIPS_SUFFIX}-${{inputs.arch_os}}-" >> $GITHUB_OUTPUT
 
       - uses: actions/cache/restore@v3
         if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
@@ -99,20 +104,28 @@ jobs:
 
       - name: Build
         if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
-        run: make otelcol-sumo-${{inputs.arch_os}}
+        run: make otelcol-sumo-${{inputs.arch_os}}${{ inputs.fips && ' FIPS_SUFFIX="$OTELCOL_FIPS_SUFFIX" CGO_ENABLED=1' || '' }}
         working-directory: ./otelcolbuilder
 
       - name: Set binary name
         id: set-binary-name
         if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
-        run: echo "binary_name=otelcol-sumo-${{inputs.arch_os}}${OTELCOL_BINARY_EXTENSION}" >> $GITHUB_OUTPUT
+        run: echo "binary_name=otelcol-sumo${OTELCOL_FIPS_SUFFIX}-${{inputs.arch_os}}${OTELCOL_BINARY_EXTENSION}" >> $GITHUB_OUTPUT
 
       - name: Show included modules
         if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
         working-directory: ./otelcolbuilder/cmd
         run: |
           go version -m ${{ steps.set-binary-name.outputs.binary_name }} | \
-          grep -E "/(receiver|exporter|processor|extension)/"
+          grep -E "/(receiver|exporter|processor|extension)/" | \
+          tee ${{ steps.set-binary-name.outputs.binary_name }}_modules.txt
+
+      - name: Show BoringSSL symbols
+        if: ${{ inputs.fips && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
+        working-directory: ./otelcolbuilder/cmd
+        run: |
+          go tool nm ${{ steps.set-binary-name.outputs.binary_name }} | \
+          grep "_Cfunc__goboringcrypto_"
 
       - name: Store binary as action artifact
         if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
@@ -120,6 +133,14 @@ jobs:
         with:
           name: ${{ steps.set-binary-name.outputs.binary_name }}
           path: ./otelcolbuilder/cmd/${{ steps.set-binary-name.outputs.binary_name }}
+          if-no-files-found: error
+
+      - name: Store list of included modules as action artifact
+        if: ${{ inputs.fips && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.set-binary-name.outputs.binary_name }}_modules.txt
+          path: ./otelcolbuilder/cmd/${{ steps.set-binary-name.outputs.binary_name }}_modules.txt
           if-no-files-found: error
 
       - uses: actions/cache/save@v3

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -1,0 +1,131 @@
+name: Build Otelcol
+
+on:
+  workflow_call:
+    inputs:
+      arch_os:
+        description: Architecture and OS in the form "{arch}_{os}". See GOARCH and GOOS for accepted values.
+        default: linux_amd64
+        type: string
+      runs-on:
+        default: ubuntu-20.04
+        type: string
+      only-if-changed:
+        description: Run only if relevant files changed.
+        default: false
+        type: boolean
+      save-cache:
+        description: Save the module and build caches.
+        default: false
+        type: boolean
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  GO_VERSION: "1.20.5"
+
+jobs:
+  build:
+    name: Build
+    runs-on: ${{ inputs.runs-on }}
+    env:
+      OTELCOL_BINARY_EXTENSION: ${{ contains(inputs.arch_os, 'windows') && '.exe' || '' }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check if build related files changed
+        id: changed-files
+        uses: tj-actions/changed-files@v35
+        with:
+          files: |
+            otelcolbuilder/.gon_config.json
+            **/go.mod
+            **/go.sum
+            **/*.go
+            **/*.yaml
+            **/*.yml
+            **/Makefile
+            **/Makefile.common
+            **/Dockerfile*
+
+      - name: Fetch current branch
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: ./ci/fetch_current_branch.sh
+
+      - name: Setup go
+        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+
+      - name: Get GOCACHE and GOMODCACHE
+        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        run: |
+          echo "GOMODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_ENV"
+          echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+
+      - name: Get cache key
+        id: get-cache-key
+        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        run: |
+          echo "cache-key=go-build-${{ env.GO_VERSION }}-${{inputs.arch_os}}${OTELCOL_FIPS_SUFFIX}-${{ hashFiles('pkg/**/go.sum', 'otelcolbuilder/.otelcol-builder.yaml') }}" >> $GITHUB_OUTPUT
+          echo "restore-keys=go-build-${{ env.GO_VERSION }}-${{inputs.arch_os}}${OTELCOL_FIPS_SUFFIX}-" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache/restore@v3
+        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        with:
+          path: |
+            ${{ env.GOMODCACHE }}/cache
+            ${{ env.GOCACHE }}
+          key: ${{ steps.get-cache-key.outputs.cache-key }}
+          restore-keys: |
+            ${{ steps.get-cache-key.outputs.restore-keys }}
+
+      - name: Set default BUILDER_BIN_PATH
+        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        run: echo "BUILDER_BIN_PATH=${HOME}/bin" >> $GITHUB_ENV
+
+      - name: Add opentelemetry-collector-builder installation dir to PATH
+        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        run: echo "$BUILDER_BIN_PATH" >> $GITHUB_PATH
+
+      - name: Install opentelemetry-collector-builder
+        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        run: make install-builder
+        working-directory: ./otelcolbuilder
+
+      - name: Build
+        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        run: make otelcol-sumo-${{inputs.arch_os}}
+        working-directory: ./otelcolbuilder
+
+      - name: Set binary name
+        id: set-binary-name
+        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        run: echo "binary_name=otelcol-sumo-${{inputs.arch_os}}${OTELCOL_BINARY_EXTENSION}" >> $GITHUB_OUTPUT
+
+      - name: Show included modules
+        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        working-directory: ./otelcolbuilder/cmd
+        run: |
+          go version -m ${{ steps.set-binary-name.outputs.binary_name }} | \
+          grep -E "/(receiver|exporter|processor|extension)/"
+
+      - name: Store binary as action artifact
+        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.set-binary-name.outputs.binary_name }}
+          path: ./otelcolbuilder/cmd/${{ steps.set-binary-name.outputs.binary_name }}
+          if-no-files-found: error
+
+      - uses: actions/cache/save@v3
+        if: ${{ inputs.save-cache && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
+        with:
+          path: |
+            ${{ env.GOMODCACHE }}/cache
+            ${{ env.GOCACHE }}
+          key: ${{ steps.get-cache-key.outputs.cache-key }}

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -7,6 +7,10 @@ on:
         description: Architecture and OS in the form "{arch}_{os}". See GOARCH and GOOS for accepted values.
         default: linux_amd64
         type: string
+      boringcrypto:
+        description: Run with BoringCrypto enabled
+        default: false
+        type: boolean
       runs-on:
         default: ubuntu-20.04
         type: string
@@ -30,6 +34,8 @@ jobs:
   test:
     name: Test
     runs-on: ${{ inputs.runs-on }}
+    env:
+      BORINGCRYPTO_SUFFIX: ${{ inputs.boringcrypto && '-boringcrypto' || '' }}
     steps:
       - uses: actions/checkout@v3
 
@@ -64,8 +70,8 @@ jobs:
         id: get-cache-key
         if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
         run: |
-          echo "cache-key=go-test-${{ env.GO_VERSION }}-${{inputs.arch_os}}${BORINGCRYPTO_SUFFIX}-${{ hashFiles('pkg/**/go.sum', 'otelcolbuilder/.otelcol-builder.yaml') }}" >> $GITHUB_OUTPUT
-          echo "restore-keys=go-test-${{ env.GO_VERSION }}-${{inputs.arch_os}}${BORINGCRYPTO_SUFFIX}-" >> $GITHUB_OUTPUT
+          echo "cache-key=go-test-${{ env.GO_VERSION }}${BORINGCRYPTO_SUFFIX}-${{inputs.arch_os}}-${{ hashFiles('pkg/**/go.sum', 'otelcolbuilder/.otelcol-builder.yaml') }}" >> $GITHUB_OUTPUT
+          echo "restore-keys=go-test-${{ env.GO_VERSION }}${BORINGCRYPTO_SUFFIX}-${{inputs.arch_os}}-" >> $GITHUB_OUTPUT
 
       - uses: actions/cache/restore@v3
         if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
@@ -87,7 +93,7 @@ jobs:
 
       - name: Run package tests
         if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
-        run: make gotest
+        run: make gotest ${{ inputs.boringcrypto && 'CGO_ENABLED=1 GOEXPERIMENT=boringcrypto' || '' }}
 
       - uses: actions/cache/save@v3
         if: ${{ inputs.save-cache && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -1,0 +1,98 @@
+name: Run tests
+
+on:
+  workflow_call:
+    inputs:
+      arch_os:
+        description: Architecture and OS in the form "{arch}_{os}". See GOARCH and GOOS for accepted values.
+        default: linux_amd64
+        type: string
+      runs-on:
+        default: ubuntu-20.04
+        type: string
+      only-if-changed:
+        description: Run only if relevant files changed.
+        default: false
+        type: boolean
+      save-cache:
+        description: Save the module and build caches.
+        default: false
+        type: boolean
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  GO_VERSION: "1.20.5"
+
+jobs:
+  test:
+    name: Test
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check if test related files changed
+        id: changed-files
+        uses: tj-actions/changed-files@v35
+        with:
+          files: |
+            **/go.mod
+            **/go.sum
+            **/*.go
+            **/*.yaml
+            **/*.yml
+            **/Makefile
+            **/Makefile.common
+            scripts/install.sh
+
+      - name: Setup go
+        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+
+      - name: Get GOCACHE and GOMODCACHE
+        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        run: |
+          echo "GOMODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_ENV"
+          echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+
+      - name: Get cache key
+        id: get-cache-key
+        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        run: |
+          echo "cache-key=go-test-${{ env.GO_VERSION }}-${{inputs.arch_os}}${BORINGCRYPTO_SUFFIX}-${{ hashFiles('pkg/**/go.sum', 'otelcolbuilder/.otelcol-builder.yaml') }}" >> $GITHUB_OUTPUT
+          echo "restore-keys=go-test-${{ env.GO_VERSION }}-${{inputs.arch_os}}${BORINGCRYPTO_SUFFIX}-" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache/restore@v3
+        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        with:
+          path: |
+            ${{ env.GOMODCACHE }}/cache
+            ${{ env.GOCACHE }}
+          key: ${{ steps.get-cache-key.outputs.cache-key }}
+          restore-keys: |
+            ${{ steps.get-cache-key.outputs.restore-keys }}
+
+      - name: Set default BUILDER_BIN_PATH
+        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        run: echo "BUILDER_BIN_PATH=${HOME}/bin" >> $GITHUB_ENV
+
+      - name: Add opentelemetry-collector-builder installation dir to PATH
+        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        run: echo "$BUILDER_BIN_PATH" >> $GITHUB_PATH
+
+      - name: Run package tests
+        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        run: make gotest
+
+      - uses: actions/cache/save@v3
+        if: ${{ inputs.save-cache && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
+        with:
+          path: |
+            ${{ env.GOMODCACHE }}/cache
+            ${{ env.GOCACHE }}
+          key: ${{ steps.get-cache-key.outputs.cache-key }}


### PR DESCRIPTION
This PR adds reusable workflows for building otel binaries and running tests. It also makes some changes to behaviour relative to the current state.

Caching now works differently. We still have a separate cache per OS and architecture, but the cache is only ever saved on `main`, and branches just use it. This is to cut down on unnecessary branch caches, which is especially important now that we also save the build cache, which significantly speeds up execution.

For this reason, we now always run tests on main - we need to build the test cache for branches.

I've left the release workflow alone for now, as it might need to be refactored further to use the new build workflow, and I didn't want to make this PR more complicated than it already is. It might be easier to review commit-by-commit.

The end result is CI executions for PRs taking 40-50% less time. See https://github.com/swiatekm-sumo/sumologic-otel-collector/pull/6. In general, that repo has all the changes in main, so they've all been tested.