### PR TITLE
chore(scripts/install.sh): align param descriptions

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -136,7 +136,7 @@ Usage: bash install.sh [--${ARG_LONG_TOKEN} <token>] [--${ARG_LONG_TAG} <key>=<v
 
 Supported arguments:
   -${ARG_SHORT_TOKEN}, --${ARG_LONG_TOKEN} <token>      Installation token. It has precedence over 'SUMOLOGIC_INSTALLATION_TOKEN' env variable.
-  -${ARG_SHORT_SKIP_TOKEN}, --${ARG_LONG_SKIP_TOKEN}              Skips requirement for installation token.
+  -${ARG_SHORT_SKIP_TOKEN}, --${ARG_LONG_SKIP_TOKEN}         Skips requirement for installation token.
                                         This option do not disable default configuration creation.
   -${ARG_SHORT_TAG}, --${ARG_LONG_TAG} <key=value>                 Sets tag for collector. This argument can be use multiple times. One per tag.
   -${ARG_SHORT_DOWNLOAD}, --${ARG_LONG_DOWNLOAD}                   Download new binary only and skip configuration part.


### PR DESCRIPTION
```
➜  sumologic-otel-collector git:(drosiek-align-installation-script) ./scripts/install.sh --help                                                                                                                                                                               
Detected OS type:       linux
Detected architecture:  amd64

Usage: bash install.sh [--installation-token <token>] [--tag <key>=<value> [ --tag ...]] [--api <url>] [--version <version>] \
                       [--yes] [--version <version>] [--help]

Supported arguments:
  -i, --installation-token <token>      Installation token. It has precedence over 'SUMOLOGIC_INSTALLATION_TOKEN' env variable.
  -k, --skip-installation-token         Skips requirement for installation token.
                                        This option do not disable default configuration creation.
  -t, --tag <key=value>                 Sets tag for collector. This argument can be use multiple times. One per tag.
  -w, --download-only                   Download new binary only and skip configuration part.

  -u, --uninstall                       Removes Sumo Logic Distribution for OpenTelemetry Collector from the system and
                                        disable Systemd service eventually.
                                        Use with '--purge' to remove all configurations as well.
  -p, --purge                           It has to be used with '--uninstall'.
                                        It removes all Sumo Logic Distribution for OpenTelemetry Collector related configuration and data.

  -a, --api <url>                       Api URL
  -d, --skip-systemd                    Do not install systemd unit.
  -s, --skip-config                     Do not create default configuration.
  -v, --version <version>               Version of Sumo Logic Distribution for OpenTelemetry Collector to install, e.g. 0.57.2-sumo-1.
                                        By default it gets latest version.
  -f, --fips                            Install the FIPS 140-2 compliant binary on Linux.
  -H, --install-hostmetrics             Install the hostmetrics configuration to collect host metrics.
  -r, --remotely-managed                Remotely manage the collector configuration with Sumo Logic.
  -m, --download-timeout <timeout>      Timeout in seconds after which download will fail. Default is 1800.
  -y, --yes                             Disable confirmation asks.

  -h, --help                            Prints this help and usage.

Supported env variables:
  SUMOLOGIC_INSTALLATION_TOKEN=<token>       Installation token.'
```