### PR TITLE
chore: fix racey test case in rawk8seventsreceiver

### DIFF
--- a/pkg/receiver/rawk8seventsreceiver/receiver_test.go
+++ b/pkg/receiver/rawk8seventsreceiver/receiver_test.go
@@ -338,7 +338,7 @@ func TestNoStorage(t *testing.T) {
 
 	// Create the second k8s event.
 	secondEvent := getEvent()
-	firstEvent.UID = types.UID("ec279341-e2d8-4b2a-b17d-6e0566481002")
+	secondEvent.UID = types.UID("ec279341-e2d8-4b2a-b17d-6e0566481002")
 	listWatch.Add(secondEvent)
 
 	// Both events should be picked up by the receiver.


### PR DESCRIPTION
A likely mistype in rawk8seventsreceiver.TestNoStorage causes a data race. Corrected the typo to fix the race case.


CI Failure: https://github.com/SumoLogic/sumologic-otel-collector/actions/runs/6099766017/job/16552657270
```==================
WARNING: DATA RACE
Write at 0x00c00029e7e0 by goroutine 55:
  github.com/SumoLogic/sumologic-otel-collector/pkg/receiver/rawk8seventsreceiver.TestNoStorage()
      /home/runner/work/sumologic-otel-collector/sumologic-otel-collector/pkg/receiver/rawk8seventsreceiver/receiver_test.go:341 +0x472
  testing.tRunner()
      /opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:1629 +0x47

Previous read at 0x00c00029e7e0 by goroutine 61:
  ....
==================
--- FAIL: TestNoStorage (0.02s)
    testing.go:1446: race detected during execution of test
```