### PR TITLE
chore: replace deprecated module go.opentelemetry.io/collector/model

### DIFF
--- a/pkg/processor/k8sprocessor/go.mod
+++ b/pkg/processor/k8sprocessor/go.mod
@@ -17,7 +17,6 @@ require (
 require (
 	go.opentelemetry.io/collector/component v0.88.0
 	go.opentelemetry.io/collector/consumer v0.88.0
-	go.opentelemetry.io/collector/model v0.50.0
 	go.opentelemetry.io/collector/otelcol v0.88.0
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0017
 	go.opentelemetry.io/collector/processor v0.88.0

--- a/pkg/processor/k8sprocessor/go.sum
+++ b/pkg/processor/k8sprocessor/go.sum
@@ -414,8 +414,6 @@ go.opentelemetry.io/collector/extension v0.88.0/go.mod h1:5wPlOyWtVJcZS9CMhFUnuR
 go.opentelemetry.io/collector/extension/zpagesextension v0.88.0 h1:cpkwzjhq6jfkVq3ltUl9wdb/8RrWbn0utHTCU3K5Mhc=
 go.opentelemetry.io/collector/featuregate v1.0.0-rcv0017 h1:DtJQalPXMWQqT6jd2LZ1oKrOfLJJRCi+rh2LKnkj4Zo=
 go.opentelemetry.io/collector/featuregate v1.0.0-rcv0017/go.mod h1:fLmJMf1AoHttkF8p5oJAc4o5ZpHu8yO5XYJ7gbLCLzo=
-go.opentelemetry.io/collector/model v0.50.0 h1:1wt8pQ4O6GaUeYEaR+dh3zHmYsFicduF2bbPGMZeSKk=
-go.opentelemetry.io/collector/model v0.50.0/go.mod h1:vKpC0JMtrL7g9tUHmzcQqd8rEbnahKVdTWZSVO7x3Ms=
 go.opentelemetry.io/collector/otelcol v0.88.0 h1:f2eRVLJY66w9WFj5iT1Tg6Qxtlljagov9v8TPStuK2g=
 go.opentelemetry.io/collector/otelcol v0.88.0/go.mod h1:F85TtMPt+ySe29HD6DOyvsMFCV3onaB3VJzky7qrtzQ=
 go.opentelemetry.io/collector/pdata v1.0.0-rcv0017 h1:AgALhc2VenoA5l1DvTdg7mkzaBGqoTSuMkAtjsttBFo=

--- a/pkg/processor/k8sprocessor/kube/kube.go
+++ b/pkg/processor/k8sprocessor/kube/kube.go
@@ -18,7 +18,7 @@ import (
 	"regexp"
 	"time"
 
-	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.18.0"
 
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/processor/k8sprocessor/pod_association.go
+++ b/pkg/processor/k8sprocessor/pod_association.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/collector/client"
-	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	conventions "go.opentelemetry.io/collector/semconv/v1.18.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sprocessor/kube"
 )

--- a/pkg/processor/k8sprocessor/processor_test.go
+++ b/pkg/processor/k8sprocessor/processor_test.go
@@ -28,12 +28,12 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
-	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/processor"
+	conventions "go.opentelemetry.io/collector/semconv/v1.18.0"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"

--- a/pkg/processor/sumologicschemaprocessor/cloud_namespace_processor.go
+++ b/pkg/processor/sumologicschemaprocessor/cloud_namespace_processor.go
@@ -15,11 +15,11 @@
 package sumologicschemaprocessor
 
 import (
-	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	conventions "go.opentelemetry.io/collector/semconv/v1.18.0"
 )
 
 // cloudNamespaceProcessor adds the `cloud.namespace` resource attribute to logs, metrics and traces.

--- a/pkg/processor/sumologicschemaprocessor/go.mod
+++ b/pkg/processor/sumologicschemaprocessor/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/stretchr/testify v1.8.4
-	go.opentelemetry.io/collector/model v0.50.0
 	go.opentelemetry.io/otel v1.19.0 // indirect
 	go.opentelemetry.io/otel/metric v1.19.0 // indirect
 	go.opentelemetry.io/otel/trace v1.19.0 // indirect
@@ -30,6 +29,7 @@ require (
 	go.opentelemetry.io/collector/otelcol v0.88.0
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0017
 	go.opentelemetry.io/collector/processor v0.88.0
+	go.opentelemetry.io/collector/semconv v0.88.0
 )
 
 require (
@@ -75,7 +75,6 @@ require (
 	go.opentelemetry.io/collector/extension v0.88.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.0.0-rcv0017 // indirect
 	go.opentelemetry.io/collector/receiver v0.88.0 // indirect
-	go.opentelemetry.io/collector/semconv v0.88.0 // indirect
 	go.opentelemetry.io/collector/service v0.88.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.20.0 // indirect
 	go.opentelemetry.io/otel/bridge/opencensus v0.42.0 // indirect

--- a/pkg/processor/sumologicschemaprocessor/go.sum
+++ b/pkg/processor/sumologicschemaprocessor/go.sum
@@ -317,8 +317,6 @@ go.opentelemetry.io/collector/extension v0.88.0/go.mod h1:5wPlOyWtVJcZS9CMhFUnuR
 go.opentelemetry.io/collector/extension/zpagesextension v0.88.0 h1:cpkwzjhq6jfkVq3ltUl9wdb/8RrWbn0utHTCU3K5Mhc=
 go.opentelemetry.io/collector/featuregate v1.0.0-rcv0017 h1:DtJQalPXMWQqT6jd2LZ1oKrOfLJJRCi+rh2LKnkj4Zo=
 go.opentelemetry.io/collector/featuregate v1.0.0-rcv0017/go.mod h1:fLmJMf1AoHttkF8p5oJAc4o5ZpHu8yO5XYJ7gbLCLzo=
-go.opentelemetry.io/collector/model v0.50.0 h1:1wt8pQ4O6GaUeYEaR+dh3zHmYsFicduF2bbPGMZeSKk=
-go.opentelemetry.io/collector/model v0.50.0/go.mod h1:vKpC0JMtrL7g9tUHmzcQqd8rEbnahKVdTWZSVO7x3Ms=
 go.opentelemetry.io/collector/otelcol v0.88.0 h1:f2eRVLJY66w9WFj5iT1Tg6Qxtlljagov9v8TPStuK2g=
 go.opentelemetry.io/collector/otelcol v0.88.0/go.mod h1:F85TtMPt+ySe29HD6DOyvsMFCV3onaB3VJzky7qrtzQ=
 go.opentelemetry.io/collector/pdata v1.0.0-rcv0017 h1:AgALhc2VenoA5l1DvTdg7mkzaBGqoTSuMkAtjsttBFo=


### PR DESCRIPTION
Changes usages of package [go.opentelemetry.io/collector/model/semconv/](https://pkg.go.dev/go.opentelemetry.io/collector/model/semconv) to latest [go.opentelemetry.io/collector/semconv/](https://pkg.go.dev/go.opentelemetry.io/collector/semconv) package (currently `v1.18.0` as of collector `v0.88.0`). I have verified that the used conventions haven't changed between versions.