### PR TITLE
chore: update Go to 1.21

### DIFF
--- a/.changelog/1340.changed.txt
+++ b/.changelog/1340.changed.txt
@@ -1,1 +1,1 @@
-chore: update Go to `v1.20.11`
+chore: update Go to `v1.21`

--- a/.changelog/1344.changed.txt
+++ b/.changelog/1344.changed.txt
@@ -1,0 +1,1 @@
+chore: update Go to `v1.21`

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -11,7 +11,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: "1.20.11"
+  GO_VERSION: "~1.21.4"
 
 jobs:
 

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -10,7 +10,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: "1.20.11"
+  GO_VERSION: "~1.21.4"
 
 jobs:
 

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -18,7 +18,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: "1.20.11"
+  GO_VERSION: "~1.21.4"
 
 jobs:
 

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -28,7 +28,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: "1.20.11"
+  GO_VERSION: "~1.21.4"
 
 jobs:
   build:

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -28,7 +28,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: "1.20.11"
+  GO_VERSION: "~1.21.4"
 
 jobs:
   test:

--- a/Dockerfile_local
+++ b/Dockerfile_local
@@ -1,4 +1,4 @@
-FROM golang:1.20.11-alpine as builder
+FROM golang:1.21-alpine as builder
 ADD . /src
 WORKDIR /src/otelcolbuilder/
 ENV CGO_ENABLED=0

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export GO_VERSION="1.20.11"
+export GO_VERSION="1.21.4"
 
 sudo apt update -y
 sudo apt install -y \


### PR DESCRIPTION
I used more flexible version constraints where I could, so we automatically use the latest minor version.