### PR TITLE
feat: add `debug` exporter and `routing` connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/SumoLogic/sumologic-otel-collector/compare/v0.85.0-sumo-0...main
 
+### Added
+
+- feat: add `debug` exporter [#1268]
+- feat: add `routing` connector [#1268]
+
 ### Changed
 
-- chore: update otelcol core to `v0.86.0`
+- chore: update otelcol core to `v0.86.0` [#1264]
 - chore(ci): build fips binary w/ glibc 2.26 [#1257]
 
 ### Fixed
@@ -22,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#1249]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1249
 [#1257]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1257
+[#1264]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1264
+[#1268]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1268
 
 ## [v0.85.0-sumo-0]
 

--- a/README.md
+++ b/README.md
@@ -69,16 +69,16 @@ The rest of the components in the table are pure upstream OpenTelemetry componen
 |:--------------------------------------------------------:|:------------------------------------------------------------:|:--------------------------------------:|:--------------------------------------------:|:-------------------------------------:|
 |     [active_directory_ds][activedirectorydsreceiver]     |              [attributes][attributesprocessor]               |         [awss3][awss3exporter]         |       [asapclient][asapauthextension]        |      [forward][forwardconnector]      |
 |              [aerospike][aerospikereceiver]              |                   [batch][batchprocessor]                    |        [carbon][carbonexporter]        |             [awsproxy][awsproxy]             |        [count][countconnector]        |
-|                 [apache][apachereceiver]                 |        [`cascading_filter`][cascadingfilterprocessor]        |          [file][fileexporter]          |       [basicauth][basicauthextension]        | [servicegraph][servicegraphconnector] |
-|          [awscloudwatch][awscloudwatchreceiver]          |       [cumulativetodelta][cumulativetodeltaprocessor]        |         [kafka][kafkaexporter]         | [bearertokenauth][bearertokenauthextension]  |  [spanmetrics][spanmetricsconnector]  |
-|    [awscontainerinsight][awscontainerinsightreceiver]    |             [deltatorate][deltatorateprocessor]              | [loadbalancing][loadbalancingexporter] |           [db_storage][dbstorage]            |                                       |
-| [awsecscontainermetrics][awsecscontainermetricsreceiver] | [experimental_metricsgeneration][metricsgenerationprocessor] |       [logging][loggingexporter]       |      [docker_observer][dockerobserver]       |                                       |
-|            [awsfirehose][awsfirehosereceiver]            |                  [filter][filterprocessor]                   |          [otlp][otlpexporter]          |         [ecs_observer][ecsobserver]          |                                       |
-|                [awsxray][awsxrayreceiver]                |            [groupbyattrs][groupbyattrsprocessor]             |      [otlphttp][otlphttpexporter]      |     [ecs_task_observer][ecstaskobserver]     |                                       |
-|          [azureeventhub][azureeventhubreceiver]          |            [groupbytrace][groupbytraceprocessor]             |    [prometheus][prometheusexporter]    |         [file_storage][filestorage]          |                                       |
-|                  [bigip][bigipreceiver]                  |                 [`k8s_tagger`][k8sprocessor]                 |    [`sumologic`][sumologicexporter]    |   [headerssetter][headerssetterextension]    |                                       |
-|                 [carbon][carbonreceiver]                 |           [k8sattributes][k8sattributesprocessor]            |       [`syslog`][syslogexporter]       |     [health_check][healthcheckextension]     |                                       |
-|                 [chrony][chronyreceiver]                 |           [logstransform][logstransformprocessor]            |                                        |        [host_observer][hostobserver]         |                                       |
+|                 [apache][apachereceiver]                 |        [`cascading_filter`][cascadingfilterprocessor]        |         [debug][debugexporter]         |       [basicauth][basicauthextension]        |      [routing][routingconnector]      |
+|          [awscloudwatch][awscloudwatchreceiver]          |       [cumulativetodelta][cumulativetodeltaprocessor]        |          [file][fileexporter]          | [bearertokenauth][bearertokenauthextension]  | [servicegraph][servicegraphconnector] |
+|    [awscontainerinsight][awscontainerinsightreceiver]    |             [deltatorate][deltatorateprocessor]              |         [kafka][kafkaexporter]         |           [db_storage][dbstorage]            |  [spanmetrics][spanmetricsconnector]  |
+| [awsecscontainermetrics][awsecscontainermetricsreceiver] | [experimental_metricsgeneration][metricsgenerationprocessor] | [loadbalancing][loadbalancingexporter] |      [docker_observer][dockerobserver]       |                                       |
+|            [awsfirehose][awsfirehosereceiver]            |                  [filter][filterprocessor]                   |       [logging][loggingexporter]       |         [ecs_observer][ecsobserver]          |                                       |
+|                [awsxray][awsxrayreceiver]                |            [groupbyattrs][groupbyattrsprocessor]             |          [otlp][otlpexporter]          |     [ecs_task_observer][ecstaskobserver]     |                                       |
+|          [azureeventhub][azureeventhubreceiver]          |            [groupbytrace][groupbytraceprocessor]             |      [otlphttp][otlphttpexporter]      |         [file_storage][filestorage]          |                                       |
+|                  [bigip][bigipreceiver]                  |                 [`k8s_tagger`][k8sprocessor]                 |    [prometheus][prometheusexporter]    |   [headerssetter][headerssetterextension]    |                                       |
+|                 [carbon][carbonreceiver]                 |           [k8sattributes][k8sattributesprocessor]            |    [`sumologic`][sumologicexporter]    |     [health_check][healthcheckextension]     |                                       |
+|                 [chrony][chronyreceiver]                 |           [logstransform][logstransformprocessor]            |       [`syslog`][syslogexporter]       |        [host_observer][hostobserver]         |                                       |
 |             [cloudflare][cloudflarereceiver]             |           [memory_limiter][memorylimiterprocessor]           |                                        |       [http_forwarder][httpforwarder]        |                                       |
 |           [cloudfoundry][cloudfoundryreceiver]           |        [`metric_frequency`][metricfrequencyprocessor]        |                                        | [jaegerremotesampling][jaegerremotesampling] |                                       |
 |               [collectd][collectdreceiver]               |        [metricstransform][metricstransformprocessor]         |                                        |         [k8s_observer][k8sobserver]          |                                       |
@@ -272,6 +272,7 @@ The rest of the components in the table are pure upstream OpenTelemetry componen
 
 [awss3exporter]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.86.0/exporter/awss3exporter
 [carbonexporter]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.86.0/exporter/carbonexporter
+[debugexporter]: https://github.com/open-telemetry/opentelemetry-collector/tree/v0.86.0/exporter/debugexporter
 [fileexporter]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.86.0/exporter/fileexporter
 [kafkaexporter]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.86.0/exporter/kafkaexporter
 [loadbalancingexporter]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.86.0/exporter/loadbalancingexporter
@@ -307,5 +308,6 @@ The rest of the components in the table are pure upstream OpenTelemetry componen
 
 [forwardconnector]: https://github.com/open-telemetry/opentelemetry-collector/tree/v0.86.0/connector/forwardconnector
 [countconnector]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.86.0/connector/countconnector
+[routingconnector]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.86.0/connector/routingconnector
 [servicegraphconnector]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.86.0/connector/servicegraphconnector
 [spanmetricsconnector]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.86.0/connector/spanmetricsconnector

--- a/otelcolbuilder/.otelcol-builder.yaml
+++ b/otelcolbuilder/.otelcol-builder.yaml
@@ -21,6 +21,7 @@ exporters:
 
   # Since include-code was removed we need to manually add all core components that we want to include:
   # https://github.com/open-telemetry/opentelemetry-collector/pull/4616
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.86.0
   - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.86.0
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.86.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.86.0
@@ -211,6 +212,7 @@ extensions:
 connectors:
   - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.86.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector v0.86.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.86.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector v0.86.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.86.0
 


### PR DESCRIPTION
They were added in upstream `v0.86.0`.