### PR TITLE
build: revert back to Go 1.20

### DIFF
--- a/.changelog/1346.fixed.txt
+++ b/.changelog/1346.fixed.txt
@@ -1,0 +1,1 @@
+build: revert back to Go 1.20

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -11,7 +11,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: "~1.21.4"
+  GO_VERSION: "1.20.11"
 
 jobs:
 

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -277,6 +277,9 @@ jobs:
             runs-on: macos-latest
           - arch_os: windows_amd64
             runs-on: windows-2022
+          - arch_os: windows_amd64
+            runs-on: windows-2022
+            fips: true
     with:
       arch_os: ${{ matrix.arch_os }}
       runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -10,7 +10,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: "~1.21.4"
+  GO_VERSION: "1.20.11"
 
 jobs:
 

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -18,7 +18,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: "~1.21.4"
+  GO_VERSION: "1.20.11"
 
 jobs:
 

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -28,7 +28,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: "~1.21.4"
+  GO_VERSION: "1.20.11"
 
 jobs:
   build:

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -28,7 +28,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: "~1.21.4"
+  GO_VERSION: "1.20.11"
 
 jobs:
   test:

--- a/Dockerfile_local
+++ b/Dockerfile_local
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine as builder
+FROM golang:1.20.11-alpine as builder
 ADD . /src
 WORKDIR /src/otelcolbuilder/
 ENV CGO_ENABLED=0

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export GO_VERSION="1.21.4"
+export GO_VERSION="1.20.11"
 
 sudo apt update -y
 sudo apt install -y \


### PR DESCRIPTION
There's a problem with the Windows FIPS build on Go 1.21. I'm reverting that change for now.

I've also added this build to the PR checks, as it was missing there.