### PR TITLE
Add zstd compression support to the Sumo exporter

### DIFF
--- a/pkg/exporter/sumologicexporter/README.md
+++ b/pkg/exporter/sumologicexporter/README.md
@@ -17,7 +17,7 @@ exporters:
     # if sumologicextension is not being used, the endpoint is required
     endpoint: <HTTP_Source_URL>
     # Compression encoding format, empty string means no compression, default = gzip
-    compress_encoding: {gzip, deflate, ""}
+    compress_encoding: {gzip, deflate, ztsd, ""}
     # max HTTP request body size in bytes before compression (if applied),
     # NOTE: this limit does not apply to data sent in otlp format,
     #   to limit size of otlp requests, please use the batch processor:

--- a/pkg/exporter/sumologicexporter/compress.go
+++ b/pkg/exporter/sumologicexporter/compress.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/klauspost/compress/flate"
 	"github.com/klauspost/compress/gzip"
+	"github.com/klauspost/compress/zstd"
 )
 
 type compressor struct {
@@ -46,6 +47,11 @@ func newCompressor(format CompressEncodingType) (compressor, error) {
 		writer = gzip.NewWriter(io.Discard)
 	case DeflateCompression:
 		writer, err = flate.NewWriter(io.Discard, flate.BestSpeed)
+		if err != nil {
+			return compressor{}, err
+		}
+	case ZSTDCompression:
+		writer, err = zstd.NewWriter(io.Discard)
 		if err != nil {
 			return compressor{}, err
 		}

--- a/pkg/exporter/sumologicexporter/config.go
+++ b/pkg/exporter/sumologicexporter/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	exporterhelper.QueueSettings  `mapstructure:"sending_queue"`
 	exporterhelper.RetrySettings  `mapstructure:"retry_on_failure"`
 
-	// Compression encoding format, either empty string, gzip or deflate (default gzip)
+	// Compression encoding format, either empty string, gzip, deflate or zstd (default gzip)
 	// Empty string means no compression
 	CompressEncoding CompressEncodingType `mapstructure:"compress_encoding"`
 	// Max HTTP request body size in bytes before compression (if applied).
@@ -176,6 +176,7 @@ func (cet CompressEncodingType) Validate() error {
 	case GZIPCompression:
 	case NoCompression:
 	case DeflateCompression:
+	case ZSTDCompression:
 
 	default:
 		return fmt.Errorf("invalid compression encoding type: %v", cet)
@@ -205,6 +206,8 @@ const (
 	GZIPCompression CompressEncodingType = "gzip"
 	// DeflateCompression represents compress_encoding: deflate
 	DeflateCompression CompressEncodingType = "deflate"
+	// ZSTDCompression represents compress_encoding: zstd
+	ZSTDCompression CompressEncodingType = "zstd"
 	// NoCompression represents disabled compression
 	NoCompression CompressEncodingType = ""
 	// MetricsPipeline represents metrics pipeline


### PR DESCRIPTION
## Benchmark

![Screenshot 2023-09-20 at 9 34 50 AM](https://github.com/SumoLogic/sumologic-otel-collector/assets/149630/a0beb27a-c22f-4058-b94a-71d92910f2de)
