### PR TITLE
chore(packaging): wix 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- chore(packaging): wix 4.0.1 [#1184]
+
+[#1184]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1184
+
 ## [v0.80.0-sumo-0]
 
 ### Released 2023-06-30

--- a/packaging/msi/SumoLogic.wixext/SumoLogic.wixext/SumoLogic.wixext.csproj
+++ b/packaging/msi/SumoLogic.wixext/SumoLogic.wixext/SumoLogic.wixext.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="WixToolset.Dtf.CustomAction" Version="4.0.0-preview.1" />
+    <PackageReference Include="WixToolset.Dtf.CustomAction" Version="4.0.1" />
     <PackageReference Include="YamlDotNet" Version="12.0.2" />
   </ItemGroup>
 

--- a/packaging/msi/wix/folders.wxs
+++ b/packaging/msi/wix/folders.wxs
@@ -3,19 +3,23 @@
   <?include variables.wxi ?>
 
   <Fragment>
-    <StandardDirectory Id="$(PlatformProgramFilesFolder)">
-      <Directory Id="INSTALLFOLDER" Name="!(bind.Property.Manufacturer)\!(bind.Property.ProductName)">
-        <Directory Id="BinFolder" Name="bin" />
+    <StandardDirectory Id="ProgramFiles6432Folder">
+      <Directory Id="CompanyFolder" Name="!(bind.Property.Manufacturer)">
+        <Directory Id="INSTALLFOLDER" Name="!(bind.Property.ProductName)">
+          <Directory Id="BinFolder" Name="bin" />
+        </Directory>
       </Directory>
     </StandardDirectory>
 
     <StandardDirectory Id="CommonAppDataFolder">
-      <Directory Id="APPDATAFOLDER" Name="!(bind.Property.Manufacturer)\!(bind.Property.ProductName)">
-        <Directory Id="ConfigFolder" Name="config">
-          <Directory Id="ConfigFragmentsFolder" Name="conf.d" />
-        </Directory>
-        <Directory Id="DataFolder" Name="data">
-          <Directory Id="FileStorageFolder" Name="file_storage" />
+      <Directory Id="CompanyAppDataFolder" Name="!(bind.Property.Manufacturer)">
+        <Directory Id="APPDATAFOLDER" Name="!(bind.Property.ProductName)">
+          <Directory Id="ConfigFolder" Name="config">
+            <Directory Id="ConfigFragmentsFolder" Name="conf.d" />
+          </Directory>
+          <Directory Id="DataFolder" Name="data">
+            <Directory Id="FileStorageFolder" Name="file_storage" />
+          </Directory>
         </Directory>
       </Directory>
     </StandardDirectory>

--- a/packaging/msi/wix/otelcol-sumo.wixproj
+++ b/packaging/msi/wix/otelcol-sumo.wixproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="WixToolset.Sdk/4.0.0-preview.1" InitialTargets="PlatformCheck">
+<Project Sdk="WixToolset.Sdk/4.0.1" InitialTargets="PlatformCheck">
   <PropertyGroup>
     <ProductVersion>1.0.0.0</ProductVersion>
     <ProjectGuid>25ec8859-fe5e-4110-a6e4-915b6ed83072</ProjectGuid>
@@ -37,8 +37,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="WixToolset.Netfx.wixext" Version="4.0.0-preview.1" />
-    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0-preview.1" />
+    <PackageReference Include="WixToolset.Netfx.wixext" Version="4.0.1" />
+    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.1" />
   </ItemGroup>
 
   <!-- <PropertyGroup Condition="'$(Platform)' == 'arm64'"> -->

--- a/packaging/msi/wix/ui/otelcol-sumo.wxs
+++ b/packaging/msi/wix/ui/otelcol-sumo.wxs
@@ -5,8 +5,9 @@
   See http://opensource.org/licenses/ms-rl for full license information.
 -->
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<?foreach WIXUIARCH in X86;X64;A64 ?>
     <Fragment>
-        <UI Id="WixUI_OtelcolSumo">
+        <UI Id="WixUI_OtelcolSumo_$(WIXUIARCH)">
             <TextStyle Id="WixUI_Font_Normal" FaceName="Tahoma" Size="8" />
             <TextStyle Id="WixUI_Font_Bigger" FaceName="Tahoma" Size="12" />
             <TextStyle Id="WixUI_Font_Title" FaceName="Tahoma" Size="9" Bold="yes" />
@@ -29,11 +30,12 @@
             <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Condition="Installed AND PATCH" />
 
             <Publish Dialog="LicenseAgreementDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" />
+            <Publish Dialog="LicenseAgreementDlg" Control="Print" Event="DoAction" Value="WixUIPrintEula_$(WIXUIARCH)" Condition="LicenseAccepted = &quot;1&quot;" />
             <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="CustomizeDlg" Condition="LicenseAccepted = &quot;1&quot;" />
 
             <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="1" Condition="Installed" />
             <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg" Order="2" Condition="NOT Installed" />
-            <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" />
+            <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="ConfigurationDlg" />
 
             <Publish Dialog="ConfigurationDlg" Control="Back" Event="NewDialog" Value="CustomizeDlg" />
             <Publish Dialog="ConfigurationDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" />
@@ -54,4 +56,5 @@
 
         <UIRef Id="WixUI_Common" />
     </Fragment>
+<?endforeach?>
 </Wix>

--- a/packaging/msi/wix/variables.wxi
+++ b/packaging/msi/wix/variables.wxi
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <?if $(sys.BUILDARCH)="arm64" ?>
-    <?define PlatformProgramFilesFolder="ProgramFiles64Folder" ?>
     <?define OtelcolBinary="otelcol-sumo-windows_arm64.exe" ?>
   <?elseif $(sys.BUILDARCH)="x64" ?>
-    <?define PlatformProgramFilesFolder="ProgramFiles64Folder" ?>
     <?define OtelcolBinary="otelcol-sumo-windows_amd64.exe" ?>
   <?elseif $(sys.BUILDARCH)="x86" ?>
-    <?define PlatformProgramFilesFolder="ProgramFilesFolder" ?>
-    <?define OtelcolBinary="otelcol-sumo-windows_arm64.exe" ?>
+    <?define OtelcolBinary="otelcol-sumo-windows_386.exe" ?>
   <?else ?>
     <?error Unsupported BUILDARCH: $(sys.BUILDARCH) ?>
   <?endif ?>


### PR DESCRIPTION
Bumps the WiX toolset version from 4.0.0-preview.1 to 4.0.1.

In order to get this to build I had to update some of our custom WixUI code:
* The UI element's `Id` attribute now requires the platform that the UI is built for.
* The `Print` control for the EULA had no action and did nothing. I've added the proper line to fix it.

I found a few other recommendations and one other bug:
* The `Next` control for the `CustomizeDlg` page was going to `VerifyReadyDlg` instead of `ConfigurationDlg`. This prevented the dialog that asks for the `InstallToken` and `Tags` from appearing unless the  `Back` control was clicked on the `VerifyReadyDlg` page.
* Removed the `PlatformProgramFilesFolder` variable and logic to determine which Program Files directory to use depending on the platform. This is now handled by a new `ProgramFiles6432Folder` built-in to WiX 4.
* Both `INSTALLFOLDER` and `APPDATAFOLDER` directory elements have had the manufacturer name (Sumo Logic) removed from their names. They've been wrapped in a new directory elements that represent the manufacturer name.
* The name of the `OtelcolBinary` value for x86 now uses `386` instead of `arm64`. This will only matter in the event that we ever produce a `windows/386` distribution of the collector.