### PR TITLE
feat(exporter/syslog): deprecate syslog exporter in favor of upstream version of syslog exporter

### DIFF
--- a/.changelog/1342.changed.txt
+++ b/.changelog/1342.changed.txt
@@ -1,0 +1,1 @@
+feat(exporter/syslog): deprecate syslog exporter in favor of upstream version of syslog exporter

--- a/pkg/exporter/syslogexporter/README.md
+++ b/pkg/exporter/syslogexporter/README.md
@@ -1,6 +1,45 @@
 # Syslog Exporter
 
-**Stability level**: Alpha
+**Stability level**: Deprecated
+
+This exporter is deprecated in favor of the [syslog exporter][syslog_exporter_contrib] that lives in the [OpenTelemetry Collector Contrib][contrib_repo] repository.
+The functionality is the same but the configuration is slightly different.
+
+To migrate, rename the following keys in configuration for `syslogexporter`:
+
+- rename `protocol` property to `network`
+- rename `format` property to `protocol`
+
+For example, given the following configuration:
+
+```yaml
+  syslog:
+    protocol: tcp
+    port: 514
+    endpoint: 127.0.0.1
+    format: rfc5424
+    tls:
+      ca_file: ca.pem
+      cert_file: cert.pem
+      key_file: key.pem
+```
+
+change it to:
+
+```yaml
+  syslog:
+    network: tcp
+    port: 514
+    endpoint: 127.0.0.1
+    protocol: rfc5424
+    tls:
+      ca_file: ca.pem
+      cert_file: cert.pem
+      key_file:  key.pem
+```
+
+[syslog_exporter_contrib]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/syslogexporter/README.md
+[contrib_repo]: https://github.com/open-telemetry/opentelemetry-collector-contrib/
 
 ## About The Exporter
 

--- a/pkg/exporter/syslogexporter/factory.go
+++ b/pkg/exporter/syslogexporter/factory.go
@@ -26,7 +26,7 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr        = "syslog"
-	stabilityLevel = component.StabilityLevelAlpha
+	stabilityLevel = component.StabilityLevelDeprecated
 )
 
 // NewFactory returns a new factory for the syslog exporter.


### PR DESCRIPTION
Related to #1341 