### PR TITLE
chore: fix `make update-ot` in MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ check-uniform-dependencies:
 	./ci/check_uniform_dependencies.sh
 
 OT_CORE_VERSION := $(shell grep "otelcol_version: .*" otelcolbuilder/.otelcol-builder.yaml | cut -f 4 -d " ")
-OT_CONTRIB_VERSION := $(shell grep --max-count=1 '^  - gomod: github\.com/open-telemetry/opentelemetry-collector-contrib/' otelcolbuilder/.otelcol-builder.yaml | cut --delimiter=" " --fields=6 | $(SED) "s/v//")
+OT_CONTRIB_VERSION := $(shell grep --max-count=1 '^  - gomod: github\.com/open-telemetry/opentelemetry-collector-contrib/' otelcolbuilder/.otelcol-builder.yaml | cut -d " " -f 6 | $(SED) "s/v//")
 # usage: make update-ot OT_CORE_NEW=x.x.x OT_CONTRIB_NEW=y.y.y
 .PHONY: update-ot
 update-ot: install-gsed


### PR DESCRIPTION
The long versions of `cut` flags are not supported in MacOS.