### PR TITLE
feat(sumologicexporter): add option to decompose OTLP Histograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Released TBD
+
+### Added
+
+- feat(sumologicexporter): add option to decompose OTLP Histograms [#1197]
+
+[#1197]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1197
+[Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.81.0-sumo-0...main
+
 ## [v0.81.0-sumo-0]
 
 ### Released 2023-07-07

--- a/pkg/exporter/sumologicexporter/README.md
+++ b/pkg/exporter/sumologicexporter/README.md
@@ -33,6 +33,11 @@ exporters:
     # NOTE: only `otlp` is supported when used with sumologicextension
     metric_format: {otlp, prometheus}
 
+    # Decompose OTLP Histograms into individual metrics, similar to how they're represented in Prometheus format.
+    # The Sumo OTLP source currently doesn't support Histograms, and they are quietly dropped. This option produces
+    # metrics similar to when metric_format is set to prometheus.
+    decompose_otlp_histograms: {true, false}
+
     # format to use when sending traces to Sumo Logic,
     # currently only otlp is supported
     trace_format: {otlp}

--- a/pkg/exporter/sumologicexporter/config.go
+++ b/pkg/exporter/sumologicexporter/config.go
@@ -50,6 +50,9 @@ type Config struct {
 	// The format of metrics you will be sending, either otlp or prometheus (Default is otlp)
 	MetricFormat MetricFormatType `mapstructure:"metric_format"`
 
+	// Decompose OTLP Histograms into individual metrics, similar to how they're represented in Prometheus format
+	DecomposeOtlpHistograms bool `mapstructure:"decompose_otlp_histograms"`
+
 	// Traces related configuration
 	// The format of traces you will be sending, currently only otlp format is supported
 	TraceFormat TraceFormatType `mapstructure:"trace_format"`

--- a/pkg/exporter/sumologicexporter/otlp.go
+++ b/pkg/exporter/sumologicexporter/otlp.go
@@ -1,0 +1,160 @@
+// Copyright 2023, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sumologicexporter
+
+import (
+	"math"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+// DecomposeHistograms decomposes any histograms present in the metric data into individual Sums and Gauges
+// This is a noop if no Histograms are present, but otherwise makes a copy of the whole structure
+// This exists because Sumo doesn't support OTLP histograms yet, and has the same semantics as the conversion to Prometheus format in prometheus_formatter.go
+func DecomposeHistograms(md pmetric.Metrics) pmetric.Metrics {
+	// short circuit and do nothing if no Histograms are present
+	foundHistogram := false
+outer:
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		resourceMetric := md.ResourceMetrics().At(i)
+		for j := 0; j < resourceMetric.ScopeMetrics().Len(); j++ {
+			scopeMetric := resourceMetric.ScopeMetrics().At(j)
+			for k := 0; k < scopeMetric.Metrics().Len(); k++ {
+				foundHistogram = scopeMetric.Metrics().At(k).Type() == pmetric.MetricTypeHistogram
+				if foundHistogram {
+					break outer
+				}
+			}
+		}
+	}
+	if !foundHistogram {
+		return md
+	}
+
+	decomposed := pmetric.NewMetrics()
+	md.CopyTo(decomposed)
+
+	for i := 0; i < decomposed.ResourceMetrics().Len(); i++ {
+		resourceMetric := decomposed.ResourceMetrics().At(i)
+		for j := 0; j < resourceMetric.ScopeMetrics().Len(); j++ {
+			metrics := resourceMetric.ScopeMetrics().At(j).Metrics()
+			for k := 0; k < metrics.Len(); k++ {
+				metric := metrics.At(k)
+				if metric.Type() == pmetric.MetricTypeHistogram {
+					decomposedHistogram := decomposeHistogram(metric)
+					decomposedHistogram.MoveAndAppendTo(metrics)
+				}
+			}
+			metrics.RemoveIf(func(m pmetric.Metric) bool { return m.Type() == pmetric.MetricTypeHistogram })
+		}
+	}
+
+	return decomposed
+}
+
+// decomposeHistogram decomposes a single Histogram metric into individual metrics for count, bucket and sum
+// non-Histograms give an empty slice as output
+func decomposeHistogram(metric pmetric.Metric) pmetric.MetricSlice {
+	output := pmetric.NewMetricSlice()
+	if metric.Type() != pmetric.MetricTypeHistogram {
+		return output
+	}
+
+	getHistogramSumMetric(metric).MoveTo(output.AppendEmpty())
+	getHistogramCountMetric(metric).MoveTo(output.AppendEmpty())
+	getHistogramBucketsMetric(metric).MoveTo(output.AppendEmpty())
+
+	return output
+}
+
+func getHistogramBucketsMetric(metric pmetric.Metric) pmetric.Metric {
+	histogram := metric.Histogram()
+
+	bucketsMetric := pmetric.NewMetric()
+	bucketsMetric.SetName(metric.Name() + "_bucket")
+	bucketsMetric.SetDescription(metric.Description())
+	bucketsMetric.SetUnit(metric.Unit())
+	bucketsMetric.SetEmptyGauge()
+	bucketsDatapoints := bucketsMetric.Gauge().DataPoints()
+
+	for i := 0; i < histogram.DataPoints().Len(); i++ {
+		histogramDataPoint := histogram.DataPoints().At(i)
+		histogramBounds := histogramDataPoint.ExplicitBounds()
+		var cumulative uint64 = 0
+
+		for j := 0; j < histogramBounds.Len(); j++ {
+			bucketDataPoint := bucketsDatapoints.AppendEmpty()
+			bound := histogramBounds.At(j)
+			histogramDataPoint.Attributes().CopyTo(bucketDataPoint.Attributes())
+			bucketDataPoint.Attributes().PutDouble(prometheusLeTag, bound)
+			bucketDataPoint.SetStartTimestamp(histogramDataPoint.StartTimestamp())
+			bucketDataPoint.SetTimestamp(histogramDataPoint.Timestamp())
+			cumulative += histogramDataPoint.BucketCounts().At(j)
+			bucketDataPoint.SetIntValue(int64(cumulative))
+		}
+
+		// need to add one more bucket at +Inf
+		bucketDataPoint := bucketsDatapoints.AppendEmpty()
+		histogramDataPoint.Attributes().CopyTo(bucketDataPoint.Attributes())
+		bucketDataPoint.Attributes().PutDouble(prometheusLeTag, math.Inf(1))
+		bucketDataPoint.SetStartTimestamp(histogramDataPoint.StartTimestamp())
+		bucketDataPoint.SetTimestamp(histogramDataPoint.Timestamp())
+		cumulative += histogramDataPoint.BucketCounts().At(histogramDataPoint.ExplicitBounds().Len())
+		bucketDataPoint.SetIntValue(int64(cumulative))
+	}
+	return bucketsMetric
+}
+
+func getHistogramSumMetric(metric pmetric.Metric) pmetric.Metric {
+	histogram := metric.Histogram()
+
+	sumMetric := pmetric.NewMetric()
+	sumMetric.SetName(metric.Name() + "_sum")
+	sumMetric.SetDescription(metric.Description())
+	sumMetric.SetUnit(metric.Unit())
+	sumMetric.SetEmptyGauge()
+	sumDataPoints := sumMetric.Gauge().DataPoints()
+
+	for i := 0; i < histogram.DataPoints().Len(); i++ {
+		histogramDataPoint := histogram.DataPoints().At(i)
+		sumDataPoint := sumDataPoints.AppendEmpty()
+		histogramDataPoint.Attributes().CopyTo(sumDataPoint.Attributes())
+		sumDataPoint.SetStartTimestamp(histogramDataPoint.StartTimestamp())
+		sumDataPoint.SetTimestamp(histogramDataPoint.Timestamp())
+		sumDataPoint.SetDoubleValue(histogramDataPoint.Sum())
+	}
+	return sumMetric
+}
+
+func getHistogramCountMetric(metric pmetric.Metric) pmetric.Metric {
+	histogram := metric.Histogram()
+
+	countMetric := pmetric.NewMetric()
+	countMetric.SetName(metric.Name() + "_count")
+	countMetric.SetDescription(metric.Description())
+	countMetric.SetUnit(metric.Unit())
+	countMetric.SetEmptyGauge()
+	countDataPoints := countMetric.Gauge().DataPoints()
+
+	for i := 0; i < histogram.DataPoints().Len(); i++ {
+		histogramDataPoint := histogram.DataPoints().At(i)
+		countDataPoint := countDataPoints.AppendEmpty()
+		histogramDataPoint.Attributes().CopyTo(countDataPoint.Attributes())
+		countDataPoint.SetStartTimestamp(histogramDataPoint.StartTimestamp())
+		countDataPoint.SetTimestamp(histogramDataPoint.Timestamp())
+		countDataPoint.SetIntValue(int64(histogramDataPoint.Count()))
+	}
+	return countMetric
+}

--- a/pkg/exporter/sumologicexporter/otlp_test.go
+++ b/pkg/exporter/sumologicexporter/otlp_test.go
@@ -1,0 +1,181 @@
+// Copyright 2023, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sumologicexporter
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+const (
+	timestamp1 = 1618124444.169 * 1e9
+	timestamp2 = 1608424699.186 * 1e9
+)
+
+func TestHistogramDecomposeNoHistogram(t *testing.T) {
+	metric, resourceAttributes := exampleIntGaugeMetric()
+	metrics := pmetric.NewMetrics()
+	resourceAttributes.CopyTo(metrics.ResourceMetrics().AppendEmpty().Resource().Attributes())
+	metric.MoveTo(metrics.ResourceMetrics().At(0).ScopeMetrics().AppendEmpty().Metrics().AppendEmpty())
+	decomposedMetrics := DecomposeHistograms(metrics)
+	assert.Equal(t, metrics, decomposedMetrics)
+}
+
+func TestHistogramDecompose(t *testing.T) {
+	metrics := metricsWithHistogram()
+	decomposedMetrics := DecomposeHistograms(metrics)
+	assert.Equal(t, metrics.ResourceMetrics().At(0).Resource(), decomposedMetrics.ResourceMetrics().At(0).Resource())
+	expectedMetrics := pmetric.NewMetrics()
+	expectedResourceMetric := expectedMetrics.ResourceMetrics().AppendEmpty()
+	metrics.ResourceMetrics().At(0).Resource().Attributes().CopyTo(expectedResourceMetric.Resource().Attributes())
+	expectedMetricSlice := expectedResourceMetric.ScopeMetrics().AppendEmpty().Metrics()
+	addExpectedHistogramSum(expectedMetricSlice)
+	addExpectedHistogramCount(expectedMetricSlice)
+	addExpectedHistogramBuckets(expectedMetricSlice)
+	assert.Equal(t, expectedMetrics, decomposedMetrics)
+}
+
+func metricsWithHistogram() pmetric.Metrics {
+	metrics := pmetric.NewMetrics()
+	resourceMetric := metrics.ResourceMetrics().AppendEmpty()
+	resourceMetric.Resource().Attributes().PutStr("key", "value")
+	scopeMetric := resourceMetric.ScopeMetrics().AppendEmpty()
+	metric := scopeMetric.Metrics().AppendEmpty()
+
+	metric.SetEmptyHistogram()
+	metric.SetUnit("unit")
+	metric.SetName("histogram_metric_double_test")
+	metric.SetDescription("Test histogram metric")
+
+	dp := metric.Histogram().DataPoints().AppendEmpty()
+	dp.Attributes().PutStr("container", "dolor")
+
+	si := pcommon.NewUInt64Slice()
+	si.FromRaw([]uint64{0, 12, 7, 5, 8, 13})
+	si.CopyTo(dp.BucketCounts())
+
+	sf := pcommon.NewFloat64Slice()
+	sf.FromRaw([]float64{0.1, 0.2, 0.5, 0.8, 1})
+	sf.CopyTo(dp.ExplicitBounds())
+
+	dp.SetTimestamp(timestamp1)
+	dp.SetSum(45.6)
+	dp.SetCount(45)
+
+	dp = metric.Histogram().DataPoints().AppendEmpty()
+	dp.Attributes().PutStr("container", "sit")
+
+	si = pcommon.NewUInt64Slice()
+	si.FromRaw([]uint64{0, 10, 1, 1, 4, 6})
+	si.CopyTo(dp.BucketCounts())
+
+	sf = pcommon.NewFloat64Slice()
+	sf.FromRaw([]float64{0.1, 0.2, 0.5, 0.8, 1})
+	sf.CopyTo(dp.ExplicitBounds())
+
+	dp.SetTimestamp(timestamp2)
+	dp.SetSum(54.1)
+	dp.SetCount(22)
+
+	return metrics
+}
+
+func addExpectedHistogramSum(metrics pmetric.MetricSlice) {
+	metric := metrics.AppendEmpty()
+	metric.SetName("histogram_metric_double_test_sum")
+	metric.SetDescription("Test histogram metric")
+	metric.SetUnit("unit")
+	metric.SetEmptyGauge()
+
+	dataPoint := metric.Gauge().DataPoints().AppendEmpty()
+	dataPoint.Attributes().PutStr("container", "dolor")
+	dataPoint.SetTimestamp(timestamp1)
+	dataPoint.SetDoubleValue(45.6)
+
+	dataPoint = metric.Gauge().DataPoints().AppendEmpty()
+	dataPoint.Attributes().PutStr("container", "sit")
+	dataPoint.SetTimestamp(timestamp2)
+	dataPoint.SetDoubleValue(54.1)
+}
+
+func addExpectedHistogramCount(metrics pmetric.MetricSlice) {
+	metric := metrics.AppendEmpty()
+	metric.SetName("histogram_metric_double_test_count")
+	metric.SetDescription("Test histogram metric")
+	metric.SetUnit("unit")
+	metric.SetEmptyGauge()
+
+	dataPoint := metric.Gauge().DataPoints().AppendEmpty()
+	dataPoint.Attributes().PutStr("container", "dolor")
+	dataPoint.SetTimestamp(timestamp1)
+	dataPoint.SetIntValue(45)
+
+	dataPoint = metric.Gauge().DataPoints().AppendEmpty()
+	dataPoint.Attributes().PutStr("container", "sit")
+	dataPoint.SetTimestamp(timestamp2)
+	dataPoint.SetIntValue(22)
+}
+
+func addExpectedHistogramBuckets(metrics pmetric.MetricSlice) {
+	metric := metrics.AppendEmpty()
+	metric.SetName("histogram_metric_double_test_bucket")
+	metric.SetDescription("Test histogram metric")
+	metric.SetUnit("unit")
+	metric.SetEmptyGauge()
+	histogramBuckets := []struct {
+		float64
+		int64
+	}{
+		{0.1, 0},
+		{0.2, 12},
+		{0.5, 19},
+		{0.8, 24},
+		{1, 32},
+		{math.Inf(1), 45},
+	}
+	for _, pair := range histogramBuckets {
+		bound, bucketCount := pair.float64, pair.int64
+		dataPoint := metric.Gauge().DataPoints().AppendEmpty()
+		dataPoint.Attributes().PutStr("container", "dolor")
+		dataPoint.Attributes().PutDouble(prometheusLeTag, bound)
+		dataPoint.SetTimestamp(timestamp1)
+		dataPoint.SetIntValue(bucketCount)
+	}
+
+	histogramBuckets = []struct {
+		float64
+		int64
+	}{
+		{0.1, 0},
+		{0.2, 10},
+		{0.5, 11},
+		{0.8, 12},
+		{1, 16},
+		{math.Inf(1), 22},
+	}
+	for _, pair := range histogramBuckets {
+		bound, bucketCount := pair.float64, pair.int64
+		dataPoint := metric.Gauge().DataPoints().AppendEmpty()
+		dataPoint.Attributes().PutStr("container", "sit")
+		dataPoint.Attributes().PutDouble(prometheusLeTag, bound)
+		dataPoint.SetTimestamp(timestamp2)
+		dataPoint.SetIntValue(bucketCount)
+	}
+
+}

--- a/pkg/exporter/sumologicexporter/sender.go
+++ b/pkg/exporter/sumologicexporter/sender.go
@@ -611,6 +611,9 @@ func (s *sender) sendOTLPMetrics(ctx context.Context, md pmetric.Metrics) error 
 		s.logger.Debug("there are no metrics to send, moving on")
 		return nil
 	}
+	if s.config.DecomposeOtlpHistograms {
+		md = DecomposeHistograms(md)
+	}
 
 	body, err := metricsMarshaler.MarshalMetrics(md)
 	if err != nil {


### PR DESCRIPTION
Sumo doesn't currently support OTLP Histograms. In the interim, we can at least make sure sending a histogram via OTLP and Prometheus gives the same result. We already have the logic for the Prometheus format, and this PR also implements it for OTLP. This comes down to decomposing the Histogram into individual sum, count and bucket metrics.

The behaviour is configurable and disabled by default.