### PR TITLE
feat(jobreceiver): Implement monitoring job receiver

### DIFF
--- a/pkg/receiver/jobreceiver/README.md
+++ b/pkg/receiver/jobreceiver/README.md
@@ -10,14 +10,6 @@ executable at defined intervals, and propagates the output from that process
 as log events. In addition, the monitoring job receiver simplifies the process
 of downloading runtime assets necessary to run a particular monitoring job.
 
-## Feature Gate
-
-This receiver is currently gated behind a [featuregate][featuregate]
-`receiver.monitoringjob.enabled`. To start the collector with monitoringjobs
-enabled use the `--feature-gates=receiver.monitoringjob.enabled` flag.
-
-[featuregate]: https://github.com/open-telemetry/opentelemetry-collector/tree/main/featuregate
-
 ## Configuration
 
 | Configuration | Default | Description

--- a/pkg/receiver/jobreceiver/README.md
+++ b/pkg/receiver/jobreceiver/README.md
@@ -10,6 +10,14 @@ executable at defined intervals, and propagates the output from that process
 as log events. In addition, the monitoring job receiver simplifies the process
 of downloading runtime assets necessary to run a particular monitoring job.
 
+## Feature Gate
+
+This receiver is currently gated behind a [featuregate][featuregate]
+`receiver.monitoringjob.enabled`. To start the collector with monitoringjobs
+enabled use the `--feature-gates=receiver.monitoringjob.enabled` flag.
+
+[featuregate]: https://github.com/open-telemetry/opentelemetry-collector/tree/main/featuregate
+
 ## Configuration
 
 | Configuration | Default | Description

--- a/pkg/receiver/jobreceiver/command/command_test.go
+++ b/pkg/receiver/jobreceiver/command/command_test.go
@@ -3,64 +3,18 @@ package command
 import (
 	"bytes"
 	"context"
-	"flag"
-	"fmt"
 	"io"
-	"os"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 
+	"github.com/SumoLogic/sumologic-otel-collector/pkg/receiver/jobreceiver/internal/commandtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // TestMain lets the test binary emulate other processes
 func TestMain(m *testing.M) {
-	flag.Parse()
-
-	pid := os.Getpid()
-	if os.Getenv("GO_EXEC_TEST_PID") == "" {
-		os.Setenv("GO_EXEC_TEST_PID", strconv.Itoa(pid))
-		os.Exit(m.Run())
-	}
-
-	args := flag.Args()
-	if len(args) == 0 {
-		fmt.Fprintf(os.Stderr, "No command\n")
-		os.Exit(2)
-	}
-
-	command, args := args[0], args[1:]
-	switch command {
-	case "echo":
-		fmt.Fprintf(os.Stdout, "%s", strings.Join(args, " "))
-	case "exit":
-		if i, err := strconv.ParseInt(args[0], 10, 32); err == nil {
-			os.Exit(int(i))
-		}
-		panic("unexpected exit argument")
-	case "sleep":
-		if d, err := time.ParseDuration(args[0]); err == nil {
-			time.Sleep(d)
-			return
-		}
-		if i, err := strconv.ParseInt(args[0], 10, 64); err == nil {
-			time.Sleep(time.Second * time.Duration(i))
-			return
-		}
-	case "fork":
-		childCommand := NewExecution(context.Background(), ExecutionRequest{
-			Command:   os.Args[0],
-			Arguments: args,
-		})
-		_, err := childCommand.Run()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "fork error: %v", err)
-			os.Exit(3)
-		}
-	}
+	commandtest.WrapTestMain(m)
 }
 
 func TestExecute(t *testing.T) {
@@ -141,12 +95,11 @@ func TestExecute(t *testing.T) {
 
 // withTestHelper takes an ExecutionRequest and adjusts it to run with the
 // test binary. TestMain will handle emulating the command.
-func withTestHelper(t *testing.T, request ExecutionRequest) ExecutionRequest {
+func withTestHelper(t *testing.T, r ExecutionRequest) ExecutionRequest {
 	t.Helper()
 
-	request.Arguments = append([]string{request.Command}, request.Arguments...)
-	request.Command = os.Args[0]
-	return request
+	r.Command, r.Arguments = commandtest.WrapCommand(r.Command, r.Arguments)
+	return r
 }
 
 func eventualOutput(t *testing.T, i *Execution) <-chan string {

--- a/pkg/receiver/jobreceiver/config.go
+++ b/pkg/receiver/jobreceiver/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	Output   output.Config   `mapstructure:"output"`
 }
 
-// ExecutionConfig defines the configuration for execution of a monitorinjob
+// ExecutionConfig defines the configuration for execution of a monitoringjob
 // process
 type ExecutionConfig struct {
 	// Command is the name of the binary to be executed

--- a/pkg/receiver/jobreceiver/go.mod
+++ b/pkg/receiver/jobreceiver/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/collector/component v0.85.0
 	go.opentelemetry.io/collector/confmap v0.85.0
+	go.opentelemetry.io/collector/featuregate v1.0.0-rcv0014
 	go.opentelemetry.io/collector/receiver v0.85.0
 	go.uber.org/zap v1.25.0
 )
@@ -38,7 +39,6 @@ require (
 	go.opentelemetry.io/collector/consumer v0.85.0 // indirect
 	go.opentelemetry.io/collector/exporter v0.85.0 // indirect
 	go.opentelemetry.io/collector/extension v0.85.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.0.0-rcv0014 // indirect
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0014 // indirect
 	go.opentelemetry.io/collector/processor v0.85.0 // indirect
 	go.opentelemetry.io/otel v1.17.0 // indirect

--- a/pkg/receiver/jobreceiver/go.mod
+++ b/pkg/receiver/jobreceiver/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/collector/component v0.85.0
 	go.opentelemetry.io/collector/confmap v0.85.0
-	go.opentelemetry.io/collector/featuregate v1.0.0-rcv0014
+	go.opentelemetry.io/collector/consumer v0.85.0
 	go.opentelemetry.io/collector/receiver v0.85.0
 	go.uber.org/zap v1.25.0
 )
@@ -36,9 +36,9 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector v0.85.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.85.0 // indirect
-	go.opentelemetry.io/collector/consumer v0.85.0 // indirect
 	go.opentelemetry.io/collector/exporter v0.85.0 // indirect
 	go.opentelemetry.io/collector/extension v0.85.0 // indirect
+	go.opentelemetry.io/collector/featuregate v1.0.0-rcv0014 // indirect
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0014 // indirect
 	go.opentelemetry.io/collector/processor v0.85.0 // indirect
 	go.opentelemetry.io/otel v1.17.0 // indirect

--- a/pkg/receiver/jobreceiver/internal/commandtest/command.go
+++ b/pkg/receiver/jobreceiver/internal/commandtest/command.go
@@ -1,0 +1,69 @@
+package commandtest
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// WrapTestMain can be used in TestMain to wrap the go test binary with basic
+// command emulation, normalizing the test environment across platforms.
+//
+// Usage:
+//
+//	func TestMain(m *testing.M) {
+//		commandtest.WrapTestMain(m)
+//	}
+func WrapTestMain(m *testing.M) {
+	flag.Parse()
+
+	pid := os.Getpid()
+	if os.Getenv("GO_EXEC_TEST_PID") == "" {
+		os.Setenv("GO_EXEC_TEST_PID", strconv.Itoa(pid))
+		os.Exit(m.Run())
+	}
+
+	args := flag.Args()
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "No command\n")
+		os.Exit(2)
+	}
+
+	command, args := args[0], args[1:]
+	switch command {
+	case "echo":
+		fmt.Fprintf(os.Stdout, "%s", strings.Join(args, " "))
+	case "exit":
+		if i, err := strconv.ParseInt(args[0], 10, 32); err == nil {
+			os.Exit(int(i))
+		}
+		panic("unexpected exit argument")
+	case "sleep":
+		if d, err := time.ParseDuration(args[0]); err == nil {
+			time.Sleep(d)
+			return
+		}
+		if i, err := strconv.ParseInt(args[0], 10, 64); err == nil {
+			time.Sleep(time.Second * time.Duration(i))
+			return
+		}
+	case "fork":
+		childCommand := exec.CommandContext(context.Background(), os.Args[0], args...)
+		if err := childCommand.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "fork error: %v", err)
+			os.Exit(3)
+		}
+	}
+}
+
+// WrapCommand adjusts a command and arguments to run emuldated by a go test
+// binary wrapped with WrapTestMain
+func WrapCommand(cmd string, args []string) (string, []string) {
+	return os.Args[0], append([]string{cmd}, args...)
+}

--- a/pkg/receiver/jobreceiver/output/consumer/consumer.go
+++ b/pkg/receiver/jobreceiver/output/consumer/consumer.go
@@ -1,9 +1,7 @@
 package consumer
 
 import (
-	"bufio"
 	"context"
-	"fmt"
 	"io"
 	"time"
 
@@ -37,38 +35,6 @@ type WriterOp interface {
 	Write(ctx context.Context, e *entry.Entry)
 }
 
-// DemoConsumer stub consumer implementation.
-// todo(ck) delete - this is a stub implementation for PoC purposes only.
-type DemoConsumer struct {
-	WriterOp
-	Logger *zap.SugaredLogger
-}
+type contextKey string
 
-// Consume reads stdout line by line and produces entries
-func (p *DemoConsumer) Consume(ctx context.Context, stdout, stderr io.Reader) CloseFunc {
-	ctx, cancel := context.WithCancel(ctx)
-	go func() {
-		scanner := bufio.NewScanner(stdout)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-			if !scanner.Scan() {
-				if scanner.Err() != nil {
-					panic(scanner.Err())
-				}
-				return
-			}
-			ent, err := p.NewEntry(scanner.Text())
-			if err != nil {
-				ent = entry.New()
-				ent.Body = fmt.Sprintf("error: %s", err)
-			}
-			p.Write(ctx, ent)
-
-		}
-	}()
-	return func(_ ExecutionSummary) { cancel() }
-}
+const ContextKeyCommandName = contextKey("commandName")

--- a/pkg/receiver/jobreceiver/output/event/config.go
+++ b/pkg/receiver/jobreceiver/output/event/config.go
@@ -6,6 +6,12 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	commandNameLabel     = "command.name"
+	commandStatusLabel   = "command.status"
+	commandDurationLabel = "command.duration"
+)
+
 // EventConfig handles output as if it is a monitoring job.
 // Should emit a single event per command execution summarizing the execution.
 type EventConfig struct {
@@ -22,7 +28,7 @@ type EventConfig struct {
 }
 
 func (c *EventConfig) Build(logger *zap.SugaredLogger, op consumer.WriterOp) (consumer.Interface, error) {
-	return &consumer.DemoConsumer{WriterOp: op, Logger: logger}, nil
+	return &handler{writer: op, logger: logger, config: *c}, nil
 }
 
 type EventConfigFactory struct{}

--- a/pkg/receiver/jobreceiver/output/event/handler.go
+++ b/pkg/receiver/jobreceiver/output/event/handler.go
@@ -1,0 +1,116 @@
+package event
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"sync"
+
+	"github.com/SumoLogic/sumologic-otel-collector/pkg/receiver/jobreceiver/output/consumer"
+	"go.uber.org/zap"
+)
+
+var errSizeLimitExceeded = errors.New("buffer size limit exceeded")
+
+type handler struct {
+	logger *zap.SugaredLogger
+	writer consumer.WriterOp
+
+	config EventConfig
+}
+
+var _ consumer.Interface = (*handler)(nil)
+
+// Consume
+func (h *handler) Consume(ctx context.Context, stdout, stderr io.Reader) consumer.CloseFunc {
+	e := eventOutputBuffer{
+		ctx:         ctx,
+		logger:      h.logger,
+		writer:      h.writer,
+		EventConfig: h.config,
+	}
+	e.Start(stdout, stderr)
+	return e.Close
+}
+
+type eventOutputBuffer struct {
+	EventConfig
+
+	ctx    context.Context
+	logger *zap.SugaredLogger
+	writer consumer.WriterOp
+
+	wg  sync.WaitGroup
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+// Start consuming the intput streams into the buffer
+func (b *eventOutputBuffer) Start(stdout, stderr io.Reader) {
+	b.wg.Add(2)
+	go b.consume(stdout)
+	go b.consume(stderr)
+}
+
+// consume reads the input into the buffer until either EOF is reached or the
+// buffer is full. Once the buffer is full, consume discards remaining input
+// until EOF or read error
+func (b *eventOutputBuffer) consume(in io.Reader) {
+	defer b.wg.Done()
+
+	_, err := io.Copy(b, in)
+	if errors.Is(err, errSizeLimitExceeded) {
+		_, err = io.Copy(io.Discard, in)
+	}
+	if err != nil {
+		b.logger.Errorf("io error consuming event input: %s", err)
+	}
+}
+
+// Close builds a new log entry based off the exeuction summary and contents
+// of the buffer. Writes the entry to the pipeline.
+func (b *eventOutputBuffer) Close(summary consumer.ExecutionSummary) {
+	// Wait for all content to be written to the buffer
+	b.wg.Wait()
+
+	ent, err := b.writer.NewEntry(b.String())
+	if err != nil {
+		b.logger.Errorf("event output buffer could not create a new log entry: %s", err)
+	}
+	if ent.Attributes == nil {
+		ent.Attributes = map[string]interface{}{}
+	}
+	if b.IncludeCommandName {
+		ent.Attributes[commandNameLabel] = summary.Command
+	}
+	if b.IncludeCommandStatus {
+		ent.Attributes[commandStatusLabel] = summary.ExitCode
+	}
+	if b.IncludeDuration {
+		ent.Attributes[commandDurationLabel] = summary.RunDuration.Seconds()
+	}
+
+	b.writer.Write(b.ctx, ent)
+}
+
+// Write to the buffer. Meant to be used by both output streams
+// in a monitoring plugin spec compliant way.
+// Will accept writes until MaxBodySize is reached.
+func (b *eventOutputBuffer) Write(p []byte) (n int, err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if rem := int(b.MaxBodySize) - b.buf.Len(); b.MaxBodySize > 0 && len(p) > rem {
+		if w, wErr := b.buf.Write(p[:rem]); wErr != nil {
+			return w, wErr
+		}
+		return rem, errSizeLimitExceeded
+	}
+	return b.buf.Write(p)
+}
+
+func (b *eventOutputBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}

--- a/pkg/receiver/jobreceiver/output/event/handler_test.go
+++ b/pkg/receiver/jobreceiver/output/event/handler_test.go
@@ -1,0 +1,70 @@
+package event
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/SumoLogic/sumologic-otel-collector/pkg/receiver/jobreceiver/output/consumer"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+)
+
+func TestConsume(t *testing.T) {
+	var w stubWriter
+	h := handler{
+		logger: nil,
+		writer: &w,
+		config: EventConfig{
+			IncludeCommandName:   true,
+			IncludeCommandStatus: true,
+			IncludeDuration:      true,
+			MaxBodySize:          5,
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	fmt.Fprint(&stdout, "hello world")
+	fmt.Fprint(&stderr, "hello world")
+	cb := h.Consume(context.Background(), io.NopCloser(&stdout), io.NopCloser(&stderr))
+	cb(consumer.ExecutionSummary{
+		Command:     "exit",
+		RunDuration: time.Millisecond * 500,
+		ExitCode:    2,
+	})
+
+	if len(w.Out) != 1 {
+		t.Fatalf("expected handler to write single entry, got %v", w.Out)
+	}
+	actualEntry := w.Out[0]
+	if actualEntry.Body.(string) != "hello" {
+		t.Errorf("expected handler to write single entry with empty string output, got %v", actualEntry.Body)
+	}
+	if actualEntry.Attributes[commandNameLabel] != "exit" {
+		t.Errorf("expected handler to write entry with command.name, got %v", actualEntry.Attributes)
+	}
+	if actualEntry.Attributes[commandStatusLabel] != 2 {
+		t.Errorf("expected handler to write entry with command.status, got %v", actualEntry.Attributes)
+	}
+	if actualEntry.Attributes[commandDurationLabel] != 0.5 {
+		t.Errorf("expected handler to write entry with command.duration, got %v", actualEntry.Attributes)
+	}
+}
+
+type stubWriter struct {
+	Out []*entry.Entry
+}
+
+func (s *stubWriter) NewEntry(value interface{}) (*entry.Entry, error) {
+	e := entry.New()
+	e.Attributes = make(map[string]interface{})
+	e.Resource = make(map[string]interface{})
+	e.Body = value
+	return e, nil
+}
+
+func (s *stubWriter) Write(ctx context.Context, e *entry.Entry) {
+	s.Out = append(s.Out, e)
+}

--- a/pkg/receiver/jobreceiver/output/logentries/config.go
+++ b/pkg/receiver/jobreceiver/output/logentries/config.go
@@ -6,7 +6,7 @@ import (
 	"io"
 
 	"github.com/SumoLogic/sumologic-otel-collector/pkg/receiver/jobreceiver/output/consumer"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/decoder"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/decode"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split"
 	"go.uber.org/zap"
@@ -35,11 +35,11 @@ type LogEntriesConfig struct {
 
 func (c *LogEntriesConfig) Build(logger *zap.SugaredLogger, op consumer.WriterOp) (consumer.Interface, error) {
 
-	encoding, err := decoder.LookupEncoding(c.Encoding)
+	encoding, err := decode.LookupEncoding(c.Encoding)
 	if err != nil {
 		return nil, fmt.Errorf("log_entries configuration unable to use encoding %s: %w", c.Encoding, err)
 	}
-	splitFunc, err := c.Multiline.Build(encoding, true, true, true, nil, int(c.MaxLogSize))
+	splitFunc, err := c.Multiline.Func(encoding, true, int(c.MaxLogSize), nopTrim)
 	if err != nil {
 		return nil, fmt.Errorf("log_entries configuration could not build split function: %w", err)
 	}
@@ -95,3 +95,5 @@ func (f scannerFactory) splitWithTruncate() bufio.SplitFunc {
 		return
 	}
 }
+
+func nopTrim(b []byte) []byte { return b }

--- a/pkg/receiver/jobreceiver/output/logentries/config.go
+++ b/pkg/receiver/jobreceiver/output/logentries/config.go
@@ -1,10 +1,20 @@
 package logentries
 
 import (
+	"bufio"
+	"fmt"
+	"io"
+
 	"github.com/SumoLogic/sumologic-otel-collector/pkg/receiver/jobreceiver/output/consumer"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/decoder"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split"
 	"go.uber.org/zap"
+)
+
+const (
+	maxDefaultBufferSize = 32 * 1024
+	defaultMaxLogSize    = 1024 * 1024
 )
 
 // LogEntriesConfig handles output as if it is a stream of distinct log events
@@ -24,7 +34,24 @@ type LogEntriesConfig struct {
 }
 
 func (c *LogEntriesConfig) Build(logger *zap.SugaredLogger, op consumer.WriterOp) (consumer.Interface, error) {
-	return &consumer.DemoConsumer{WriterOp: op, Logger: logger}, nil
+
+	encoding, err := decoder.LookupEncoding(c.Encoding)
+	if err != nil {
+		return nil, fmt.Errorf("log_entries configuration unable to use encoding %s: %w", c.Encoding, err)
+	}
+	splitFunc, err := c.Multiline.Build(encoding, true, true, true, nil, int(c.MaxLogSize))
+	if err != nil {
+		return nil, fmt.Errorf("log_entries configuration could not build split function: %w", err)
+	}
+	return &handler{
+		logger: logger,
+		writer: op,
+		config: *c,
+		scanFactory: scannerFactory{
+			splitFunc:  splitFunc,
+			maxLogSize: int(c.MaxLogSize),
+		},
+	}, nil
 }
 
 type LogEntriesConfigFactory struct{}
@@ -33,5 +60,38 @@ func (LogEntriesConfigFactory) CreateDefaultConfig() consumer.Builder {
 	return &LogEntriesConfig{
 		IncludeCommandName: true,
 		IncludeStreamName:  true,
+		MaxLogSize:         defaultMaxLogSize,
+	}
+}
+
+type scannerFactory struct {
+	maxLogSize int
+	splitFunc  bufio.SplitFunc
+}
+
+func (f scannerFactory) Build(in io.Reader) *bufio.Scanner {
+	scanner := bufio.NewScanner(in)
+
+	if f.maxLogSize <= 0 {
+		f.maxLogSize = defaultMaxLogSize
+	}
+	bufferSize := f.maxLogSize / 2
+	if bufferSize > maxDefaultBufferSize {
+		bufferSize = maxDefaultBufferSize
+	}
+	scanner.Buffer(make([]byte, 0, bufferSize), f.maxLogSize)
+	scanner.Split(f.splitWithTruncate())
+	return scanner
+}
+
+func (f scannerFactory) splitWithTruncate() bufio.SplitFunc {
+	return func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+		advance, token, err = f.splitFunc(data, atEOF)
+		if advance == 0 && token == nil && len(data) >= f.maxLogSize {
+			advance, token = f.maxLogSize, data[:f.maxLogSize]
+		} else if len(token) > f.maxLogSize {
+			advance, token = f.maxLogSize, data[:f.maxLogSize]
+		}
+		return
 	}
 }

--- a/pkg/receiver/jobreceiver/output/logentries/handler.go
+++ b/pkg/receiver/jobreceiver/output/logentries/handler.go
@@ -1,0 +1,55 @@
+package logentries
+
+import (
+	"context"
+	"io"
+
+	"github.com/SumoLogic/sumologic-otel-collector/pkg/receiver/jobreceiver/output/consumer"
+	"go.uber.org/zap"
+)
+
+const (
+	streamNameStdout       = "stdout"
+	streamNameStderr       = "stderr"
+	commandNameLabel       = "command.name"
+	commandStreamNameLabel = "command.stream.name"
+)
+
+type handler struct {
+	logger *zap.SugaredLogger
+	writer consumer.WriterOp
+
+	config      LogEntriesConfig
+	scanFactory scannerFactory
+}
+
+func (h *handler) Consume(ctx context.Context, stdout, stderr io.Reader) consumer.CloseFunc {
+	go h.consume(ctx, stdout, streamNameStdout)
+	go h.consume(ctx, stderr, streamNameStderr)
+	return nopCloser
+}
+func (h *handler) consume(ctx context.Context, in io.Reader, stream string) {
+
+	scanner := h.scanFactory.Build(in)
+	for scanner.Scan() {
+		ent, err := h.writer.NewEntry(scanner.Text())
+		if err != nil {
+			h.logger.Errorf("log entry handler could not create a new log entry: %s", err)
+		}
+		if ent.Attributes == nil {
+			ent.Attributes = map[string]interface{}{}
+		}
+		if h.config.IncludeCommandName {
+			ent.Attributes[commandNameLabel] = ctx.Value(consumer.ContextKeyCommandName)
+		}
+		if h.config.IncludeStreamName {
+			ent.Attributes[commandStreamNameLabel] = stream
+		}
+		h.writer.Write(ctx, ent)
+	}
+	if err := scanner.Err(); err != nil {
+		h.logger.Errorf("error reading input stream %s: %w", stream, err)
+	}
+}
+
+func nopCloser(_ consumer.ExecutionSummary) {}

--- a/pkg/receiver/jobreceiver/output/logentries/handler_test.go
+++ b/pkg/receiver/jobreceiver/output/logentries/handler_test.go
@@ -1,0 +1,91 @@
+package logentries
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestConsumeWithMaxLogSize(t *testing.T) {
+	var w stubWriter
+	cfg := LogEntriesConfig{
+		IncludeCommandName: true,
+		IncludeStreamName:  true,
+		MaxLogSize:         128,
+	}
+	h, err := cfg.Build(zap.NewNop().Sugar(), &w)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stdoutR, stdoutW := io.Pipe()
+	stderrR, stderrW := io.Pipe()
+
+	writeStdout := func(w io.WriteCloser) {
+		fmt.Fprint(w, strings.Repeat("a", 64))
+		fmt.Fprint(w, strings.Repeat("a", 64))
+		for i := 0; i < 64; i = i + 8 {
+			fmt.Fprint(w, strings.Repeat("b", 8))
+		}
+		fmt.Fprint(w, "\n")
+		w.Close()
+	}
+
+	writeStderr := func(w io.WriteCloser) {
+		fmt.Fprint(w, "hello world")
+		w.Close()
+	}
+	h.Consume(context.Background(), stdoutR, stderrR)
+
+	go writeStdout(stdoutW)
+	go writeStderr(stderrW)
+
+	done := make(chan struct{})
+	go func() {
+		close(done)
+	}()
+
+	require.Eventually(t,
+		func() bool {
+			w.MU.Lock()
+			defer w.MU.Unlock()
+			return len(w.Out) == 3
+		},
+		time.Second,
+		time.Millisecond*100,
+		"expected three log entries out",
+	)
+	for _, ent := range w.Out {
+		body, ok := ent.Body.(string)
+		require.True(t, ok)
+		assert.LessOrEqual(t, len(body), 128)
+	}
+}
+
+type stubWriter struct {
+	MU  sync.Mutex
+	Out []*entry.Entry
+}
+
+func (s *stubWriter) NewEntry(value interface{}) (*entry.Entry, error) {
+	e := entry.New()
+	e.Attributes = make(map[string]interface{})
+	e.Resource = make(map[string]interface{})
+	e.Body = value
+	return e, nil
+}
+
+func (s *stubWriter) Write(ctx context.Context, e *entry.Entry) {
+	s.MU.Lock()
+	s.Out = append(s.Out, e)
+	s.MU.Unlock()
+}

--- a/pkg/receiver/jobreceiver/receiver_test.go
+++ b/pkg/receiver/jobreceiver/receiver_test.go
@@ -1,0 +1,81 @@
+package jobreceiver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SumoLogic/sumologic-otel-collector/pkg/receiver/jobreceiver/internal/commandtest"
+	"github.com/SumoLogic/sumologic-otel-collector/pkg/receiver/jobreceiver/output"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/featuregate"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+)
+
+// TestMain enable command emulation from commandtest
+func TestMain(m *testing.M) {
+	commandtest.WrapTestMain(m)
+}
+
+func TestMonitoringJob(t *testing.T) {
+	// basic test
+	require.NoError(t, featuregate.GlobalRegistry().Set(featureEnabledId, true))
+	t.Cleanup(func() { require.NoError(t, featuregate.GlobalRegistry().Set(featureEnabledId, false)) })
+
+	f := NewFactory()
+	cfg := testdataConfigSimple()
+
+	sink := new(consumertest.LogsSink)
+
+	rec, err := f.CreateLogsReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, sink)
+	require.NoError(t, err)
+
+	require.NoError(t, rec.Start(context.Background(), componenttest.NewNopHost()))
+
+	if !assert.Eventually(t, expectNLogs(sink, 1), time.Second*5, time.Millisecond*50, "expected one log entry") {
+		t.Fatalf("actual %d, %v", sink.LogRecordCount(), sink.AllLogs())
+	}
+	require.NoError(t, rec.Shutdown(context.Background()))
+
+	first := sink.AllLogs()[0]
+	firstRecord := first.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	assert.Equal(t, "hello world", firstRecord.Body().AsString())
+
+	t.Run("disabled by feature gate", func(t *testing.T) {
+		require.NoError(t, featuregate.GlobalRegistry().Set(featureEnabledId, false))
+
+		f := NewFactory()
+		cfg := testdataConfigSimple()
+
+		sink := new(consumertest.LogsSink)
+
+		rec, err := f.CreateLogsReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, sink)
+		require.NoError(t, err)
+
+		require.NoError(t, rec.Start(context.Background(), componenttest.NewNopHost()))
+		// TODO(ck) bleh.
+		<-time.After(time.Millisecond * 1500)
+
+		assert.Equal(t, 0, sink.LogRecordCount())
+	})
+}
+
+func testdataConfigSimple() *Config {
+	cfg := &Config{
+		Exec:     newDefaultExecutionConfig(),
+		Schedule: ScheduleConfig{Interval: time.Millisecond * 100},
+		Output:   output.NewDefaultConfig(),
+	}
+	cmd, args := commandtest.WrapCommand("echo", []string{"hello world"})
+	cfg.Exec.Command, cfg.Exec.Arguments = cmd, args
+	return cfg
+}
+
+func expectNLogs(sink *consumertest.LogsSink, expected int) func() bool {
+	return func() bool {
+		return expected <= sink.LogRecordCount()
+	}
+}

--- a/pkg/receiver/jobreceiver/runner.go
+++ b/pkg/receiver/jobreceiver/runner.go
@@ -29,6 +29,7 @@ type stubRunner struct {
 func (r *stubRunner) Start(operator.Persister) error {
 	go func() {
 		ctx := context.Background()
+		ctx = context.WithValue(ctx, consumer.ContextKeyCommandName, r.Exec.Command)
 		cmd := command.NewExecution(ctx, command.ExecutionRequest{
 			Command:   r.Exec.Command,
 			Arguments: r.Exec.Arguments,

--- a/pkg/receiver/jobreceiver/runner.go
+++ b/pkg/receiver/jobreceiver/runner.go
@@ -9,33 +9,12 @@ import (
 	"github.com/SumoLogic/sumologic-otel-collector/pkg/receiver/jobreceiver/command"
 	"github.com/SumoLogic/sumologic-otel-collector/pkg/receiver/jobreceiver/output/consumer"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
-	"go.opentelemetry.io/collector/featuregate"
 	"go.uber.org/zap"
 )
-
-const (
-	featureEnabledId          = "receiver.monitoringjob.enabled"
-	featureEnabledStage       = featuregate.StageAlpha
-	featureEnabledDescription = "When enabled, the collector will schedule monitoring jobs."
-)
-
-var enabledGate *featuregate.Gate
-
-func init() {
-	enabledGate = featuregate.GlobalRegistry().MustRegister(
-		featureEnabledId,
-		featureEnabledStage,
-		featuregate.WithRegisterDescription(featureEnabledDescription),
-	)
-}
 
 // Build returns the job runner, the process responsible for scheduling and
 // running commands and piping their output to the output consumer.
 func (c Config) Build(logger *zap.SugaredLogger, out consumer.Interface) (builder.JobRunner, error) {
-	if !enabledGate.IsEnabled() {
-		logger.Warn("monitoringjob feature is not enabled, will not run.")
-		return &nopRunner{}, nil
-	}
 	return &runner{
 		exec:     c.Exec,
 		schedule: c.Schedule,
@@ -114,8 +93,3 @@ func (r *runner) Stop() error {
 	r.wg.Wait()
 	return nil
 }
-
-type nopRunner struct{}
-
-func (_ *nopRunner) Start(operator.Persister) error { return nil }
-func (_ *nopRunner) Stop() error                    { return nil }

--- a/pkg/receiver/jobreceiver/testdata/usage.yaml
+++ b/pkg/receiver/jobreceiver/testdata/usage.yaml
@@ -2,7 +2,7 @@
 receivers:
   monitoringjob/log:
     schedule:
-      interval: 1h
+      interval: 1m
     exec:
       command: /bin/sh
       timeout: 1m
@@ -41,7 +41,7 @@ receivers:
 
   monitoringjob/event:
     schedule:
-      interval: 1h
+      interval: 10s
     exec:
       command: uptime
       timeout: 1m
@@ -79,7 +79,7 @@ processors:
 
 service:
   pipelines:
-    logs/monitorinjob:
+    logs/monitoringjob:
       receivers:
         - monitoringjob/event
         - monitoringjob/log

--- a/pkg/receiver/jobreceiver/testdata/usage.yaml
+++ b/pkg/receiver/jobreceiver/testdata/usage.yaml
@@ -4,9 +4,11 @@ receivers:
     schedule:
       interval: 1h
     exec:
-      command: echo
+      command: /bin/sh
+      timeout: 1m
       arguments:
-          - "hello world"
+        - '-c'
+        - 'for i in {0..120}; do echo -n "werning: " && date -Iseconds --date "90 seconds ago" && sleep 1 && echo "multi line $(head -c 12 /dev/urandom | base64)"; done;'
     output:
       type: log_entries
       log_entries:
@@ -14,6 +16,8 @@ receivers:
         include_stream_name: true
         max_log_size: '16kb'
         encoding: 'utf-8'
+        multiline:
+          line_start_pattern: '\w+:.*'
       attributes:
         type: log
       resource:
@@ -21,28 +25,30 @@ receivers:
       operators:
         - type: regex_parser
           parse_from: body
-          regex: '^(?P<first>\w+).*$'
+          regex: '^(?P<level>\w+):\s+(?P<ts>.*)'
         - type: severity_parser
-          parse_from: attributes.first
+          parse_from: attributes.level
           mapping:
-            error: total
+            error: errrrer
             warn:
+              - werning
               - nonsense
-              - '.'
-              - hello
+              - 'w.a.r.n.'
+        - type: time_parser
+          parse_from: attributes.ts
+          layout_type: gotime
+          layout: '2006-01-02T15:04:05-07:00'
+
   monitoringjob/event:
     schedule:
       interval: 1h
     exec:
-      command: /bin/sh
+      command: uptime
       timeout: 1m
-      arguments:
-        - '-c'
-        - 'for i in {0..120}; do date -Iseconds --date "90 seconds ago" && sleep 1; done;'
     output:
       type: event
       event:
-        include_command_name: false
+        include_command_name: true
         include_command_status: true
         include_command_duration: true
         max_body_size: 1024
@@ -50,11 +56,6 @@ receivers:
         type: event
       resource:
         bingo: bango
-      operators:
-        - type: time_parser
-          parse_from: body
-          layout_type: gotime
-          layout: '2006-01-02T15:04:05-07:00'
 
 
 exporters:


### PR DESCRIPTION
More of an integration PR. I've taken some care to organize this work into discrete commits so that they may be reviewed separately, but I'm not super confident that each could be rebased directly on main in a tidy way. Happy to hear the team's thoughts on how y'all like to review work.

## CLs

* Implement the `event` output handler 
* Implement the `log_entries` output handler
* Implement the receiver ~~(behind feature gate)~~
* ~~Include the receiver in the sumo distro~~

## Demo

Install otel collector per usual, then replace the binary with one built from this branch.
Add this configuration to the globbed config directory:
```
# /etc/otelcol-sumo/conf.d/monitoringjobs.yaml

receivers:
  monitoringjob/log:
    schedule:
      interval: 1m
    exec:
      command: /bin/sh
      timeout: 1m
      arguments:
        - '-c'
        - 'for i in {0..120}; do echo -n "warning: " && date -Iseconds --date "90 seconds ago" && sleep 1 && echo "multi line $(head -c 12 /dev/urandom | base64)"; done;'
    output:
      type: log_entries
      log_entries:
        include_command_name: true
        include_stream_name: true
        max_log_size: '16kb'
        encoding: 'utf-8'
        multiline:
          line_start_pattern: '\w+:.*'
      attributes:
        type: log
      resource:
        demo: '#1258'
      operators:
        - type: regex_parser
          parse_from: body
          regex: '^(?P<level>\w+):\s+(?P<ts>.*)'
        - type: severity_parser
          parse_from: attributes.level
        - type: time_parser
          parse_from: attributes.ts
          layout_type: gotime
          layout: '2006-01-02T15:04:05-07:00'
        - type: move
          from: attributes["command.name"]
          to: resource["_sourceName"]
 monitoringjob/event:
    schedule:
      interval: 10s
    exec:
      command: df
      arguments:
        - '-h'
    output:
      type: event
      event:
        include_command_name: true
        include_command_status: true
        include_command_duration: true
        max_body_size: 1024
      resource:
        demo: '#1258'
      operators:
        - type: move
          from: attributes["command.name"]
          to: resource["_sourceName"]


service:
  pipelines:
    logs/monitoringjob:
      receivers:
        - monitoringjob/event
        - monitoringjob/log
      processors:
        - memory_limiter
        - batch
        - resourcedetection/system
      exporters:
        - sumologic
```


See output in sumo:
<img width="1451" alt="image" src="https://github.com/SumoLogic/sumologic-otel-collector/assets/33990804/dbab3b40-6c3a-4fc5-bb05-86f5c136c8ef">

<img width="1474" alt="image" src="https://github.com/SumoLogic/sumologic-otel-collector/assets/33990804/dec7817d-e5fc-40bc-9223-84cc14be2306">

