### PR TITLE
fix: build release fips binary w/glibc 2.26

### DIFF
--- a/.changelog/1317.fixed.txt
+++ b/.changelog/1317.fixed.txt
@@ -1,0 +1,1 @@
+fix: build release fips binary w/glibc 2.26

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -227,9 +227,11 @@ jobs:
       - name: Prepare tags in otelcolbuilder's config
         run: make prepare-tag TAG=${{ steps.extract_tag.outputs.tag }}
 
-      - name: Build
-        run: make otelcol-sumo-${{matrix.arch_os}} FIPS_SUFFIX="-fips" CGO_ENABLED=1
-        working-directory: ./otelcolbuilder
+      - name: Build (FIPS)
+        id: containerized-build
+        uses: ./ci/build-fips-action
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Set filename
         id: set_filename


### PR DESCRIPTION
Related to: https://github.com/SumoLogic/sumologic-otel-collector/pull/1257
At this moment dev FIPS binary is built with glibc 2.26 but release FIPS binary is built with glibc 2.28 which is not available on Linux Amazon 2