### PR TITLE
Use shorter SHA abbreviation for dev build version tags

### DIFF
--- a/otelcolbuilder/Makefile
+++ b/otelcolbuilder/Makefile
@@ -97,7 +97,7 @@ endif
 
 .PHONY: _builder
 _builder:
-	$(eval VERSION ?= $(shell git describe --tags --abbrev=10 --match "v[0-9]*"))
+	$(eval VERSION ?= $(shell git describe --tags --abbrev=5 --match "v[0-9]*"))
 # Need to specify go path because otherwise opentelemetry-collector-builder
 # uses /usr/bin/go which on Github Actions is using preinstalled 1.15.12 by default.
 	CGO_ENABLED=$(CGO_ENABLED) $(BUILDER_BIN_NAME) \


### PR DESCRIPTION
The sumologic OT collector metadata service has a limit of 32 characters for version number. When we publish a dev build the additional `-fips` suffix puts us over the 32 character limit. This change shortens the commit sha abbreviation so that we'll stay under 32 characters.