### PR TITLE
fix: mute more errors when collecting host metrics

### DIFF
--- a/examples/conf.d/linux.yaml
+++ b/examples/conf.d/linux.yaml
@@ -18,6 +18,8 @@ receivers:
       network: null
       paging: null
       process:
+        mute_process_exe_error: true
+        mute_process_io_error: true
         mute_process_name_error: true
         metrics:
           process.threads:

--- a/examples/conf.d/windows.yaml
+++ b/examples/conf.d/windows.yaml
@@ -25,6 +25,8 @@ receivers:
       network: null
       paging: null
       process:
+        mute_process_exe_error: true
+        mute_process_io_error: true
         mute_process_name_error: true
         metrics:
           process.threads:


### PR DESCRIPTION
Use two more configuration properties
to prevent unneeded error logs from the collector.