### PR TITLE
fix(install): install policycoreutils on RHEL if missing

### DIFF
--- a/.changelog/1306.fixed.txt
+++ b/.changelog/1306.fixed.txt
@@ -1,0 +1,1 @@
+fix(install): install policycoreutils on RHEL if missing This dependency is necessary for using semanage, which is needed to do SELinux relabeling.


### PR DESCRIPTION
This dependency is necessary for using semanage, which is needed to do SELinux relabeling.