### PR TITLE
chore: remove `multierr` package in favor of built-in `errors.Join`

### DIFF
--- a/pkg/exporter/sumologicexporter/exporter.go
+++ b/pkg/exporter/sumologicexporter/exporter.go
@@ -32,7 +32,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"github.com/SumoLogic/sumologic-otel-collector/pkg/extension/sumologicextension"
@@ -251,7 +250,7 @@ func (se *sumologicexporter) pushLogsData(ctx context.Context, ld plog.Logs) err
 
 		errs = deduplicateErrors(errs)
 		se.handleUnauthorizedErrors(ctx, errs...)
-		return consumererror.NewLogs(multierr.Combine(errs...), ld)
+		return consumererror.NewLogs(errors.Join(errs...), ld)
 	}
 
 	return nil
@@ -302,7 +301,7 @@ func (se *sumologicexporter) pushMetricsData(ctx context.Context, md pmetric.Met
 
 	if len(errs) > 0 {
 		se.handleUnauthorizedErrors(ctx, errs...)
-		return consumererror.NewMetrics(multierr.Combine(errs...), droppedMetrics)
+		return consumererror.NewMetrics(errors.Join(errs...), droppedMetrics)
 	}
 
 	return nil

--- a/pkg/exporter/sumologicexporter/go.mod
+++ b/pkg/exporter/sumologicexporter/go.mod
@@ -13,7 +13,6 @@ require (
 	go.opentelemetry.io/collector/consumer v0.88.0
 	go.opentelemetry.io/collector/exporter v0.88.0
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0017
-	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.26.0
 	golang.org/x/exp v0.0.0-20230711023510-fffb14384f22
 )
@@ -66,6 +65,7 @@ require (
 	go.opentelemetry.io/otel v1.19.0 // indirect
 	go.opentelemetry.io/otel/metric v1.19.0 // indirect
 	go.opentelemetry.io/otel/trace v1.19.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect

--- a/pkg/exporter/sumologicexporter/sender.go
+++ b/pkg/exporter/sumologicexporter/sender.go
@@ -32,7 +32,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"github.com/SumoLogic/sumologic-otel-collector/pkg/exporter/sumologicexporter/internal/observability"
@@ -465,7 +464,7 @@ func (s *sender) sendNonOTLPLogs(ctx context.Context, rl plog.ResourceLogs, flds
 		}
 	}
 
-	return droppedRecords, multierr.Combine(errs...)
+	return droppedRecords, errors.Join(errs...)
 }
 
 func (s *sender) formatLogLine(lr plog.LogRecord) (string, error) {

--- a/pkg/exporter/sumologicexporter/sender_test.go
+++ b/pkg/exporter/sumologicexporter/sender_test.go
@@ -351,7 +351,7 @@ func TestSendLogsSplitFailedAll(t *testing.T) {
 	assert.EqualError(
 		t,
 		err,
-		"failed sending data: status: 500 Internal Server Error; failed sending data: status: 404 Not Found",
+		"failed sending data: status: 500 Internal Server Error\nfailed sending data: status: 404 Not Found",
 	)
 	assert.Len(t, dropped, 2)
 
@@ -825,7 +825,7 @@ func TestSendLogsJsonSplitFailedAll(t *testing.T) {
 	assert.EqualError(
 		t,
 		err,
-		"failed sending data: status: 500 Internal Server Error; failed sending data: status: 404 Not Found",
+		"failed sending data: status: 500 Internal Server Error\nfailed sending data: status: 404 Not Found",
 	)
 	assert.Len(t, dropped, 2)
 


### PR DESCRIPTION
Refs: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/25121