### PR TITLE
Add FIPS MSI build & FIPS install.ps1 flag

### DIFF
--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -36,6 +36,13 @@ jobs:
             runs_on: windows-2022
             builder_bin_path: '${RUNNER_TEMP}\bin'
             builder_bin_ext: .exe
+          - arch_os: windows_amd64
+            runs_on: windows-2022
+            builder_bin_path: '${RUNNER_TEMP}\bin'
+            builder_bin_ext: .exe
+            fips: true
+    env:
+      OTELCOL_FIPS_SUFFIX: ${{ matrix.fips && '-fips' || '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -43,10 +50,18 @@ jobs:
         run: ./ci/fetch_current_branch.sh
 
       - name: Setup go
+        if: ${{ ! (contains(matrix.arch_os, 'windows') && matrix.fips) }}
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: '**/go.sum'
+
+      - name: Setup go (Microsoft fork)
+        if: contains(matrix.arch_os, 'windows') && matrix.fips
+        run: |
+          curl -Lo go.zip https://aka.ms/golang/release/latest/go${{ env.GO_VERSION }}.windows-amd64.zip &&
+          powershell -command "Expand-Archive go.zip D:\\a\\_work\\1\\s" &&
+          echo "/d/a/_work/1/s/go/bin" >> $GITHUB_PATH
 
       - name: Set default BUILDER_BIN_PATH
         run: echo "BUILDER_BIN_PATH=${HOME}/bin" >> $GITHUB_ENV
@@ -73,16 +88,29 @@ jobs:
         run: make prepare-tag TAG=${{ steps.extract_tag.outputs.tag }}
 
       - name: Build
+        if: ${{ ! (matrix.fips && contains(matrix.arch_os, 'windows')) }}
         run: make otelcol-sumo-${{matrix.arch_os}}
+        working-directory: ./otelcolbuilder
+
+      - name: Build (FIPS) for Windows
+        if: matrix.fips && contains(matrix.arch_os, 'windows')
+        run: make otelcol-sumo-${{matrix.arch_os}} FIPS_SUFFIX="-fips" CGO_ENABLED=1
         working-directory: ./otelcolbuilder
 
       - name: Set filename
         id: set_filename
-        run: echo "filename=$(echo otelcol-sumo-${{ steps.extract_tag.outputs.tag }}-${{matrix.arch_os}})${{matrix.builder_bin_ext}}" > $GITHUB_OUTPUT
+        run: echo "filename=$(echo otelcol-sumo-${{ steps.extract_tag.outputs.tag }}${OTELCOL_FIPS_SUFFIX}-${{matrix.arch_os}})${{matrix.builder_bin_ext}}" > $GITHUB_OUTPUT
 
       - name: Rename to include tag in filename
-        run: cp otelcol-sumo-${{matrix.arch_os}}${{matrix.builder_bin_ext}} ${{ steps.set_filename.outputs.filename }}
+        run: cp otelcol-sumo${OTELCOL_FIPS_SUFFIX}-${{matrix.arch_os}}${{matrix.builder_bin_ext}} ${{ steps.set_filename.outputs.filename }}
         working-directory: ./otelcolbuilder/cmd
+
+      - name: Show Microsoft Cryptography Next-Generation symbols
+        if: matrix.fips && contains(matrix.arch_os, 'windows')
+        working-directory: ./otelcolbuilder/cmd
+        run: |
+          go tool nm ${{ steps.set_filename.outputs.filename }} | \
+          grep "vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt.GetFipsAlgorithmMode"
 
       - name: Sign Windows binary
         if: runner.os == 'Windows'
@@ -98,7 +126,7 @@ jobs:
       - name: Store binary as action artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{matrix.arch_os}}
+          name: ${{matrix.arch_os}}${{ matrix.fips && '_fips' || '' }}
           path: ./otelcolbuilder/cmd/${{ steps.set_filename.outputs.filename }}
           if-no-files-found: error
 
@@ -371,6 +399,15 @@ jobs:
     runs-on: windows-2019
     needs:
       - build
+    strategy:
+      matrix:
+        include:
+          - arch_os: windows_amd64
+            platform: x64
+            fips: false
+          - arch_os: windows_amd64
+            platform: x64
+            fips: true
     steps:
       - uses: actions/checkout@v4
 
@@ -380,15 +417,22 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.3
 
-      - name: Fetch binary artifact for windows/amd64
+      - name: Extract tag
+        id: extract_tag
+        run: echo "tag=$(echo ${GITHUB_REF#refs/tags/v})" > $GITHUB_OUTPUT
+
+      - name: Print tag
+        run: echo "${{ steps.extract_tag.outputs.tag }}"
+
+      - name: Fetch binary artifact for ${{ matrix.arch_os }}
         uses: actions/download-artifact@v3
         with:
-          name: windows_amd64
+          name: windows_amd64_fips
           path: ./otelcolbuilder/cmd
 
-      - name: Rename binary for windows/amd64
+      - name: Rename binary artifact for ${{ matrix.arch_os }}
         working-directory: ./otelcolbuilder/cmd
-        run: mv otelcol-sumo-*-sumo-*-windows_amd64.exe otelcol-sumo-windows_amd64.exe
+        run: mv otelcol-sumo-*-sumo-*${{ matrix.arch_os }}.exe otelcol-sumo-${{ matrix.arch_os }}.exe
 
       - name: Set VERSION_TAG
         run: echo "VERSION_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
@@ -396,9 +440,9 @@ jobs:
       - name: Set PRODUCT_VERSION
         run: echo "PRODUCT_VERSION=$(./ci/get_version.sh productversion)" >> $GITHUB_ENV
 
-      - name: Build MSI for windows/amd64
+      - name: Build MSI for ${{ matrix.arch_os }}
         working-directory: ./packaging/msi/wix
-        run: msbuild.exe -p:Configuration=Release -p:Platform=x64 -p:ProductVersion=$PRODUCT_VERSION -Restore
+        run: msbuild.exe -p:Configuration=Release -p:Platform=${{ matrix.platform }} -p:ProductVersion=$PRODUCT_VERSION -p:FIPSEnabled=${{ matrix.fips }} -Restore
 
       - name: Sign MSI
         uses: skymatic/code-sign-action@v2
@@ -408,13 +452,13 @@ jobs:
           certificatesha1: '${{ secrets.MICROSOFT_CERTHASH }}'
           certificatename: '${{ secrets.MICROSOFT_CERTNAME }}'
           description: '${{ secrets.MICROSOFT_DESCRIPTION }}'
-          folder: ./packaging/msi/wix/bin/x64/en-US
+          folder: ./packaging/msi/wix/bin/${{ matrix.platform }}/en-US
 
-      - name: Store MSI as action artifact for windows/amd64
+      - name: Store MSI as action artifact for ${{ matrix.arch_os }}
         uses: actions/upload-artifact@v3
         with:
-          name: windows_amd64_msi
-          path: ./packaging/msi/wix/bin/x64/en-US/*.msi
+          name: ${{ matrix.arch_os }}${{ matrix.fips && '_fips' || '' }}_msi
+          path: ./packaging/msi/wix/bin/${{ matrix.platform }}/en-US/*.msi
           if-no-files-found: error
 
   install-script:


### PR DESCRIPTION
Adds a FIPS release build for `windows/amd64` and a new `-Fips` flag for the `install.ps1` script. This shouldn't be merged until we're approved to use Microsoft's fork of Go.

I tested this on a fork of this repository. CI run https://github.com/sensu/sumologic-otel-collector/actions/runs/6822421395 & release https://github.com/sensu/sumologic-otel-collector/releases.