### PR TITLE
Bypass FQDN resolution in darwin tests

### DIFF
--- a/pkg/extension/sumologicextension/extension.go
+++ b/pkg/extension/sumologicextension/extension.go
@@ -986,10 +986,13 @@ func addClientCredentials(req *http.Request, credentials accessCredentials) {
 	req.Header.Add("Authorization", authHeaderValue)
 }
 
+// TODO(ck): hostname allows the darwin tests to bypass fqdn.
+var hostname = fqdn.FqdnHostname
+
 // getHostname returns the host name consistently with the resource detection processor's defaults
 // TODO: try to dynamically extract this from the resource processor in the pipeline
 func getHostname(logger *zap.Logger) (string, error) {
-	fqdnHostname, err := fqdn.FqdnHostname()
+	fqdnHostname, err := hostname()
 	if err == nil {
 		return fqdnHostname, nil
 	}

--- a/pkg/extension/sumologicextension/extension_darwin_test.go
+++ b/pkg/extension/sumologicextension/extension_darwin_test.go
@@ -1,0 +1,10 @@
+package sumologicextension
+
+import "os"
+
+func init() {
+	// fqdn seems to hang running in github actions on darwin amd64. This
+	// bypasses it.
+	// https://github.com/SumoLogic/sumologic-otel-collector/issues/1295
+	hostname = os.Hostname
+}


### PR DESCRIPTION
Adds a hack to work around issue https://github.com/SumoLogic/sumologic-otel-collector/issues/1295