### PR TITLE
feat(receiver/sqlquery): go back to using upstream receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ The rest of the components in the table are pure upstream OpenTelemetry componen
 [snowflakereceiver]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.83.0/receiver/snowflakereceiver
 [solacereceiver]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.83.0/receiver/solacereceiver
 [splunkhecreceiver]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.83.0/receiver/splunkhecreceiver
-[sqlqueryreceiver]: https://github.com/dmolenda-sumo/opentelemetry-collector-contrib/tree/sqlquery-receiver-add-logs-v0.78.0/receiver/sqlqueryreceiver
+[sqlqueryreceiver]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.83.0/receiver/sqlqueryreceiver
 [sqlserverreceiver]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.83.0/receiver/sqlserverreceiver
 [sshcheckreceiver]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.83.0/receiver/sshcheckreceiver
 [statsdreceiver]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.83.0/receiver/statsdreceiver

--- a/otelcolbuilder/.otelcol-builder.yaml
+++ b/otelcolbuilder/.otelcol-builder.yaml
@@ -235,4 +235,3 @@ replaces:
 
   # lokireceiver does a replace for this, so we need to as well
   - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki => github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki v0.83.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver => github.com/dmolenda-sumo/opentelemetry-collector-contrib/receiver/sqlqueryreceiver sqlquery-receiver-add-logs-v0.78.0


### PR DESCRIPTION
We switched to using a fork of the SQL Query receiver in v0.78.0 to introduce logs support before it was available in upstream. Now that upstream has logs support, we can remove the override.

This change is actually a bit belated. We could and should've done it in v0.80.0, as the upstream already included logs support in it.