### PR TITLE
chore: remove routing_attributes_to_drop

### DIFF
--- a/.changelog/1201.breaking.txt
+++ b/.changelog/1201.breaking.txt
@@ -1,0 +1,3 @@
+chore: remove routing_attributes_to_drop
+
+This option is duplication of `drop_resource_routing_attribute` of routingprocessor

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -4,7 +4,7 @@
   - [Upgrading to v0.90.0-sumo-1](#upgrading-to-v0900-sumo-1)
     - [Change configuration for `syslogexporter`](#change-configuration-for-syslogexporter)
     - [`sumologic` exporter: deprecate `clear_logs_timestamp`](#sumologic-exporter-deprecate-clear_logs_timestamp)
-    - [Removing `routing_attributes_to_drop` from `sumologic` exporter](#removing-routing_attributes_to_drop-from-sumologic-exporter)
+    - [`sumologic` exporter: remove `routing_attributes_to_drop`](#sumologic-exporter-remove-routing_attributes_to_drop)
   - [Upgrading to v0.89.0-sumo-0](#upgrading-to-v0890-sumo-0)
     - [`remoteobserver` processor: renamed to `remotetap` processor](#remoteobserver-processor-renamed-to-remotetap-processor)
     - [`sumologic` exporter: changed default `timeout` from `5s` to `30s`](#sumologic-exporter-changed-default-timeout-from-5s-to-30s)
@@ -120,7 +120,7 @@ service:
         - transform/clear_logs_timestamp
 ```
 
-### Removing `routing_attributes_to_drop` from `sumologic` exporter
+### `sumologic` exporter: remove `routing_attributes_to_drop`
 
 `routing_attributes_to_drop` has been removed from `sumologic` exporter in favor of `routing` processor's `drop_resource_routing_attribute`.
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -4,6 +4,7 @@
   - [Upgrading to v0.90.0-sumo-1](#upgrading-to-v0900-sumo-1)
     - [Change configuration for `syslogexporter`](#change-configuration-for-syslogexporter)
     - [`sumologic` exporter: deprecate `clear_logs_timestamp`](#sumologic-exporter-deprecate-clear_logs_timestamp)
+    - [Removing `routing_attributes_to_drop` from `sumologic` exporter](#removing-routing_attributes_to_drop-from-sumologic-exporter)
   - [Upgrading to v0.89.0-sumo-0](#upgrading-to-v0890-sumo-0)
     - [`remoteobserver` processor: renamed to `remotetap` processor](#remoteobserver-processor-renamed-to-remotetap-processor)
     - [`sumologic` exporter: changed default `timeout` from `5s` to `30s`](#sumologic-exporter-changed-default-timeout-from-5s-to-30s)
@@ -117,6 +118,47 @@ service:
       processors:
         # - ...
         - transform/clear_logs_timestamp
+```
+
+### Removing `routing_attributes_to_drop` from `sumologic` exporter
+
+`routing_attributes_to_drop` has been removed from `sumologic` exporter in favor of `routing` processor's `drop_resource_routing_attribute`.
+
+To migrate, perform the following steps:
+
+- remove `routing_attributes_to_drop` from `sumologic` exporter
+- add `drop_resource_routing_attribute` to `routing` processor
+
+For example, given the following configuration:
+
+```yaml
+processors:
+  routing:
+    from_attribute: X-Tenant
+    default_exporters:
+    - jaeger
+    table:
+    - value: acme
+      exporters: [jaeger/acme]
+exporters:
+  sumologic:
+    routing_attributes_to_drop: X-Tenant
+```
+
+change it to:
+
+```yaml
+processors:
+  routing:
+    drop_resource_routing_attribute: true
+    from_attribute: X-Tenant
+    default_exporters:
+    - jaeger
+    table:
+    - value: acme
+      exporters: [jaeger/acme]
+exporters:
+  sumologic:
 ```
 
 ## Upgrading to v0.89.0-sumo-0

--- a/pkg/exporter/sumologicexporter/README.md
+++ b/pkg/exporter/sumologicexporter/README.md
@@ -54,14 +54,6 @@ exporters:
     # default = true
     clear_logs_timestamp: {true, false}
 
-    # name of resource attribute which should be dropped for records
-    # this is for attribute used by routing processor
-    # other attributes should be removed by processors in pipelines before
-    # This is workaround for the following issue:
-    # https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7407
-    # default = ``
-    routing_atttribute_to_drop: <routing_atttribute_to_drop>
-
     json_logs:
       # defines which key will be used to attach the log body at.
       # This option affects JSON log format only.

--- a/pkg/exporter/sumologicexporter/config.go
+++ b/pkg/exporter/sumologicexporter/config.go
@@ -60,11 +60,6 @@ type Config struct {
 	// DEPRECATED: The below attributes only exist so we can print a nicer error
 	// message about not supporting them anymore.
 
-	// Attribute used by routingprocessor which should be dropped during data ingestion
-	// This is workaround for the following issue:
-	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7407
-	DropRoutingAttribute string `mapstructure:"routing_atttribute_to_drop"`
-
 	// Sumo specific options
 	// Name of the client
 	Client string `mapstructure:"client"`

--- a/pkg/exporter/sumologicexporter/exporter.go
+++ b/pkg/exporter/sumologicexporter/exporter.go
@@ -225,7 +225,6 @@ func (se *sumologicexporter) pushLogsData(ctx context.Context, ld plog.Logs) err
 	for i := 0; i < rls.Len(); i++ {
 		rl := rls.At(i)
 
-		se.dropRoutingAttribute(rl.Resource().Attributes())
 		currentMetadata := newFields(rl.Resource().Attributes())
 
 		if droppedRecords, err := sdr.sendNonOTLPLogs(ctx, rl, currentMetadata); err != nil {
@@ -285,15 +284,6 @@ func (se *sumologicexporter) pushMetricsData(ctx context.Context, md pmetric.Met
 		se.id,
 	)
 
-	// Transform metrics metadata
-	// this includes dropping the routing attribute and translating attributes
-	rms := md.ResourceMetrics()
-	for i := 0; i < rms.Len(); i++ {
-		rm := rms.At(i)
-
-		se.dropRoutingAttribute(rm.Resource().Attributes())
-	}
-
 	var droppedMetrics pmetric.Metrics
 	var errs []error
 	if sdr.config.MetricFormat == OTLPMetricFormat {
@@ -350,12 +340,6 @@ func (se *sumologicexporter) pushTracesData(ctx context.Context, td ptrace.Trace
 		tracesUrl,
 		se.id,
 	)
-
-	// Drop routing attribute from ResourceSpans
-	rss := td.ResourceSpans()
-	for i := 0; i < rss.Len(); i++ {
-		se.dropRoutingAttribute(rss.At(i).Resource().Attributes())
-	}
 
 	err = sdr.sendTraces(ctx, td)
 	se.handleUnauthorizedErrors(ctx, err)
@@ -485,10 +469,6 @@ func (se *sumologicexporter) getDataURLs() (logs, metrics, traces string) {
 
 func (se *sumologicexporter) shutdown(context.Context) error {
 	return nil
-}
-
-func (se *sumologicexporter) dropRoutingAttribute(attr pcommon.Map) {
-	attr.Remove(se.config.DropRoutingAttribute)
 }
 
 // get the destination url for a given signal type

--- a/pkg/exporter/sumologicexporter/exporter_test.go
+++ b/pkg/exporter/sumologicexporter/exporter_test.go
@@ -641,25 +641,6 @@ func TestPushMetricsInvalidCompressor(t *testing.T) {
 	assert.EqualError(t, err, "failed to initialize compressor: invalid format: invalid")
 }
 
-func TestLogsTextFormatMetadataFilterWithDroppedAttribute(t *testing.T) {
-	test := prepareExporterTest(t, createTestConfig(), []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
-			body := extractBody(t, req)
-			assert.Equal(t, `Example log`, body)
-			assert.Equal(t, "key2=value2", req.Header.Get("X-Sumo-Fields"))
-		},
-	})
-	test.exp.config.LogFormat = TextFormat
-	test.exp.config.DropRoutingAttribute = "key1"
-
-	logs := LogRecordsToLogs(exampleLog())
-	logs.ResourceLogs().At(0).Resource().Attributes().PutStr("key1", "value1")
-	logs.ResourceLogs().At(0).Resource().Attributes().PutStr("key2", "value2")
-
-	err := test.exp.pushLogsData(context.Background(), logs)
-	assert.NoError(t, err)
-}
-
 func TestMetricsPrometheusFormatMetadataFilter(t *testing.T) {
 	test := prepareExporterTest(t, createTestConfig(), []func(w http.ResponseWriter, req *http.Request){
 		func(w http.ResponseWriter, req *http.Request) {
@@ -678,55 +659,6 @@ func TestMetricsPrometheusFormatMetadataFilter(t *testing.T) {
 	attrs.PutStr("key2", "value2")
 
 	err := test.exp.pushMetricsData(context.Background(), metrics)
-	assert.NoError(t, err)
-}
-
-func TestMetricsPrometheusWithDroppedRoutingAttribute(t *testing.T) {
-	test := prepareExporterTest(t, createTestConfig(), []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
-			body := extractBody(t, req)
-			expected := `test.metric.data{test="test_value",test2="second_value",key1="value1",key2="value2"} 14500 1605534165000`
-			assert.Equal(t, expected, body)
-			assert.Equal(t, "application/vnd.sumologic.prometheus", req.Header.Get("Content-Type"))
-		},
-	})
-	test.exp.config.MetricFormat = PrometheusFormat
-	test.exp.config.DropRoutingAttribute = "http_listener_v2_path_custom"
-
-	metrics := metricAndAttributesToPdataMetrics(exampleIntMetric())
-
-	attrs := metrics.ResourceMetrics().At(0).Resource().Attributes()
-	attrs.PutStr("key1", "value1")
-	attrs.PutStr("key2", "value2")
-	attrs.PutStr("http_listener_v2_path_custom", "prometheus.metrics")
-
-	err := test.exp.pushMetricsData(context.Background(), metrics)
-	assert.NoError(t, err)
-}
-
-func TestTracesWithDroppedAttribute(t *testing.T) {
-	// Prepare data to compare (trace without routing attribute)
-	traces := exampleTrace()
-	traces.ResourceSpans().At(0).Resource().Attributes().PutStr("key2", "value2")
-	tracesMarshaler = ptrace.ProtoMarshaler{}
-	bytes, err := tracesMarshaler.MarshalTraces(traces)
-	require.NoError(t, err)
-
-	test := prepareExporterTest(t, createTestConfig(), []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
-			body := extractBody(t, req)
-			assert.Equal(t, string(bytes), body)
-		},
-	})
-	test.exp.config.DropRoutingAttribute = "key1"
-
-	// add routing attribute and check if after marshalling it's different
-	traces.ResourceSpans().At(0).Resource().Attributes().PutStr("key1", "value1")
-	bytesWithAttribute, err := tracesMarshaler.MarshalTraces(traces)
-	require.NoError(t, err)
-	require.NotEqual(t, bytes, bytesWithAttribute)
-
-	err = test.exp.pushTracesData(context.Background(), traces)
 	assert.NoError(t, err)
 }
 

--- a/pkg/exporter/sumologicexporter/factory.go
+++ b/pkg/exporter/sumologicexporter/factory.go
@@ -59,10 +59,9 @@ func createDefaultConfig() component.Config {
 		},
 		TraceFormat: OTLPTraceFormat,
 
-		HTTPClientSettings:   CreateDefaultHTTPClientSettings(),
-		RetrySettings:        exporterhelper.NewDefaultRetrySettings(),
-		QueueSettings:        qs,
-		DropRoutingAttribute: DefaultDropRoutingAttribute,
+		HTTPClientSettings: CreateDefaultHTTPClientSettings(),
+		RetrySettings:      exporterhelper.NewDefaultRetrySettings(),
+		QueueSettings:      qs,
 	}
 }
 

--- a/pkg/exporter/sumologicexporter/factory_test.go
+++ b/pkg/exporter/sumologicexporter/factory_test.go
@@ -57,9 +57,8 @@ func TestCreateDefaultConfig(t *testing.T) {
 				AuthenticatorID: component.NewID("sumologic"),
 			},
 		},
-		RetrySettings:        exporterhelper.NewDefaultRetrySettings(),
-		QueueSettings:        qs,
-		DropRoutingAttribute: "",
+		RetrySettings: exporterhelper.NewDefaultRetrySettings(),
+		QueueSettings: qs,
 	})
 
 	assert.NoError(t, component.ValidateConfig(cfg))


### PR DESCRIPTION
The upstream issue that necessitated this configuration was closed in 2022, and special treatment is no longer required.