### PR TITLE
fix(install): fail install if Otelcol is not running on darwin

### DIFF
--- a/pkg/scripts_test/install_darwin_test.go
+++ b/pkg/scripts_test/install_darwin_test.go
@@ -81,6 +81,7 @@ func TestInstallScriptDarwin(t *testing.T) {
 				checkLaunchdConfigCreated,
 				checkHomeDirectoryCreated,
 			},
+			installCode: 1, // because of invalid installation token
 		},
 		{
 			name: "installation token only",
@@ -102,6 +103,7 @@ func TestInstallScriptDarwin(t *testing.T) {
 				checkHostmetricsConfigNotCreated,
 				checkHomeDirectoryCreated,
 			},
+			installCode: 1, // because of invalid installation token
 		},
 		{
 			name: "installation token and ephemeral",
@@ -124,6 +126,7 @@ func TestInstallScriptDarwin(t *testing.T) {
 				checkHostmetricsConfigNotCreated,
 				checkHomeDirectoryCreated,
 			},
+			installCode: 1, // because of invalid installation token
 		},
 		{
 			name: "override default config",
@@ -146,6 +149,7 @@ func TestInstallScriptDarwin(t *testing.T) {
 				checkUserConfigCreated,
 				checkLaunchdConfigCreated,
 			},
+			installCode: 1, // because of invalid installation token
 		},
 		{
 			name: "installation token and hostmetrics",
@@ -168,6 +172,7 @@ func TestInstallScriptDarwin(t *testing.T) {
 				checkHostmetricsOwnershipAndPermissions(systemUser, systemGroup),
 				checkHomeDirectoryCreated,
 			},
+			installCode: 1, // because of invalid installation token
 		},
 		{
 			name: "installation token and remotely-managed",
@@ -190,6 +195,7 @@ func TestInstallScriptDarwin(t *testing.T) {
 				checkGroupExists,
 				checkHomeDirectoryCreated,
 			},
+			installCode: 1, // because of invalid installation token
 		},
 		{
 			name: "installation token, remotely-managed, and ephemeral",
@@ -213,6 +219,7 @@ func TestInstallScriptDarwin(t *testing.T) {
 				checkGroupExists,
 				checkHomeDirectoryCreated,
 			},
+			installCode: 1, // because of invalid installation token
 		},
 		{
 			name: "installation token only, binary not in PATH",
@@ -235,6 +242,7 @@ func TestInstallScriptDarwin(t *testing.T) {
 				checkGroupExists,
 				checkHomeDirectoryCreated,
 			},
+			installCode: 1, // because of invalid installation token
 		},
 		{
 			name: "same installation token in launchd config",
@@ -259,6 +267,7 @@ func TestInstallScriptDarwin(t *testing.T) {
 				checkTokenInLaunchdConfig,
 				checkHomeDirectoryCreated,
 			},
+			installCode: 1, // because of invalid installation token
 		},
 		{
 			name: "different installation token in launchd config",
@@ -311,6 +320,7 @@ func TestInstallScriptDarwin(t *testing.T) {
 				checkUserConfigCreated,
 				checkAPIBaseURLInConfig,
 			},
+			installCode: 1, // because of invalid installation token
 		},
 		{
 			name: "different api base url",
@@ -355,6 +365,7 @@ func TestInstallScriptDarwin(t *testing.T) {
 				checkUserConfigCreated,
 				checkAPIBaseURLInConfig,
 			},
+			installCode: 1, // because of invalid installation token
 		},
 		{
 			name: "editing api base url",
@@ -377,6 +388,7 @@ func TestInstallScriptDarwin(t *testing.T) {
 				checkUserConfigCreated,
 				checkAPIBaseURLInConfig,
 			},
+			installCode: 1, // because of invalid installation token
 		},
 		{
 			name: "configuration with tags",
@@ -399,6 +411,7 @@ func TestInstallScriptDarwin(t *testing.T) {
 				checkTags,
 				checkLaunchdConfigCreated,
 			},
+			installCode: 1, // because of invalid installation token
 		},
 		{
 			name: "same tags",
@@ -429,6 +442,7 @@ func TestInstallScriptDarwin(t *testing.T) {
 				checkTags,
 				checkLaunchdConfigCreated,
 			},
+			installCode: 1, // because of invalid installation token
 		},
 		{
 			name: "different tags",
@@ -489,6 +503,7 @@ func TestInstallScriptDarwin(t *testing.T) {
 				checkTags,
 				checkLaunchdConfigCreated,
 			},
+			installCode: 1, // because of invalid installation token
 		},
 	} {
 		t.Run(spec.name, func(t *testing.T) {

--- a/pkg/scripts_test/install_unix_test.go
+++ b/pkg/scripts_test/install_unix_test.go
@@ -414,7 +414,7 @@ func TestInstallScript(t *testing.T) {
 				checkVarLogACL,
 			},
 			conditionalChecks: []condCheckFunc{checkSystemdAvailability},
-			installCode:       3, // because of invalid installation token
+			installCode:       1, // because of invalid installation token
 		},
 		{
 			name: "systemd installation token with existing user directory",
@@ -444,7 +444,7 @@ func TestInstallScript(t *testing.T) {
 				checkOutputUserAddWarnings,
 			},
 			conditionalChecks: []condCheckFunc{checkSystemdAvailability},
-			installCode:       3, // because of invalid install token
+			installCode:       1, // because of invalid install token
 		},
 		{
 			name: "systemd existing installation different token env",
@@ -474,7 +474,7 @@ func TestInstallScript(t *testing.T) {
 				checkOutputUserAddWarnings,
 			},
 			conditionalChecks: []condCheckFunc{checkSystemdAvailability},
-			installCode:       3, // because of invalid install token
+			installCode:       1, // because of invalid install token
 		},
 		{
 			name: "installation of hostmetrics in systemd during upgrade",
@@ -522,7 +522,7 @@ func TestInstallScript(t *testing.T) {
 				checkVarLogACL,
 			},
 			conditionalChecks: []condCheckFunc{checkSystemdAvailability},
-			installCode:       3, // because of invalid installation token
+			installCode:       1, // because of invalid installation token
 		},
 		{
 			name: "uninstallation without autoconfirm fails",
@@ -586,7 +586,7 @@ func TestInstallScript(t *testing.T) {
 			postChecks: []checkFunc{checkBinaryCreated, checkBinaryIsRunning, checkConfigCreated, checkDifferentTokenInConfig, checkSystemdConfigCreated,
 				checkUserExists, checkTokenEnvFileNotCreated},
 			conditionalChecks: []condCheckFunc{checkSystemdAvailability},
-			installCode:       3, // because of invalid installation token
+			installCode:       1, // because of invalid installation token
 		},
 		{
 			name: "systemd installation if token in file",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1931,6 +1931,13 @@ if [[ "${OS_TYPE}" == "darwin" ]]; then
     launchctl unload "${LAUNCHD_CONFIG}"
     launchctl load -w "${LAUNCHD_CONFIG}"
 
+    echo 'Waiting 10s before checking status'
+    sleep 10
+    if launchctl print system/otelcol-sumo | grep "last exit code = 1"; then
+        echo "Failed to launch otelcol"
+        tail /var/log/otelcol-sumo/otelcol-sumo.log
+        exit 1
+    fi
     exit 0
 fi
 
@@ -2127,4 +2134,9 @@ systemctl restart otelcol-sumo
 
 echo 'Waiting 10s before checking status'
 sleep 10
-systemctl status otelcol-sumo --no-pager
+if ! systemctl status otelcol-sumo --no-pager; then
+    echo "Failed to launch otelcol"
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Check if the launchd task is running after installation, same as we do for systemd. Add an error message to both of these cases.

I think this also resolves #1361 - @astencel-sumo @sumo-drosiek can you have a look?