### PR TITLE
ci: add fips build & msi for windows/amd64

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -88,6 +88,7 @@ jobs:
     name: Build
     uses: ./.github/workflows/workflow-build.yml
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch_os: linux_amd64
@@ -103,6 +104,9 @@ jobs:
             runs-on: macos-latest
           - arch_os: windows_amd64
             runs-on: windows-2022
+          - arch_os: windows_amd64
+            runs-on: windows-2022
+            fips: true
     with:
       arch_os: ${{ matrix.arch_os }}
       runs-on: ${{ matrix.runs-on }}
@@ -219,6 +223,15 @@ jobs:
     runs-on: windows-2019
     needs:
       - build
+    strategy:
+      matrix:
+        include:
+          - arch_os: windows_amd64
+            platform: x64
+            fips: false
+          - arch_os: windows_amd64
+            platform: x64
+            fips: true
     steps:
       - uses: actions/checkout@v4
 
@@ -228,11 +241,16 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.3
 
-      - name: Fetch binary artifact for windows/amd64
+      - name: Fetch binary artifact for ${{ matrix.arch_os }}
         uses: actions/download-artifact@v3
         with:
-          name: otelcol-sumo-windows_amd64.exe
+          name: otelcol-sumo${{ matrix.fips && '-fips' || '' }}-${{ matrix.arch_os }}.exe
           path: ./otelcolbuilder/cmd
+
+      - name: Rename fips binary artifact for ${{ matrix.arch_os }}
+        if: matrix.fips
+        working-directory: ./otelcolbuilder/cmd
+        run: mv otelcol-sumo-fips-${{ matrix.arch_os }}.exe otelcol-sumo-${{ matrix.arch_os }}.exe
 
       - name: Set OVERRIDE_BUILD_NUMBER
         run: echo "OVERRIDE_BUILD_VERSION=$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
@@ -240,15 +258,15 @@ jobs:
       - name: Set PRODUCT_VERSION
         run: echo "PRODUCT_VERSION=$(./ci/get_version.sh productversion)" >> $GITHUB_ENV
 
-      - name: Build MSI for windows/amd64
+      - name: Build MSI for ${{ matrix.arch_os }}
         working-directory: ./packaging/msi/wix
-        run: msbuild.exe -p:Configuration=Release -p:Platform=x64 -p:ProductVersion=$PRODUCT_VERSION -Restore
+        run: msbuild.exe -p:Configuration=Release -p:Platform=${{ matrix.platform }} -p:ProductVersion=$PRODUCT_VERSION -p:FIPSEnabled=${{ matrix.fips }} -Restore
 
-      - name: Store MSI as action artifact for windows/amd64
+      - name: Store MSI as action artifact for ${{ matrix.arch_os }}
         uses: actions/upload-artifact@v3
         with:
-          name: windows_amd64_msi
-          path: ./packaging/msi/wix/bin/x64/en-US/*.msi
+          name: ${{ matrix.arch_os }}${{ matrix.fips && '_fips' || '' }}_msi
+          path: ./packaging/msi/wix/bin/${{ matrix.platform }}/en-US/*.msi
           if-no-files-found: error
 
   # Triggers build_packages workflow in the sumologic-otel-collector-packaging

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -59,11 +59,24 @@ jobs:
         run: ./ci/fetch_current_branch.sh
 
       - name: Setup go
-        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
+        if: |
+          ! (contains(inputs.arch_os, 'windows') && inputs.fips) &&
+          (! inputs.only-if-changed ||
+          steps.changed-files.outputs.any_changed == 'true')
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
+
+      - name: Setup go (Microsoft fork)
+        if: |
+          (contains(inputs.arch_os, 'windows') && inputs.fips) &&
+          (! inputs.only-if-changed ||
+          steps.changed-files.outputs.any_changed == 'true')
+        run: |
+          curl -Lo go.zip https://aka.ms/golang/release/latest/go${{ env.GO_VERSION }}.windows-amd64.zip &&
+          powershell -command "Expand-Archive go.zip D:\\a\\_work\\1\\s" &&
+          echo "/d/a/_work/1/s/go/bin" >> $GITHUB_PATH
 
       - name: Get Go env values
         if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
@@ -92,15 +105,15 @@ jobs:
             ${{ steps.get-cache-key.outputs.restore-keys }}
 
       - name: Set default BUILDER_BIN_PATH
-        if: ${{ ! inputs.fips && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
+        if: ${{ ! (inputs.fips && contains(inputs.arch_os, 'linux')) && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
         run: echo "BUILDER_BIN_PATH=${HOME}/bin" >> $GITHUB_ENV
 
       - name: Add opentelemetry-collector-builder installation dir to PATH
-        if: ${{ ! inputs.fips && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
+        if: ${{ ! (inputs.fips && contains(inputs.arch_os, 'linux')) && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
         run: echo "$BUILDER_BIN_PATH" >> $GITHUB_PATH
 
       - name: Install opentelemetry-collector-builder
-        if: ${{ ! inputs.fips && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
+        if: ${{ ! (inputs.fips && contains(inputs.arch_os, 'linux')) && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
         run: make install-builder
         working-directory: ./otelcolbuilder
 
@@ -110,11 +123,16 @@ jobs:
         working-directory: ./otelcolbuilder
 
       - name: Build (FIPS)
-        if: ${{ inputs.fips && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
+        if: ${{ inputs.fips && contains(inputs.arch_os, 'linux') && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
         id: containerized-build
         uses: ./ci/build-fips-action
         with:
           go-version: ${{ env.GO_VERSION }}
+
+      - name: Build (FIPS)
+        if: ${{ inputs.fips && ! contains(inputs.arch_os, 'linux') && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
+        run: make otelcol-sumo-${{inputs.arch_os}} FIPS_SUFFIX="-fips" CGO_ENABLED=1
+        working-directory: ./otelcolbuilder
 
       - name: Set binary name
         id: set-binary-name
@@ -122,11 +140,26 @@ jobs:
         run: echo "binary_name=otelcol-sumo${OTELCOL_FIPS_SUFFIX}-${{inputs.arch_os}}${OTELCOL_BINARY_EXTENSION}" >> $GITHUB_OUTPUT
 
       - name: Show BoringSSL symbols
-        if: ${{ inputs.fips && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
+        if: |
+          inputs.fips &&
+          contains(inputs.arch_os, 'linux') &&
+          (! inputs.only-if-changed ||
+          steps.changed-files.outputs.any_changed == 'true')
         working-directory: ./otelcolbuilder/cmd
         run: |
           go tool nm ${{ steps.set-binary-name.outputs.binary_name }} | \
           grep "_Cfunc__goboringcrypto_"
+
+      - name: Show Microsoft Cryptography Next-Generation symbols
+        if: |
+          inputs.fips &&
+          contains(inputs.arch_os, 'windows') &&
+          (! inputs.only-if-changed ||
+          steps.changed-files.outputs.any_changed == 'true')
+        working-directory: ./otelcolbuilder/cmd
+        run: |
+          go tool nm ${{ steps.set-binary-name.outputs.binary_name }} | \
+          grep "vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt.GetFipsAlgorithmMode"
 
       - name: Test binary
         if: ${{ (inputs.arch_os == env.ARCH_OS) && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}

--- a/otelcolbuilder/Makefile
+++ b/otelcolbuilder/Makefile
@@ -3,6 +3,7 @@ BUILDER_VERSION ?= 0.87.0
 FIPS_SUFFIX ?= ""
 BUILDER_REPO ?= github.com/open-telemetry/opentelemetry-collector
 GO ?= go
+GOTAGS ?=
 
 ifeq ($(OS),Windows_NT)
 	OS=windows
@@ -51,14 +52,20 @@ GOEXPERIMENT=""
 LDFLAGS="-s -w"
 # We want to use boringcrypto for fips setup
 else
+ifeq ($(shell go env GOOS),windows)
+GOEXPERIMENT=cngcrypto
+GOTAGS := $(GOTAGS) requirefips
+LDFLAGS="-w"
+else
 GOEXPERIMENT=boringcrypto
 LDFLAGS="-w"
+endif
 endif
 
 # We want to enforce go dns for all types of binaries. The FIPS binaries are built with CGO enabled and use
 # the CGO resolver. This has caused a DNS resolution error for .local domains in our K8s containers.
 # ref: https://pkg.go.dev/net#hdr-Name_Resolution
-GOFLAGS=-tags=netgo
+GOTAGS := $(GOTAGS) netgo
 
 .PHONY: _install-bin
 _install-bin:
@@ -103,7 +110,8 @@ _builder:
 .PHONY: _gobuild
 _gobuild:
 	(cd cmd && \
-		GOFLAGS=$(GOFLAGS) CGO_ENABLED=$(CGO_ENABLED) GOEXPERIMENT=$(GOEXPERIMENT) go build -v \
+		CGO_ENABLED=$(CGO_ENABLED) GOEXPERIMENT=$(GOEXPERIMENT) go build -v \
+		-tags "$(GOTAGS)" \
 		-ldflags=$(LDFLAGS) \
 		-trimpath \
 		-o ./$(BINARY_NAME)$(BUILDER_BIN_EXT) . \
@@ -113,7 +121,8 @@ _gobuild:
 .PHONY: _gobuild_debug
 _gobuild_debug:
 	(cd cmd && \
-		GOFLAGS=$(GOFLAGS) CGO_ENABLED=$(CGO_ENABLED) GOEXPERIMENT=$(GOEXPERIMENT) go build -v \
+		CGO_ENABLED=$(CGO_ENABLED) GOEXPERIMENT=$(GOEXPERIMENT) go build -v \
+		-tags "$(GOTAGS)" \
 		-race \
 		-gcflags "all=-N -l" \
 		-o ./$(BINARY_NAME)-debug$(BUILDER_BIN_EXT) . \

--- a/otelcolbuilder/cmd/fips.go
+++ b/otelcolbuilder/cmd/fips.go
@@ -1,4 +1,4 @@
-//go:build boringcrypto
+//go:build goexperiment.boringcrypto || goexperiment.cngcrypto
 
 package main
 

--- a/packaging/msi/wix/otelcol-sumo.wixproj
+++ b/packaging/msi/wix/otelcol-sumo.wixproj
@@ -7,6 +7,7 @@
     <Cultures>en-US</Cultures>
     <DebugType>none</DebugType>
     <RepoRoot>$([System.IO.Path]::GetFullPath('..\..\..'))</RepoRoot>
+    <FIPSEnabled>false</FIPSEnabled>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -14,9 +15,16 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <OutputName>otelcol-sumo_$(ProductVersion)_en-US.$(Platform)</OutputName>
     <OutputPath>bin\$(Platform)\</OutputPath>
     <IntermediateOutputPath>obj\$(Platform)\</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(FIPSEnabled)' == 'false'">
+    <OutputName>otelcol-sumo_$(ProductVersion)_en-US.$(Platform)</OutputName>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(FIPSEnabled)' == 'true'">
+    <OutputName>otelcol-sumo_$(ProductVersion)_en-US.$(Platform)-fips</OutputName>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Adds a new `windows/amd64` FIPS binary and a new corresponding MSI package. Test CI run: https://github.com/SumoLogic/sumologic-otel-collector/actions/runs/6397614173

I validated the new FIPS binary is installed by the new MSI package by both verifying the checksum of the installed `otelcol-sumo.exe` file and using `go tool nm .\otelcol-sumo.exe | Select-String vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt.GetFipsAlgorithmMode`.