### PR TITLE
fix(build): allow otel commands to be used

### DIFF
--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -66,11 +66,14 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
 
-      - name: Get GOCACHE and GOMODCACHE
+      - name: Get Go env values
         if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           echo "GOMODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_ENV"
           echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+          echo "GOARCH=$(go env GOARCH)" >> "$GITHUB_ENV"
+          echo "GOOS=$(go env GOOS)" >> "$GITHUB_ENV"
+          echo "ARCH_OS=$(go env GOOS)_$(go env GOARCH)" >> $GITHUB_ENV
 
       - name: Get cache key
         id: get-cache-key
@@ -126,6 +129,14 @@ jobs:
         run: |
           go tool nm ${{ steps.set-binary-name.outputs.binary_name }} | \
           grep "_Cfunc__goboringcrypto_"
+
+      - name: Test binary
+        if: ${{ (inputs.arch_os == env.ARCH_OS) && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
+        working-directory: ./otelcolbuilder/cmd
+        run: |
+          ./${{ steps.set-binary-name.outputs.binary_name }} help
+          ./${{ steps.set-binary-name.outputs.binary_name }} components
+          ./${{ steps.set-binary-name.outputs.binary_name }} completion bash
 
       - name: Store binary as action artifact
         if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - fix(sumologicexporter): don't send empty attributes [#1174]
+- fix(build): allow otel commands to be used [#1180]
 
 [#1167]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1167
 [#1169]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1169
 [#1174]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1174
+[#1180]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1180
 
 [unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.79.0-sumo-0...main
 

--- a/otelcolbuilder/cmd/configprovider.go
+++ b/otelcolbuilder/cmd/configprovider.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -61,7 +60,9 @@ func UseCustomConfigProvider(params *otelcol.CollectorSettings) error {
 
 	locations := getConfigFlag(flagset)
 	if len(locations) == 0 {
-		return errors.New("at least one config flag must be provided")
+		// if no locations, use defaults
+		// either this is a command, or the default provider will throw an error
+		return nil
 	}
 
 	// create the config provider using the locations


### PR DESCRIPTION
Due to our config provider override, we were exiting with an error when using built-in commands like `components`. Fix this. 