### PR TITLE
feat(scripts): add linux deb & rpm package support to install script

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -139,6 +139,7 @@ jobs:
     name: Test Install Script
     runs-on: ${{ matrix.runs_on }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch_os: linux_amd64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Released TBD
 
 - feat(install.sh): prevent permission error when collecting host metrics [#1228]
+- feat(install.sh): add linux deb & rpm package support [#1219]
 
 [#1228]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1228
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.83.0-sumo-0...main

--- a/pkg/scripts_test/command.go
+++ b/pkg/scripts_test/command.go
@@ -31,6 +31,8 @@ type installOptions struct {
 	dontKeepDownloads      bool
 	installHostmetrics     bool
 	timeout                float64
+	useNativePackaging     bool
+	version                string
 }
 
 func (io *installOptions) string() []string {
@@ -96,6 +98,14 @@ func (io *installOptions) string() []string {
 		opts = append(opts, "--download-timeout", fmt.Sprintf("%f", io.timeout))
 	}
 
+	if io.useNativePackaging {
+		opts = append(opts, "--use-native-packaging")
+	}
+
+	if io.version != "" {
+		opts = append(opts, "--version", io.version)
+	}
+
 	return opts
 }
 
@@ -113,6 +123,11 @@ func (io *installOptions) buildEnvs() []string {
 	if io.deprecatedInstallToken != "" {
 		e = append(e, fmt.Sprintf("%s=%s", deprecatedInstallTokenEnv, io.deprecatedInstallToken))
 	}
+
+	// Enable non-interactive deb package installation & force default config
+	// conflict resolution
+	e = append(e, "DEBIAN_FRONTEND=noninteractive")
+	e = append(e, "DPKG_FORCE=confdef")
 
 	return e
 }

--- a/pkg/scripts_test/common.go
+++ b/pkg/scripts_test/common.go
@@ -3,20 +3,79 @@
 package sumologic_scripts_tests
 
 import (
+	"context"
+	"io"
+	"net"
+	"net/http"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
+type installType int
+
+const (
+	BINARY_INSTALL installType = 1 << iota
+	PACKAGE_INSTALL
+)
+
 type testSpec struct {
 	name              string
+	installType       installType
 	options           installOptions
 	preChecks         []checkFunc
 	postChecks        []checkFunc
 	preActions        []checkFunc
 	conditionalChecks []condCheckFunc
 	installCode       int
+}
+
+func NewTestSpecFromTestSpec(old testSpec) testSpec {
+	options := installOptions{
+		installToken:           old.options.installToken,
+		deprecatedInstallToken: old.options.deprecatedInstallToken,
+		autoconfirm:            old.options.autoconfirm,
+		skipSystemd:            old.options.skipSystemd,
+		tags:                   make(map[string]string),
+		skipConfig:             old.options.skipConfig,
+		skipInstallToken:       old.options.skipInstallToken,
+		fips:                   old.options.fips,
+		envs:                   make(map[string]string),
+		uninstall:              old.options.uninstall,
+		purge:                  old.options.purge,
+		apiBaseURL:             old.options.apiBaseURL,
+		configBranch:           old.options.configBranch,
+		downloadOnly:           old.options.downloadOnly,
+		dontKeepDownloads:      old.options.dontKeepDownloads,
+		installHostmetrics:     old.options.installHostmetrics,
+		timeout:                old.options.timeout,
+		useNativePackaging:     old.options.useNativePackaging,
+		version:                old.options.version,
+	}
+	for k, v := range old.options.tags {
+		options.tags[k] = v
+	}
+	for k, v := range old.options.envs {
+		options.envs[k] = v
+	}
+
+	new := testSpec{
+		name:              old.name,
+		installType:       old.installType,
+		options:           options,
+		preChecks:         []checkFunc{},
+		postChecks:        []checkFunc{},
+		preActions:        []checkFunc{},
+		conditionalChecks: []condCheckFunc{},
+		installCode:       old.installCode,
+	}
+	new.preChecks = append(new.preChecks, old.preChecks...)
+	new.postChecks = append(new.postChecks, old.postChecks...)
+	new.preActions = append(new.preActions, old.preActions...)
+	new.conditionalChecks = append(new.conditionalChecks, old.conditionalChecks...)
+
+	return new
 }
 
 // These checks always have to be true after a script execution
@@ -31,6 +90,7 @@ func runTest(t *testing.T, spec *testSpec) {
 	ch := check{
 		test:                t,
 		installOptions:      spec.options,
+		installType:         spec.installType,
 		expectedInstallCode: spec.installCode,
 	}
 
@@ -43,6 +103,29 @@ func runTest(t *testing.T, spec *testSpec) {
 
 	defer tearDown(t)
 
+	t.Log("Starting HTTP server")
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.WriteString(w, "200 OK\n")
+		require.NoError(t, err)
+	})
+
+	listener, err := net.Listen("tcp", ":3333")
+	require.NoError(t, err)
+
+	httpServer := &http.Server{
+		Handler: mux,
+	}
+	go func() {
+		err := httpServer.Serve(listener)
+		if err != nil && err != http.ErrServerClosed {
+			require.NoError(t, err)
+		}
+	}()
+	defer func() {
+		require.NoError(t, httpServer.Shutdown(context.Background()))
+	}()
+
 	t.Log("Running pre actions")
 	for _, a := range spec.preActions {
 		a(ch)
@@ -53,6 +136,7 @@ func runTest(t *testing.T, spec *testSpec) {
 		c(ch)
 	}
 
+	t.Log("Running install script")
 	ch.code, ch.output, ch.errorOutput, ch.err = runScript(ch)
 
 	// Remove cache in case of curl issue

--- a/pkg/scripts_test/config.go
+++ b/pkg/scripts_test/config.go
@@ -39,6 +39,7 @@ func getConfig(path string) (config, error) {
 	return conf, err
 }
 
+//nolint:unused
 func saveConfig(path string, conf config) error {
 	out, err := yaml.Marshal(conf)
 	if err != nil {

--- a/pkg/scripts_test/consts.go
+++ b/pkg/scripts_test/consts.go
@@ -12,11 +12,27 @@ const (
 	hostmetricsConfigPath string = confDPath + "/hostmetrics.yaml"
 	cacheDirectory        string = "/var/cache/otelcol-sumo/"
 	logDirPath            string = "/var/log/otelcol-sumo"
+	envDirectoryPath      string = etcPath + "/env"
+	tokenEnvFilePath      string = envDirectoryPath + "/token.env"
 
 	installToken              string = "token"
 	installTokenEnv           string = "SUMOLOGIC_INSTALLATION_TOKEN"
 	deprecatedInstallTokenEnv string = "SUMOLOGIC_INSTALL_TOKEN"
 	apiBaseURL                string = "https://open-collectors.sumologic.com"
+	mockAPIBaseURL            string = "http://127.0.0.1:3333"
+
+	// previousBinaryVersion and previousPackageVersion specify a previous
+	// version to test upgrades from. It is necessary to upgrade from an older
+	// version as same-version package upgrades can behave differently than
+	// proper upgrades.
+	previousBinaryVersion  string = "0.82.0-sumo-0"
+	previousPackageVersion string = "0.83.0-551"
 
 	curlTimeoutErrorCode int = 28
+
+	commonConfigPathFilePermissions uint32 = 0660
+	configPathDirPermissions        uint32 = 0770
+	configPathFilePermissions       uint32 = 0440
+	confDPathFilePermissions        uint32 = 0644
+	etcPathPermissions              uint32 = 0751
 )

--- a/pkg/scripts_test/consts_darwin.go
+++ b/pkg/scripts_test/consts_darwin.go
@@ -7,14 +7,6 @@ const (
 	launchdPathFilePermissions uint32 = 0640
 	uninstallScriptPath        string = appSupportDirPath + "/uninstall.sh"
 
-	// TODO: fix mismatch between darwin permissions & linux binary install permissions
-	// common.yaml must be writable as the install scripts mutate it
-	commonConfigPathFilePermissions uint32 = 0660
-	configPathDirPermissions        uint32 = 0770
-	configPathFilePermissions       uint32 = 0440
-	confDPathFilePermissions        uint32 = 0644
-	etcPathPermissions              uint32 = 0751
-
 	rootGroup   string = "wheel"
 	rootUser    string = "root"
 	systemGroup string = "_otelcol-sumo"

--- a/pkg/scripts_test/consts_linux.go
+++ b/pkg/scripts_test/consts_linux.go
@@ -1,17 +1,9 @@
 package sumologic_scripts_tests
 
 const (
-	envDirectoryPath     string = etcPath + "/env"
-	systemdDirectoryPath string = "/run/systemd/system"
-	systemdPath          string = "/etc/systemd/system/otelcol-sumo.service"
-	tokenEnvFilePath     string = envDirectoryPath + "/token.env"
-
-	// TODO: fix mismatch between package permissions & expected permissions
-	commonConfigPathFilePermissions uint32 = 0550
-	configPathDirPermissions        uint32 = 0550
-	configPathFilePermissions       uint32 = 0440
-	confDPathFilePermissions        uint32 = 0644
-	etcPathPermissions              uint32 = 0551
+	systemdDirectoryPath  string = "/run/systemd/system"
+	systemdPath           string = "/lib/systemd/system/otelcol-sumo.service"
+	deprecatedSystemdPath string = "/etc/systemd/system/otelcol-sumo.service"
 
 	rootGroup   string = "root"
 	rootUser    string = "root"

--- a/pkg/scripts_test/install_unix_test.go
+++ b/pkg/scripts_test/install_unix_test.go
@@ -3,28 +3,69 @@
 package sumologic_scripts_tests
 
 import (
+	"fmt"
 	"testing"
 )
 
 func TestInstallScript(t *testing.T) {
+	notInstalledChecks := []checkFunc{
+		checkBinaryNotCreated,
+		checkConfigNotCreated,
+		checkUserConfigNotCreated,
+		checkUserNotExists,
+		checkGroupNotExists,
+		checkUserConfigNotCreated,
+		checkSystemdConfigNotCreated,
+		checkTokenEnvFileNotCreated,
+		checkHostmetricsConfigNotCreated,
+	}
+
+	installedWithSystemdChecks := []checkFunc{
+		checkBinaryCreated,
+		checkConfigCreated,
+		checkUserConfigCreated,
+		checkSystemdConfigCreated,
+		checkUserExists,
+		checkGroupExists,
+	}
+
 	for _, spec := range []testSpec{
 		{
 			name:        "no arguments",
+			installType: BINARY_INSTALL | PACKAGE_INSTALL,
 			options:     installOptions{},
-			preChecks:   []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
-			postChecks:  []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkAbortedDueToNoToken, checkUserNotExists},
+			preChecks:   notInstalledChecks,
+			postChecks:  append(notInstalledChecks, checkAbortedDueToNoToken),
 			installCode: 1,
 		},
 		{
-			name: "download only",
+			name:        "download only",
+			installType: BINARY_INSTALL,
 			options: installOptions{
 				downloadOnly: true,
 			},
-			preChecks:  []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
-			postChecks: []checkFunc{checkBinaryCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkSystemdConfigNotCreated, checkUserNotExists},
+			preChecks: notInstalledChecks,
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigNotCreated,
+				checkUserConfigNotCreated,
+				checkSystemdConfigNotCreated,
+				checkUserNotExists,
+				checkGroupNotExists,
+			},
 		},
 		{
-			name: "download only with timeout",
+			name:        "download only",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				downloadOnly: true,
+			},
+			preChecks:  notInstalledChecks,
+			postChecks: append(notInstalledChecks, checkPackageCreated),
+		},
+		{
+			name:        "download only with timeout",
+			installType: BINARY_INSTALL | PACKAGE_INSTALL,
 			options: installOptions{
 				downloadOnly:      true,
 				timeout:           1,
@@ -32,58 +73,122 @@ func TestInstallScript(t *testing.T) {
 			},
 			// Skip this test as getting binary in github actions takes less than one second
 			conditionalChecks: []condCheckFunc{checkSkipTest},
-			preChecks:         []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
-			postChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkSystemdConfigNotCreated, checkUserNotExists,
-				checkDownloadTimeout},
-			installCode: curlTimeoutErrorCode,
+			preChecks:         notInstalledChecks,
+			postChecks:        append(notInstalledChecks, checkDownloadTimeout),
+			installCode:       curlTimeoutErrorCode,
 		},
 		{
-			name: "skip config",
+			name:        "skip config",
+			installType: BINARY_INSTALL,
 			options: installOptions{
 				skipConfig:       true,
 				skipInstallToken: true,
 			},
-			preChecks:  []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
-			postChecks: []checkFunc{checkBinaryCreated, checkConfigNotCreated, checkUserConfigNotCreated},
+			preChecks: notInstalledChecks,
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigNotCreated,
+				checkUserConfigNotCreated,
+			},
 		},
 		{
-			name: "skip installation token",
+			name:        "skip config",
+			installType: PACKAGE_INSTALL,
 			options: installOptions{
+				skipConfig:       true,
 				skipInstallToken: true,
 			},
-			preChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
+			preChecks: notInstalledChecks,
+			postChecks: append(notInstalledChecks, []checkFunc{
+				checkAbortedDueToSkipConfigUnsupported,
+			}...),
+			installCode: 1,
+		},
+		{
+			name:        "skip installation token",
+			installType: BINARY_INSTALL,
+			options: installOptions{
+				skipInstallToken: true,
+				skipSystemd:      true,
+			},
+			preChecks: notInstalledChecks,
 			postChecks: []checkFunc{
 				checkBinaryCreated,
 				checkBinaryIsRunning,
 				checkConfigCreated,
-				checkConfigFilesOwnershipAndPermissions(rootUser, rootGroup),
+				checkConfigFilesOwnershipAndPermissions,
 				checkUserConfigNotCreated,
 				checkSystemdConfigNotCreated,
 			},
 		},
 		{
-			name: "override default config",
+			name:        "skip installation token",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				skipInstallToken: true,
+			},
+			preChecks:   notInstalledChecks,
+			postChecks:  notInstalledChecks,
+			installCode: 1,
+		},
+		{
+			name:        "override default config",
+			installType: BINARY_INSTALL,
 			options: installOptions{
 				skipInstallToken: true,
 				autoconfirm:      true,
 			},
-			preActions: []checkFunc{preActionMockConfig},
-			preChecks:  []checkFunc{checkBinaryNotCreated, checkConfigCreated, checkUserConfigNotCreated, checkUserNotExists},
-			postChecks: []checkFunc{checkBinaryCreated, checkBinaryIsRunning, checkConfigCreated, checkConfigOverrided, checkUserConfigNotCreated,
-				checkSystemdConfigNotCreated},
-		},
-		{
-			name: "installation token only",
-			options: installOptions{
-				skipSystemd:  true,
-				installToken: installToken,
+			preActions: []checkFunc{
+				preActionMockConfig,
 			},
-			preChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigCreated,
+				checkUserConfigNotCreated,
+				checkUserNotExists,
+			},
 			postChecks: []checkFunc{
 				checkBinaryCreated,
 				checkBinaryIsRunning,
 				checkConfigCreated,
-				checkConfigFilesOwnershipAndPermissions(rootUser, rootGroup),
+				checkConfigOverrided,
+				checkUserConfigNotCreated,
+				checkSystemdConfigNotCreated,
+			},
+		},
+		{
+			name:        "override default config",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				installToken: installToken,
+				autoconfirm:  true,
+			},
+			preActions: []checkFunc{
+				preActionInstallPreviousVersion,
+			},
+			preChecks: installedWithSystemdChecks,
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkConfigOverrided,
+				checkUserConfigCreated,
+				checkSystemdConfigCreated,
+			},
+		},
+		{
+			name:        "installation token only",
+			installType: BINARY_INSTALL,
+			options: installOptions{
+				skipSystemd:  true,
+				installToken: installToken,
+			},
+			preChecks: notInstalledChecks,
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkConfigFilesOwnershipAndPermissions,
 				checkUserConfigCreated,
 				checkTokenInConfig,
 				checkSystemdConfigNotCreated,
@@ -93,166 +198,511 @@ func TestInstallScript(t *testing.T) {
 			},
 		},
 		{
-			name: "deprecated installation token only",
+			name:        "installation token only",
+			installType: PACKAGE_INSTALL,
 			options: installOptions{
-				skipSystemd:            true,
-				deprecatedInstallToken: installToken,
+				apiBaseURL:   mockAPIBaseURL,
+				installToken: installToken,
 			},
-			preChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
+			preChecks: notInstalledChecks,
 			postChecks: []checkFunc{
 				checkBinaryCreated,
 				checkBinaryIsRunning,
 				checkConfigCreated,
-				checkConfigFilesOwnershipAndPermissions(rootUser, rootGroup),
+				checkConfigFilesOwnershipAndPermissions,
 				checkUserConfigCreated,
-				checkDeprecatedTokenInConfig,
+				checkTokenEnvFileCreated,
+				checkTokenInEnvFile,
+				checkSystemdConfigCreated,
+				checkUserExists,
+				checkHostmetricsConfigNotCreated,
+			},
+		},
+		{
+			name:        "deprecated installation token only",
+			installType: BINARY_INSTALL,
+			options: installOptions{
+				skipSystemd:            true,
+				deprecatedInstallToken: installToken,
+			},
+			preChecks: notInstalledChecks,
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkConfigFilesOwnershipAndPermissions,
+				checkUserConfigCreated,
 				checkSystemdConfigNotCreated,
 				checkUserNotExists,
 				checkHostmetricsConfigNotCreated,
 			},
 		},
 		{
-			name: "installation token and hostmetrics",
+			name:        "installation token and hostmetrics",
+			installType: BINARY_INSTALL | PACKAGE_INSTALL,
 			options: installOptions{
-				skipSystemd:        true,
+				apiBaseURL:         mockAPIBaseURL,
 				installToken:       installToken,
 				installHostmetrics: true,
 			},
-			preChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
+			preChecks: notInstalledChecks,
 			postChecks: []checkFunc{
 				checkBinaryCreated,
 				checkBinaryIsRunning,
 				checkConfigCreated,
-				checkConfigFilesOwnershipAndPermissions(rootUser, rootGroup),
+				checkConfigFilesOwnershipAndPermissions,
 				checkUserConfigCreated,
-				checkTokenInConfig,
-				checkSystemdConfigNotCreated,
-				checkUserNotExists,
+				checkTokenInEnvFile,
+				checkSystemdConfigCreated,
+				checkUserExists,
 				checkHostmetricsConfigCreated,
-				checkHostmetricsOwnershipAndPermissions(rootUser, rootGroup),
+				checkHostmetricsOwnershipAndPermissions,
 			},
 		},
 		{
-			name: "installation token only, binary not in PATH",
+			name:        "installation token only, binary not in PATH",
+			installType: BINARY_INSTALL | PACKAGE_INSTALL,
 			options: installOptions{
-				skipSystemd:  true,
+				apiBaseURL:   mockAPIBaseURL,
 				installToken: installToken,
 				envs: map[string]string{
 					"PATH": "/sbin:/bin:/usr/sbin:/usr/bin",
 				},
 			},
-			preChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
+			preChecks: notInstalledChecks,
 			postChecks: []checkFunc{
 				checkBinaryCreated,
 				checkBinaryIsRunning,
 				checkConfigCreated,
-				checkConfigFilesOwnershipAndPermissions(rootUser, rootGroup),
+				checkConfigFilesOwnershipAndPermissions,
+				checkUserConfigCreated,
+				checkTokenInEnvFile,
+				checkSystemdConfigCreated,
+				checkUserExists,
+			},
+		},
+		{
+			name:        "same installation token",
+			installType: BINARY_INSTALL,
+			options: installOptions{
+				skipSystemd:  true,
+				installToken: installToken,
+			},
+			preActions: []checkFunc{
+				preActionMockUserConfig,
+				preActionWriteTokenToUserConfig,
+			},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigCreated,
+				checkUserNotExists,
+			},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
 				checkUserConfigCreated,
 				checkTokenInConfig,
 				checkSystemdConfigNotCreated,
+			},
+		},
+		{
+			name:        "same installation token",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				installToken: installToken,
+			},
+			preActions: []checkFunc{
+				preActionInstallPreviousVersion,
+			},
+			preChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkTokenInEnvFile,
+				checkUserExists,
+			},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkTokenInEnvFile,
+				checkSystemdConfigCreated,
+			},
+		},
+		{
+			name:        "different installation token",
+			installType: BINARY_INSTALL,
+			options: installOptions{
+				skipSystemd:  true,
+				installToken: installToken,
+			},
+			preActions: []checkFunc{
+				preActionMockUserConfig,
+				preActionWriteDifferentTokenToUserConfig,
+			},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigCreated,
 				checkUserNotExists,
 			},
-		},
-		{
-			name: "same installation token",
-			options: installOptions{
-				skipSystemd:  true,
-				installToken: installToken,
+			postChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigCreated,
+				checkSystemdConfigNotCreated,
+				checkAbortedDueToDifferentToken,
 			},
-			preActions: []checkFunc{preActionMockUserConfig, preActionWriteTokenToUserConfig},
-			preChecks:  []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigCreated, checkUserNotExists},
-			postChecks: []checkFunc{checkBinaryCreated, checkBinaryIsRunning, checkConfigCreated, checkUserConfigCreated, checkTokenInConfig, checkSystemdConfigNotCreated},
-		},
-		{
-			name: "different installation token",
-			options: installOptions{
-				skipSystemd:  true,
-				installToken: installToken,
-			},
-			preActions:  []checkFunc{preActionMockUserConfig, preActionWriteDifferentTokenToUserConfig},
-			preChecks:   []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigCreated, checkUserNotExists},
-			postChecks:  []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigCreated, checkSystemdConfigNotCreated, checkAbortedDueToDifferentToken},
 			installCode: 1,
 		},
 		{
-			name: "adding installation token",
+			name:        "different installation token",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				installToken: installToken,
+			},
+			preActions: []checkFunc{
+				preActionInstallPackage,
+				preActionWriteDifferentTokenToUserConfig,
+			},
+			preChecks: installedWithSystemdChecks,
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkSystemdConfigCreated,
+				checkAbortedDueToDifferentToken,
+			},
+			installCode: 1,
+		},
+		{
+			name:        "adding installation token",
+			installType: BINARY_INSTALL,
 			options: installOptions{
 				skipSystemd:  true,
 				installToken: installToken,
 			},
-			preActions: []checkFunc{preActionMockUserConfig},
-			preChecks:  []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigCreated, checkUserNotExists},
-			postChecks: []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkTokenInConfig, checkSystemdConfigNotCreated},
+			preActions: []checkFunc{
+				preActionMockUserConfig,
+			},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigCreated,
+				checkUserNotExists,
+			},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkTokenInConfig,
+				checkSystemdConfigNotCreated,
+			},
 		},
 		{
-			name: "editing installation token",
+			name:        "adding installation token",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				installToken: installToken,
+			},
+			preActions: []checkFunc{
+				preActionInstallPreviousVersion,
+			},
+			preChecks: installedWithSystemdChecks,
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkTokenInEnvFile,
+				checkSystemdConfigCreated,
+			},
+		},
+		{
+			name:        "editing installation token",
+			installType: BINARY_INSTALL,
 			options: installOptions{
 				skipSystemd:  true,
 				apiBaseURL:   apiBaseURL,
 				installToken: installToken,
 			},
-			preActions: []checkFunc{preActionMockUserConfig, preActionWriteEmptyUserConfig},
-			preChecks:  []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigCreated, checkUserNotExists},
-			postChecks: []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkTokenInConfig, checkSystemdConfigNotCreated},
+			preActions: []checkFunc{
+				preActionMockUserConfig,
+				preActionWriteEmptyUserConfig,
+			},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigCreated,
+				checkUserNotExists,
+			},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkTokenInConfig,
+				checkSystemdConfigNotCreated,
+			},
 		},
 		{
-			name: "same api base url",
+			name:        "editing installation token",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				apiBaseURL:   apiBaseURL,
+				installToken: installToken,
+			},
+			preActions: []checkFunc{
+				preActionInstallPreviousVersion,
+				preActionWriteEmptyUserConfig,
+			},
+			preChecks: installedWithSystemdChecks,
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkTokenInEnvFile,
+				checkSystemdConfigCreated,
+			},
+		},
+		{
+			name:        "same api base url",
+			installType: BINARY_INSTALL,
 			options: installOptions{
 				skipSystemd:      true,
 				apiBaseURL:       apiBaseURL,
 				skipInstallToken: true,
 			},
-			preActions: []checkFunc{preActionMockUserConfig, preActionWriteAPIBaseURLToUserConfig},
-			preChecks:  []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigCreated, checkUserNotExists},
-			postChecks: []checkFunc{checkBinaryCreated, checkBinaryIsRunning, checkConfigCreated, checkUserConfigCreated, checkAPIBaseURLInConfig,
-				checkSystemdConfigNotCreated},
+			preActions: []checkFunc{
+				preActionMockUserConfig,
+				preActionWriteAPIBaseURLToUserConfig,
+			},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigCreated,
+				checkUserNotExists,
+			},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkAPIBaseURLInConfig,
+				checkSystemdConfigNotCreated,
+			},
 		},
 		{
-			name: "different api base url",
+			name:        "same api base url",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				apiBaseURL:   apiBaseURL,
+				installToken: installToken,
+			},
+			preActions: []checkFunc{
+				preActionInstallPreviousVersion,
+				preActionWriteAPIBaseURLToUserConfig,
+			},
+			preChecks: installedWithSystemdChecks,
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkAPIBaseURLInConfig,
+				checkSystemdConfigCreated,
+			},
+		},
+		{
+			name:        "different api base url",
+			installType: BINARY_INSTALL,
 			options: installOptions{
 				skipSystemd:      true,
 				apiBaseURL:       apiBaseURL,
 				skipInstallToken: true,
 			},
-			preActions: []checkFunc{preActionMockUserConfig, preActionWriteDifferentAPIBaseURLToUserConfig},
-			preChecks:  []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigCreated, checkUserNotExists},
-			postChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigCreated, checkSystemdConfigNotCreated,
-				checkAbortedDueToDifferentAPIBaseURL},
+			preActions: []checkFunc{
+				preActionMockUserConfig,
+				preActionWriteDifferentAPIBaseURLToUserConfig,
+			},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigCreated,
+				checkUserNotExists,
+			},
+			postChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigCreated,
+				checkSystemdConfigNotCreated,
+				checkAbortedDueToDifferentAPIBaseURL,
+			},
 			installCode: 1,
 		},
 		{
-			name: "adding api base url",
+			name:        "different api base url",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				apiBaseURL:   apiBaseURL,
+				installToken: installToken,
+			},
+			preActions: []checkFunc{
+				preActionInstallPackage,
+				preActionWriteDifferentAPIBaseURLToUserConfig,
+			},
+			preChecks: installedWithSystemdChecks,
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkSystemdConfigCreated,
+				checkAbortedDueToDifferentAPIBaseURL,
+			},
+			installCode: 1,
+		},
+		{
+			name:        "adding api base url",
+			installType: BINARY_INSTALL,
 			options: installOptions{
 				skipSystemd:      true,
 				apiBaseURL:       apiBaseURL,
 				skipInstallToken: true,
 			},
 			preActions: []checkFunc{preActionMockUserConfig},
-			preChecks:  []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigCreated, checkUserNotExists},
-			postChecks: []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkAPIBaseURLInConfig, checkSystemdConfigNotCreated},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigCreated,
+				checkUserNotExists,
+			},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkAPIBaseURLInConfig,
+				checkSystemdConfigNotCreated,
+			},
 		},
 		{
-			name: "editing api base url",
+			name:        "adding api base url",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				apiBaseURL:   apiBaseURL,
+				installToken: installToken,
+			},
+			preActions: []checkFunc{
+				preActionInstallPackageWithOptions(installOptions{
+					apiBaseURL:   mockAPIBaseURL,
+					installToken: installToken,
+					version:      previousPackageVersion,
+				}),
+				preActionWriteEmptyUserConfig,
+			},
+			preChecks: installedWithSystemdChecks,
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkAPIBaseURLInConfig,
+				checkSystemdConfigCreated,
+			},
+		},
+		{
+			name:        "editing api base url",
+			installType: BINARY_INSTALL,
 			options: installOptions{
 				skipSystemd:      true,
 				apiBaseURL:       apiBaseURL,
 				skipInstallToken: true,
 			},
-			preActions: []checkFunc{preActionMockUserConfig, preActionWriteEmptyUserConfig},
-			preChecks:  []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigCreated, checkUserNotExists},
-			postChecks: []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkAPIBaseURLInConfig, checkSystemdConfigNotCreated},
+			preActions: []checkFunc{
+				preActionMockUserConfig,
+				preActionWriteEmptyUserConfig,
+			},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigCreated,
+				checkUserNotExists,
+			},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkAPIBaseURLInConfig,
+				checkSystemdConfigNotCreated,
+			},
 		},
 		{
-			name: "empty installation token",
+			name:        "editing api base url",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				apiBaseURL:   apiBaseURL,
+				installToken: installToken,
+			},
+			preActions: []checkFunc{
+				preActionInstallPackageWithOptions(installOptions{
+					apiBaseURL:   mockAPIBaseURL,
+					installToken: installToken,
+				}),
+			},
+			preChecks: installedWithSystemdChecks,
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkSystemdConfigCreated,
+			},
+			installCode: 1,
+		},
+		{
+			name:        "empty installation token",
+			installType: BINARY_INSTALL,
 			options: installOptions{
 				skipSystemd: true,
 			},
-			preActions: []checkFunc{preActionMockUserConfig, preActionWriteDifferentTokenToUserConfig},
-			preChecks:  []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigCreated, checkUserNotExists},
-			postChecks: []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkSystemdConfigNotCreated, checkDifferentTokenInConfig},
+			preActions: []checkFunc{
+				preActionMockUserConfig,
+				preActionWriteDifferentTokenToUserConfig,
+			},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigCreated,
+				checkUserNotExists,
+			},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkSystemdConfigNotCreated,
+				checkDifferentTokenInConfig,
+			},
 		},
 		{
-			name: "configuration with tags",
+			name:        "upgrade with empty installation token",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				installToken: "",
+			},
+			preActions: []checkFunc{
+				preActionInstallPreviousVersion,
+				preActionWriteDifferentTokenToUserConfig,
+			},
+			preChecks: installedWithSystemdChecks,
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkSystemdConfigCreated,
+				checkDifferentTokenInConfig,
+			},
+		},
+		{
+			name:        "configuration with tags",
+			installType: BINARY_INSTALL,
 			options: installOptions{
 				skipSystemd:      true,
 				skipInstallToken: true,
@@ -264,36 +714,49 @@ func TestInstallScript(t *testing.T) {
 					"numeric":   "1_024",
 				},
 			},
-			preChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigNotCreated,
+				checkUserNotExists,
+			},
 			postChecks: []checkFunc{
 				checkBinaryCreated,
 				checkBinaryIsRunning,
 				checkConfigCreated,
-				checkConfigFilesOwnershipAndPermissions(rootUser, rootGroup),
+				checkConfigFilesOwnershipAndPermissions,
 				checkTags,
 				checkSystemdConfigNotCreated,
 			},
 		},
 		{
-			name: "same tags",
+			name:        "configuration with tags",
+			installType: PACKAGE_INSTALL,
 			options: installOptions{
-				skipSystemd:      true,
-				skipInstallToken: true,
+				installToken: installToken,
 				tags: map[string]string{
-					"lorem":     "ipsum",
-					"foo":       "bar",
-					"escape_me": "'\\/",
-					"slash":     "a/b",
-					"numeric":   "1_024",
+					"lorem": "ipsum",
+					"foo":   "bar",
 				},
 			},
-			preActions: []checkFunc{preActionMockUserConfig, preActionWriteTagsToUserConfig},
-			preChecks:  []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigCreated, checkUserNotExists},
-			postChecks: []checkFunc{checkBinaryCreated, checkBinaryIsRunning, checkConfigCreated, checkUserConfigCreated, checkTags,
-				checkSystemdConfigNotCreated},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigNotCreated,
+				checkUserNotExists,
+			},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkConfigFilesOwnershipAndPermissions,
+				checkTags,
+				checkSystemdConfigCreated,
+			},
 		},
 		{
-			name: "different tags",
+			name:        "same tags",
+			installType: BINARY_INSTALL,
 			options: installOptions{
 				skipSystemd:      true,
 				skipInstallToken: true,
@@ -305,14 +768,112 @@ func TestInstallScript(t *testing.T) {
 					"numeric":   "1_024",
 				},
 			},
-			preActions: []checkFunc{preActionMockUserConfig, preActionWriteDifferentTagsToUserConfig},
-			preChecks:  []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigCreated, checkUserNotExists},
-			postChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigCreated, checkDifferentTags, checkSystemdConfigNotCreated,
-				checkAbortedDueToDifferentTags},
+			preActions: []checkFunc{
+				preActionMockUserConfig,
+				preActionWriteTagsToUserConfig,
+			},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigCreated,
+				checkUserNotExists,
+			},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkTags,
+				checkSystemdConfigNotCreated,
+			},
+		},
+		{
+			name:        "same tags",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				installToken: installToken,
+				tags: map[string]string{
+					"lorem": "ipsum",
+					"foo":   "bar",
+				},
+			},
+			preActions: []checkFunc{
+				preActionInstallPreviousVersion,
+				preActionWriteTagsToUserConfig,
+			},
+			preChecks: installedWithSystemdChecks,
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkTags,
+				checkSystemdConfigCreated,
+			},
+		},
+		{
+			name:        "different tags",
+			installType: BINARY_INSTALL,
+			options: installOptions{
+				skipSystemd:      true,
+				skipInstallToken: true,
+				tags: map[string]string{
+					"lorem":     "ipsum",
+					"foo":       "bar",
+					"escape_me": "'\\/",
+					"slash":     "a/b",
+					"numeric":   "1_024",
+				},
+			},
+			preActions: []checkFunc{
+				preActionMockUserConfig,
+				preActionWriteDifferentTagsToUserConfig,
+			},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigCreated,
+				checkUserNotExists,
+			},
+			postChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigCreated,
+				checkDifferentTags,
+				checkSystemdConfigNotCreated,
+
+				checkAbortedDueToDifferentTags,
+			},
 			installCode: 1,
 		},
 		{
-			name: "editing tags",
+			name:        "different tags",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				tags: map[string]string{
+					"lorem": "ipsum",
+					"foo":   "bar",
+				},
+			},
+			preActions: []checkFunc{
+				preActionInstallPreviousVersion,
+				preActionWriteDifferentTagsToUserConfig,
+			},
+			preChecks: installedWithSystemdChecks,
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkDifferentTags,
+				checkSystemdConfigCreated,
+
+				checkAbortedDueToDifferentTags,
+			},
+			installCode: 1,
+		},
+		{
+			name:        "editing tags",
+			installType: BINARY_INSTALL,
 			options: installOptions{
 				skipSystemd:      true,
 				skipInstallToken: true,
@@ -324,21 +885,65 @@ func TestInstallScript(t *testing.T) {
 					"numeric":   "1_024",
 				},
 			},
-			preActions: []checkFunc{preActionMockUserConfig, preActionWriteEmptyUserConfig},
-			preChecks:  []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigCreated, checkUserNotExists},
-			postChecks: []checkFunc{checkBinaryCreated, checkBinaryIsRunning, checkConfigCreated, checkTags, checkSystemdConfigNotCreated},
-		},
-		{
-			name: "systemd",
-			options: installOptions{
-				installToken: installToken,
+			preActions: []checkFunc{
+				preActionMockUserConfig,
+				preActionWriteEmptyUserConfig,
 			},
-			preChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists, checkTokenEnvFileNotCreated},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigCreated,
+				checkUserNotExists,
+			},
 			postChecks: []checkFunc{
 				checkBinaryCreated,
 				checkBinaryIsRunning,
 				checkConfigCreated,
-				checkConfigFilesOwnershipAndPermissions(systemUser, systemUser),
+				checkTags,
+				checkSystemdConfigNotCreated,
+			},
+		},
+		{
+			name:        "editing tags",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				installToken: installToken,
+				tags: map[string]string{
+					"lorem": "ipsum",
+					"foo":   "bar",
+				},
+			},
+			preActions: []checkFunc{
+				preActionInstallPreviousVersion,
+				preActionWriteEmptyUserConfig,
+			},
+			preChecks: installedWithSystemdChecks,
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkTags,
+				checkSystemdConfigCreated,
+			},
+		},
+		{
+			name:        "systemd",
+			installType: BINARY_INSTALL,
+			options: installOptions{
+				installToken: installToken,
+			},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigNotCreated,
+				checkUserNotExists,
+				checkTokenEnvFileNotCreated,
+			},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkConfigFilesOwnershipAndPermissions,
 				checkUserConfigNotCreated,
 				checkSystemdConfigCreated,
 				checkSystemdEnvDirExists,
@@ -348,15 +953,45 @@ func TestInstallScript(t *testing.T) {
 				checkUserExists,
 				checkVarLogACL,
 			},
-			conditionalChecks: []condCheckFunc{checkSystemdAvailability},
-			installCode:       3, // because of invalid installation token
+			conditionalChecks: []condCheckFunc{
+				checkSystemdAvailability,
+			},
 		},
 		{
-			name: "systemd installation token with existing user directory",
+			name:        "systemd",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				apiBaseURL:   mockAPIBaseURL,
+				installToken: installToken,
+			},
+			preChecks: notInstalledChecks,
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkConfigFilesOwnershipAndPermissions,
+				checkUserConfigCreated,
+				checkSystemdConfigCreated,
+				checkSystemdEnvDirExists,
+				checkSystemdEnvDirPermissions,
+				checkTokenEnvFileCreated,
+				checkTokenInEnvFile,
+				checkUserExists,
+				checkVarLogACL,
+			},
+			conditionalChecks: []condCheckFunc{
+				checkSystemdAvailability,
+			},
+		},
+		{
+			name:        "systemd installation token with existing user directory",
+			installType: BINARY_INSTALL,
 			options: installOptions{
 				installToken: installToken,
 			},
-			preActions: []checkFunc{preActionCreateHomeDirectory},
+			preActions: []checkFunc{
+				preActionCreateHomeDirectory,
+			},
 			preChecks: []checkFunc{
 				checkBinaryNotCreated,
 				checkConfigNotCreated,
@@ -368,7 +1003,7 @@ func TestInstallScript(t *testing.T) {
 				checkBinaryCreated,
 				checkBinaryIsRunning,
 				checkConfigCreated,
-				checkConfigFilesOwnershipAndPermissions(systemUser, systemUser),
+				checkConfigFilesOwnershipAndPermissions,
 				checkSystemdConfigCreated,
 				checkSystemdEnvDirExists,
 				checkSystemdEnvDirPermissions,
@@ -378,15 +1013,19 @@ func TestInstallScript(t *testing.T) {
 				checkVarLogACL,
 				checkOutputUserAddWarnings,
 			},
-			conditionalChecks: []condCheckFunc{checkSystemdAvailability},
-			installCode:       3, // because of invalid install token
+			conditionalChecks: []condCheckFunc{
+				checkSystemdAvailability,
+			},
 		},
 		{
-			name: "systemd existing installation different token env",
+			name:        "systemd installation token with existing user directory",
+			installType: PACKAGE_INSTALL,
 			options: installOptions{
 				installToken: installToken,
 			},
-			preActions: []checkFunc{preActionCreateHomeDirectory},
+			preActions: []checkFunc{
+				preActionCreateHomeDirectory,
+			},
 			preChecks: []checkFunc{
 				checkBinaryNotCreated,
 				checkConfigNotCreated,
@@ -398,7 +1037,7 @@ func TestInstallScript(t *testing.T) {
 				checkBinaryCreated,
 				checkBinaryIsRunning,
 				checkConfigCreated,
-				checkConfigFilesOwnershipAndPermissions(systemUser, systemUser),
+				checkConfigFilesOwnershipAndPermissions,
 				checkSystemdConfigCreated,
 				checkSystemdEnvDirExists,
 				checkSystemdEnvDirPermissions,
@@ -408,18 +1047,95 @@ func TestInstallScript(t *testing.T) {
 				checkVarLogACL,
 				checkOutputUserAddWarnings,
 			},
-			conditionalChecks: []condCheckFunc{checkSystemdAvailability},
-			installCode:       3, // because of invalid install token
+			conditionalChecks: []condCheckFunc{
+				checkSystemdAvailability,
+			},
+			installCode: 3, // because of invalid install token
 		},
 		{
-			name: "installation of hostmetrics in systemd during upgrade",
+			name:        "systemd existing installation different token env",
+			installType: BINARY_INSTALL,
+			options: installOptions{
+				installToken: installToken,
+			},
+			preActions: []checkFunc{
+				preActionCreateHomeDirectory,
+			},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigNotCreated,
+				checkUserNotExists,
+				checkHomeDirectoryCreated,
+			},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkConfigFilesOwnershipAndPermissions,
+				checkSystemdConfigCreated,
+				checkSystemdEnvDirExists,
+				checkSystemdEnvDirPermissions,
+				checkTokenEnvFileCreated,
+				checkTokenInEnvFile,
+				checkUserExists,
+				checkVarLogACL,
+				checkOutputUserAddWarnings,
+			},
+			conditionalChecks: []condCheckFunc{
+				checkSystemdAvailability,
+			},
+			installCode: 3, // because of invalid install token
+		},
+		{
+			name:        "systemd existing installation different token env",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				installToken: installToken,
+			},
+			preActions: []checkFunc{
+				preActionCreateHomeDirectory,
+			},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigNotCreated,
+				checkUserNotExists,
+				checkHomeDirectoryCreated,
+			},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkConfigFilesOwnershipAndPermissions,
+				checkSystemdConfigCreated,
+				checkSystemdEnvDirExists,
+				checkSystemdEnvDirPermissions,
+				checkTokenEnvFileCreated,
+				checkTokenInEnvFile,
+				checkUserExists,
+				checkVarLogACL,
+				checkOutputUserAddWarnings,
+			},
+			conditionalChecks: []condCheckFunc{
+				checkSystemdAvailability,
+			},
+			installCode: 3, // because of invalid install token
+		},
+		{
+			name:        "installation of hostmetrics in systemd during upgrade",
+			installType: BINARY_INSTALL,
 			options: installOptions{
 				installToken:       installToken,
 				installHostmetrics: true,
 			},
-			preActions:        []checkFunc{preActionMockSystemdStructure, preActionCreateUser},
-			conditionalChecks: []condCheckFunc{checkSystemdAvailability},
-			preChecks:         []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkUserExists},
+			preActions: []checkFunc{
+				preActionInstallPreviousVersion,
+			},
+			conditionalChecks: []condCheckFunc{
+				checkSystemdAvailability,
+			},
+			preChecks: installedWithSystemdChecks,
 			postChecks: []checkFunc{
 				checkBinaryCreated,
 				checkBinaryIsRunning,
@@ -428,107 +1144,378 @@ func TestInstallScript(t *testing.T) {
 				checkTokenInEnvFile,
 				checkUserExists,
 				checkHostmetricsConfigCreated,
-				checkHostmetricsOwnershipAndPermissions(systemUser, systemUser),
+				checkHostmetricsOwnershipAndPermissions,
 			},
 		},
 		{
-			name: "uninstallation without autoconfirm fails",
+			name:        "installation of hostmetrics in systemd during upgrade",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				installToken:       installToken,
+				installHostmetrics: true,
+			},
+			preActions: []checkFunc{
+				preActionInstallPreviousVersion,
+			},
+			conditionalChecks: []condCheckFunc{
+				checkSystemdAvailability,
+			},
+			preChecks: installedWithSystemdChecks,
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkTokenInEnvFile,
+				checkUserExists,
+				checkHostmetricsConfigCreated,
+				checkHostmetricsOwnershipAndPermissions,
+			},
+		},
+		{
+			name:        "uninstallation without autoconfirm fails",
+			installType: BINARY_INSTALL,
 			options: installOptions{
 				uninstall: true,
 			},
+			preActions: []checkFunc{
+				preActionMockStructure,
+			},
+			preChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkUserNotExists,
+			},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+			},
 			installCode: 1,
-			preActions:  []checkFunc{preActionMockStructure},
-			preChecks:   []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkUserNotExists},
-			postChecks:  []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated},
 		},
 		{
-			name: "uninstallation with autoconfirm",
+			name:        "uninstallation without autoconfirm fails",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				uninstall: true,
+			},
+			preActions: []checkFunc{
+				preActionInstallPackage,
+			},
+			preChecks: installedWithSystemdChecks,
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+			},
+			installCode: 1,
+		},
+		{
+			name:        "uninstallation with autoconfirm",
+			installType: BINARY_INSTALL,
 			options: installOptions{
 				autoconfirm: true,
 				uninstall:   true,
 			},
-			preActions: []checkFunc{preActionMockStructure},
-			preChecks:  []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkUserNotExists},
-			postChecks: []checkFunc{checkBinaryNotCreated, checkConfigCreated, checkUserConfigCreated, checkUninstallationOutput},
+			preActions: []checkFunc{
+				preActionMockStructure,
+			},
+			preChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkUserNotExists,
+			},
+			postChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkUninstallationOutput,
+			},
 		},
 		{
-			name: "systemd uninstallation",
+			name:        "uninstallation with autoconfirm",
+			installType: PACKAGE_INSTALL,
 			options: installOptions{
 				autoconfirm: true,
 				uninstall:   true,
 			},
-			preActions:        []checkFunc{preActionMockSystemdStructure},
-			preChecks:         []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkSystemdConfigCreated, checkUserNotExists},
-			postChecks:        []checkFunc{checkBinaryNotCreated, checkConfigCreated, checkUserConfigCreated, checkSystemdConfigCreated, checkUserNotExists},
-			conditionalChecks: []condCheckFunc{checkSystemdAvailability},
+			preActions: []checkFunc{
+				preActionInstallPackage,
+			},
+			preChecks: installedWithSystemdChecks,
+			postChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkUserConfigOrBackupCreated,
+				checkUninstallationOutput,
+			},
 		},
 		{
-			name: "purge",
+			name:        "systemd uninstallation",
+			installType: BINARY_INSTALL,
+			options: installOptions{
+				autoconfirm: true,
+				uninstall:   true,
+			},
+			preActions: []checkFunc{
+				preActionMockSystemdStructure,
+			},
+			preChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkSystemdConfigCreated,
+				checkUserNotExists,
+			},
+			postChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkSystemdConfigCreated,
+				checkUserNotExists,
+			},
+			conditionalChecks: []condCheckFunc{
+				checkSystemdAvailability,
+			},
+		},
+		{
+			name:        "systemd uninstallation",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				autoconfirm: true,
+				uninstall:   true,
+			},
+			preActions: []checkFunc{
+				preActionInstallPreviousVersion,
+			},
+			preChecks: installedWithSystemdChecks,
+			postChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkUserConfigOrBackupCreated,
+				checkSystemdConfigOrBackupCreated,
+				checkUserExists,
+			},
+			conditionalChecks: []condCheckFunc{
+				checkSystemdAvailability,
+			},
+		},
+		{
+			name:        "purge",
+			installType: BINARY_INSTALL,
 			options: installOptions{
 				uninstall:   true,
 				purge:       true,
 				autoconfirm: true,
 			},
-			preActions: []checkFunc{preActionMockStructure},
-			preChecks:  []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkUserNotExists},
-			postChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated},
+			preActions: []checkFunc{
+				preActionMockStructure,
+			},
+			preChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkUserNotExists,
+			},
+			postChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigNotCreated,
+			},
 		},
 		{
-			name: "systemd purge",
+			name:        "purge",
+			installType: PACKAGE_INSTALL,
 			options: installOptions{
 				uninstall:   true,
 				purge:       true,
 				autoconfirm: true,
 			},
-			preActions:        []checkFunc{preActionMockSystemdStructure},
-			preChecks:         []checkFunc{checkBinaryCreated, checkConfigCreated, checkUserConfigCreated, checkSystemdConfigCreated, checkUserNotExists},
-			postChecks:        []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkSystemdConfigNotCreated, checkUserNotExists},
-			conditionalChecks: []condCheckFunc{checkSystemdAvailability},
+			preActions: []checkFunc{
+				preActionInstallPackage,
+			},
+			preChecks: installedWithSystemdChecks,
+			postChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigNotCreated,
+			},
 		},
 		{
-			name:       "systemd creation if token in file",
-			options:    installOptions{},
-			preActions: []checkFunc{preActionMockUserConfig, preActionWriteDifferentTokenToUserConfig, preActionWriteDefaultAPIBaseURLToUserConfig},
-			preChecks:  []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigCreated, checkUserNotExists},
-			postChecks: []checkFunc{checkBinaryCreated, checkBinaryIsRunning, checkConfigCreated, checkDifferentTokenInConfig, checkSystemdConfigCreated,
-				checkUserExists, checkTokenEnvFileNotCreated},
-			conditionalChecks: []condCheckFunc{checkSystemdAvailability},
-			installCode:       3, // because of invalid installation token
+			name:        "systemd purge",
+			installType: BINARY_INSTALL,
+			options: installOptions{
+				uninstall:   true,
+				purge:       true,
+				autoconfirm: true,
+			},
+			preActions: []checkFunc{
+				preActionMockSystemdStructure,
+			},
+			preChecks: []checkFunc{
+				checkBinaryCreated,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkSystemdConfigCreated,
+				checkUserNotExists,
+			},
+			postChecks: notInstalledChecks,
+			conditionalChecks: []condCheckFunc{
+				checkSystemdAvailability,
+			},
 		},
 		{
-			name: "systemd installation if token in file",
+			name:        "systemd purge",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				uninstall:   true,
+				purge:       true,
+				autoconfirm: true,
+			},
+			preActions: []checkFunc{
+				preActionInstallPreviousVersion,
+			},
+			preChecks:  installedWithSystemdChecks,
+			postChecks: notInstalledChecks,
+			conditionalChecks: []condCheckFunc{
+				checkSystemdAvailability,
+			},
+		},
+		{
+			// This only applies to binary installations as packages
+			// will always use the token.env file.
+			name:        "systemd creation if token in file",
+			installType: BINARY_INSTALL,
+			options:     installOptions{},
+			preActions: []checkFunc{
+				preActionMockUserConfig,
+				preActionWriteDifferentTokenToUserConfig,
+				preActionWriteDefaultAPIBaseURLToUserConfig,
+			},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkConfigNotCreated,
+				checkUserConfigCreated,
+				checkUserNotExists,
+			},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkDifferentTokenInConfig,
+				checkSystemdConfigCreated,
+				checkUserExists,
+				checkTokenEnvFileNotCreated,
+			},
+			conditionalChecks: []condCheckFunc{
+				checkSystemdAvailability,
+			},
+		},
+		{
+			// This only applies to binary installations as packages
+			// will always use the token.env file.
+			name:        "systemd installation if token in file",
+			installType: BINARY_INSTALL,
 			options: installOptions{
 				installToken: installToken,
 			},
-			preActions:        []checkFunc{preActionWriteDifferentTokenToEnvFile},
-			preChecks:         []checkFunc{checkBinaryNotCreated, checkUserConfigNotCreated, checkUserNotExists},
-			postChecks:        []checkFunc{checkDifferentTokenInEnvFile, checkAbortedDueToDifferentToken},
-			conditionalChecks: []condCheckFunc{checkSystemdAvailability},
-			installCode:       1, // because of invalid installation token
+			preActions: []checkFunc{
+				preActionWriteDifferentTokenToEnvFile,
+			},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkUserConfigNotCreated,
+				checkUserNotExists,
+			},
+			postChecks: []checkFunc{
+				checkDifferentTokenInEnvFile,
+				checkAbortedDueToDifferentToken,
+			},
+			conditionalChecks: []condCheckFunc{
+				checkSystemdAvailability,
+			},
+			installCode: 1, // because of invalid installation token
 		},
 		{
-			name: "systemd installation if deprecated token in file",
+			// This only applies to binary installations as packages
+			// will always use the token.env file.
+			name:        "systemd installation if deprecated token in file",
+			installType: BINARY_INSTALL,
 			options: installOptions{
 				installToken: installToken,
 			},
-			preActions:        []checkFunc{preActionWriteDifferentDeprecatedTokenToEnvFile},
-			preChecks:         []checkFunc{checkBinaryNotCreated, checkUserConfigNotCreated, checkUserNotExists},
-			postChecks:        []checkFunc{checkDifferentTokenInEnvFile, checkAbortedDueToDifferentToken},
-			conditionalChecks: []condCheckFunc{checkSystemdAvailability},
-			installCode:       1, // because of invalid installation token
+			preActions: []checkFunc{
+				preActionWriteDifferentDeprecatedTokenToEnvFile,
+			},
+			preChecks: []checkFunc{
+				checkBinaryNotCreated,
+				checkUserConfigNotCreated,
+				checkUserNotExists,
+			},
+			postChecks: []checkFunc{
+				checkDifferentTokenInEnvFile,
+				checkAbortedDueToDifferentToken,
+			},
+			conditionalChecks: []condCheckFunc{
+				checkSystemdAvailability,
+			},
+			installCode: 1, // because of invalid installation token
 		},
 		{
-			name: "don't keep downloads",
+			name:        "don't keep downloads",
+			installType: BINARY_INSTALL,
 			options: installOptions{
 				skipInstallToken:  true,
 				dontKeepDownloads: true,
 			},
-			preChecks:  []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
-			postChecks: []checkFunc{checkBinaryCreated, checkBinaryIsRunning, checkConfigCreated, checkUserConfigNotCreated, checkSystemdConfigNotCreated},
+			preChecks: notInstalledChecks,
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkUserConfigNotCreated,
+				checkSystemdConfigNotCreated,
+			},
+		},
+		{
+			name:        "don't keep downloads",
+			installType: PACKAGE_INSTALL,
+			options: installOptions{
+				apiBaseURL:        mockAPIBaseURL,
+				installToken:      installToken,
+				dontKeepDownloads: true,
+			},
+			preChecks: notInstalledChecks,
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				checkUserConfigCreated,
+				checkSystemdConfigCreated,
+			},
 		},
 	} {
-		t.Run(spec.name, func(t *testing.T) {
-			runTest(t, &spec)
-		})
+		binaryTestSpec := NewTestSpecFromTestSpec(spec)
+		packageTestSpec := NewTestSpecFromTestSpec(spec)
+
+		if spec.installType&BINARY_INSTALL != 0 {
+			// Run spec for binary installation
+			binaryTestSpec.name = fmt.Sprintf("binary install -- %s", spec.name)
+			binaryTestSpec.options.useNativePackaging = false
+
+			t.Run(binaryTestSpec.name, func(t *testing.T) {
+				runTest(t, &binaryTestSpec)
+			})
+		}
+
+		if spec.installType&PACKAGE_INSTALL != 0 {
+			// Run spec for package installation
+			packageTestSpec.name = fmt.Sprintf("package install -- %s", spec.name)
+			packageTestSpec.options.useNativePackaging = true
+
+			t.Run(packageTestSpec.name, func(t *testing.T) {
+				runTest(t, &packageTestSpec)
+			})
+		}
 	}
 }


### PR DESCRIPTION
**WIP:** This is still a WIP but is nearly complete. There are a few test failures for deb packages that should be fixed shortly.

Adds support for Linux deb & rpm packages to the install script. A new `--use-native-packaging` flag has been added to use package installation instead of the current binary installation method.

https://github.com/SumoLogic/sumologic-otel-collector-packaging/pull/28 contains fixes for packages that are required for the package installation via `install.sh` to function. A new package release is required after that PR is merged.