### PR TITLE
chore(ci): build fips binary w/glibc 2.26

### DIFF
--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -92,22 +92,29 @@ jobs:
             ${{ steps.get-cache-key.outputs.restore-keys }}
 
       - name: Set default BUILDER_BIN_PATH
-        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        if: ${{ ! inputs.fips && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
         run: echo "BUILDER_BIN_PATH=${HOME}/bin" >> $GITHUB_ENV
 
       - name: Add opentelemetry-collector-builder installation dir to PATH
-        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        if: ${{ ! inputs.fips && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
         run: echo "$BUILDER_BIN_PATH" >> $GITHUB_PATH
 
       - name: Install opentelemetry-collector-builder
-        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        if: ${{ ! inputs.fips && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
         run: make install-builder
         working-directory: ./otelcolbuilder
 
       - name: Build
-        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
-        run: make otelcol-sumo-${{inputs.arch_os}}${{ inputs.fips && ' FIPS_SUFFIX="$OTELCOL_FIPS_SUFFIX" CGO_ENABLED=1' || '' }}
+        if: ${{ ! inputs.fips && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
+        run: make otelcol-sumo-${{inputs.arch_os}}
         working-directory: ./otelcolbuilder
+
+      - name: Build (FIPS)
+        if: ${{ inputs.fips && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
+        id: containerized-build
+        uses: ./ci/build-fips-action
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Set binary name
         id: set-binary-name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.85.0-sumo-0...main
 
+### Changed
+
+- chore(ci): build fips binary w/glibc 2.26 [#1257]
+
 ### Fixed
 
 - fix: ensure selinux records are created [#1249]
 
 [#1249]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1249
+[#1257]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1257
 
 ## [v0.85.0-sumo-0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- chore(ci): build fips binary w/glibc 2.26 [#1257]
+- chore(ci): build fips binary w/ glibc 2.26 [#1257]
 
 ### Fixed
 

--- a/ci/build-fips-action/Dockerfile
+++ b/ci/build-fips-action/Dockerfile
@@ -6,6 +6,10 @@ ENV TARGETARCH=$TARGETARCH
 
 RUN yum groupinstall -y "Development Tools" && yum install -y curl git
 
+RUN curl -Lo go.tar.gz https://go.dev/dl/go1.20.5.linux-$TARGETARCH.tar.gz
+RUN tar -zxvf go.tar.gz -C /usr/local
+ENV PATH="/usr/local/go/bin:${PATH}"
+
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/ci/build-fips-action/Dockerfile
+++ b/ci/build-fips-action/Dockerfile
@@ -1,0 +1,11 @@
+FROM amazonlinux:2
+
+ARG TARGETARCH
+
+ENV TARGETARCH=$TARGETARCH
+
+RUN yum groupinstall -y "Development Tools" && yum install -y curl git
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/ci/build-fips-action/action.yml
+++ b/ci/build-fips-action/action.yml
@@ -1,0 +1,9 @@
+name: 'Build FIPS'
+description: 'Build the otelcol-sumo FIPS binary'
+inputs:
+  go-version:
+    description: 'The version of Go to use'
+    required: true
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/ci/build-fips-action/entrypoint.sh
+++ b/ci/build-fips-action/entrypoint.sh
@@ -2,13 +2,6 @@
 
 git config --global --add safe.directory /github/workspace
 
-# Install Go
-url="https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz"
-echo "Downloading ${url}"
-curl -Lo go.tar.gz "$url"
-tar -zxvf go.tar.gz -C /usr/local
-export PATH="/usr/local/go/bin:${PATH}"
-
 # Install builder
 cd otelcolbuilder || exit 1
 mkdir "${HOME}/bin"

--- a/ci/build-fips-action/entrypoint.sh
+++ b/ci/build-fips-action/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+git config --global --add safe.directory /github/workspace
+
+# Install Go
+url="https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz"
+echo "Downloading ${url}"
+curl -Lo go.tar.gz "$url"
+tar -zxvf go.tar.gz -C /usr/local
+export PATH="/usr/local/go/bin:${PATH}"
+
+# Install builder
+cd otelcolbuilder || exit 1
+mkdir "${HOME}/bin"
+export PATH="${HOME}/bin:${PATH}"
+make install-builder
+
+# Build otelcol-sumo
+make otelcol-sumo-linux_amd64 FIPS_SUFFIX="-fips" CGO_ENABLED="1"

--- a/otelcolbuilder/Makefile
+++ b/otelcolbuilder/Makefile
@@ -134,6 +134,11 @@ build-debug: ensure-correct-builder-version
 	@$(MAKE) generate-sources
 	@$(MAKE) _gobuild_debug
 
+.PHONY: build-fips
+build-fips:
+	docker build --platform linux/amd64	-t otelcol-sumo-builder-fips -f ../ci/build-fips-action/Dockerfile ../ci/build-fips-action
+	docker run -it --platform linux/amd64 --rm -v $(PWD)/../:/github/workspace -w /github/workspace --tmpfs /tmp otelcol-sumo-builder-fips
+
 .PHONY: generate-sources
 generate-sources:
 	@$(MAKE) _builder SKIP_COMPILATION=true

--- a/otelcolbuilder/Makefile
+++ b/otelcolbuilder/Makefile
@@ -136,7 +136,7 @@ build-debug: ensure-correct-builder-version
 
 .PHONY: build-fips
 build-fips:
-	docker build --platform linux/amd64	-t otelcol-sumo-builder-fips -f ../ci/build-fips-action/Dockerfile ../ci/build-fips-action
+	docker build --platform linux/amd64 -t otelcol-sumo-builder-fips -f ../ci/build-fips-action/Dockerfile ../ci/build-fips-action
 	docker run -it --platform linux/amd64 --rm -v $(PWD)/../:/github/workspace -w /github/workspace --tmpfs /tmp otelcol-sumo-builder-fips
 
 .PHONY: generate-sources


### PR DESCRIPTION
The `linux/amd64` FIPS binary is currently built using GLIBC 2.28. Some supported Linux distributions use an older version of GLIBC and the binary we produce is incompatible as a result. This change updates CI to build the binary using the `amazonlinux:2` container image which has GLIBC 2.26.