### PR TITLE
chore(ci): Remove Included Modules Report from CI

### DIFF
--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -84,13 +84,6 @@ jobs:
         run: cp otelcol-sumo-${{matrix.arch_os}}${{matrix.builder_bin_ext}} ${{ steps.set_filename.outputs.filename }}
         working-directory: ./otelcolbuilder/cmd
 
-      - name: Show included modules
-        working-directory: ./otelcolbuilder/cmd
-        run: |
-          go version -m ${{ steps.set_filename.outputs.filename }} | \
-          { grep -E "/(receiver|exporter|processor|extension)/" || true; } | \
-          tee otelcol-sumo-${{matrix.arch_os}}_modules.txt
-
       - name: Sign Windows binary
         if: runner.os == 'Windows'
         uses: skymatic/code-sign-action@v2
@@ -185,13 +178,6 @@ jobs:
         run: cp otelcol-sumo-${{matrix.arch_os}} ${{ steps.set_filename.outputs.filename }}
         working-directory: ./otelcolbuilder/cmd
 
-      - name: Show included modules
-        working-directory: ./otelcolbuilder/cmd
-        run: |
-          go version -m ${{ steps.set_filename.outputs.filename }} | \
-          { grep -E "/(receiver|exporter|processor|extension)/" || true; } | \
-          tee otelcol-sumo-${{matrix.arch_os}}_modules.txt
-
       # Store binary and .dmg into pipeline artifacts after they have been signed
 
       - name: Store .dmg as action artifact
@@ -258,13 +244,6 @@ jobs:
         run: |
           go tool nm ${{ steps.set_filename.outputs.filename }} | \
           grep "_Cfunc__goboringcrypto_"
-
-      - name: Show included modules
-        working-directory: ./otelcolbuilder/cmd
-        run: |
-          go version -m ${{ steps.set_filename.outputs.filename }} | \
-          { grep -E "/(receiver|exporter|processor|extension)/" || true; } | \
-          tee otelcol-sumo-fips-${{matrix.arch_os}}_modules.txt
 
       - name: Store binary as action artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -114,14 +114,6 @@ jobs:
         if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
         run: echo "binary_name=otelcol-sumo${OTELCOL_FIPS_SUFFIX}-${{inputs.arch_os}}${OTELCOL_BINARY_EXTENSION}" >> $GITHUB_OUTPUT
 
-      - name: Show included modules
-        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
-        working-directory: ./otelcolbuilder/cmd
-        run: |
-          go version -m ${{ steps.set-binary-name.outputs.binary_name }} | \
-          { grep -E "/(receiver|exporter|processor|extension)/" || true; } | \
-          tee ${{ steps.set-binary-name.outputs.binary_name }}_modules.txt
-
       - name: Show BoringSSL symbols
         if: ${{ inputs.fips && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
         working-directory: ./otelcolbuilder/cmd
@@ -143,14 +135,6 @@ jobs:
         with:
           name: ${{ steps.set-binary-name.outputs.binary_name }}
           path: ./otelcolbuilder/cmd/${{ steps.set-binary-name.outputs.binary_name }}
-          if-no-files-found: error
-
-      - name: Store list of included modules as action artifact
-        if: ${{ inputs.fips && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.set-binary-name.outputs.binary_name }}_modules.txt
-          path: ./otelcolbuilder/cmd/${{ steps.set-binary-name.outputs.binary_name }}_modules.txt
           if-no-files-found: error
 
       - uses: actions/cache/save@v3


### PR DESCRIPTION
Removes the broken debugging step in the build and release CI workflows showing the included collector components and their go module versions.

This information is baked into the executable. To see components run the components command `otelcol-sumo components`. If more subtle debugging is required and knowing the module versions is helpful, there is a workaround until go1.22 is available with the fix for `go version -m` (https://github.com/golang/go/issues/61644). Inspect the binary in a platform specific way.
e.g. `objcopy -O binary -j .go.buildinfo otelcol-sumo-0.80.0-sumo-0-linux_amd64 buildinfo.txt`

Closes https://github.com/SumoLogic/sumologic-otel-collector/issues/1190