### PR TITLE
Cleaned up opamp config, removed duplicate endpoint

### DIFF
--- a/pkg/extension/opampextension/config.go
+++ b/pkg/extension/opampextension/config.go
@@ -27,9 +27,6 @@ import (
 type Config struct {
 	confighttp.HTTPClientSettings `mapstructure:",squash"`
 
-	// Endpoint is the OpAMP server URL. Transport based on the scheme of the URL.
-	Endpoint string `mapstructure:"endpoint"`
-
 	// InstanceUID is a ULID formatted as a 26 character string in canonical
 	// representation. Auto-generated on start if missing.
 	InstanceUID string `mapstructure:"instance_uid"`

--- a/pkg/extension/opampextension/config_test.go
+++ b/pkg/extension/opampextension/config_test.go
@@ -49,7 +49,6 @@ func TestUnmarshalConfig(t *testing.T) {
 					AuthenticatorID: component.NewID("sumologic"),
 				},
 			},
-			Endpoint:                     "wss://127.0.0.1:4320/v1/opamp",
 			InstanceUID:                  "01BX5ZZKBKACTAV9WEVGEMMVRZ",
 			RemoteConfigurationDirectory: "/tmp/",
 		}, cfg)


### PR DESCRIPTION
`Endpoint` is already provided by `confighttp.HTTPClientSettings`.