### PR TITLE
fix(install.sh): ensure selinux records are created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.85.0-sumo-0...main
 
+### Fixed
+
+- fix: ensure selinux records are created [#1249]
+
+[#1249]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1249
+
 ## [v0.85.0-sumo-0]
 
 ### Released 2023-09-12

--- a/pkg/scripts_test/check_linux.go
+++ b/pkg/scripts_test/check_linux.go
@@ -219,7 +219,8 @@ func preActionMockStructure(c check) {
 	err := os.MkdirAll(fileStoragePath, os.ModePerm)
 	require.NoError(c.test, err)
 
-	_, err = os.Create(binaryPath)
+	content := []byte("#!/bin/sh\necho hello world\n")
+	err = os.WriteFile(binaryPath, content, 0755)
 	require.NoError(c.test, err)
 }
 

--- a/pkg/scripts_test/install_unix_test.go
+++ b/pkg/scripts_test/install_unix_test.go
@@ -416,6 +416,7 @@ func TestInstallScript(t *testing.T) {
 			options: installOptions{
 				installToken:       installToken,
 				installHostmetrics: true,
+				apiBaseURL:         "http://127.0.0.1:3333",
 			},
 			preActions:        []checkFunc{preActionMockSystemdStructure, preActionCreateUser},
 			conditionalChecks: []condCheckFunc{checkSystemdAvailability},


### PR DESCRIPTION
A bug currently exists where selinux records are sometimes not set for the otelcol-sumo binary. This will occur if the systemd unit file exists when installing but the otelcol-sumo binary does not. For example, attempting to install after an uninstallation without purging configs.

I've removed the logic that checks if the systemd unit file already exists. This fixes the bug described and will also ensure that users are always using the correct systemd unit file for the version of the collector they're installing.