### PR TITLE
docs(upgrading): deprecate json_logs

### DIFF
--- a/.changelog/1377.changed.txt
+++ b/.changelog/1377.changed.txt
@@ -1,0 +1,1 @@
+chore(sumologicexporter): deprecate json_logs

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -231,8 +231,8 @@ processors:
     log_statements:
       - context: log
         statements:
+          - set(time, Now()) where time_unix_nano == 0
           - set(attributes["timestamp_key"], Int(time_unix_nano / 1000000))
-          - set(attributes["timestamp_key"], Int(now() / 1000000)) where attributes["timestamp_key"] == 0
 service:
   pipelines:
     logs:

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -176,7 +176,8 @@ To migrate perform the following steps:
       log_statements:
         - context: log
           statements:
-            - set(attributes["timestamp"], Int(time_unix_nano / 1000000))
+            - set(time, Now()) where time_unix_nano == 0
+            - set(attributes["timestamp_key"], Int(time_unix_nano / 1000000))
   ```
 
 - use `transform` processor in replace of `json_logs.flatten_body`:

--- a/pkg/exporter/sumologicexporter/exporter.go
+++ b/pkg/exporter/sumologicexporter/exporter.go
@@ -101,6 +101,11 @@ func initExporter(cfg *Config, createSettings exporter.CreateSettings) (*sumolog
 			"https://github.com/SumoLogic/sumologic-otel-collector/blob/main/docs/upgrading.md#sumologic-exporter-deprecate-clear_logs_timestamp")
 	}
 
+	if cfg.LogFormat == JSONFormat {
+		se.logger.Warn("'json_logs' is deprecated and suboptimal. It is going to be removed in 'v0.95.0-sumo-0'. Please follow the upgrade guide: " +
+			"https://github.com/SumoLogic/sumologic-otel-collector/blob/main/docs/upgrading.md#sumologic-exporter-deprecate-json_logs")
+	}
+
 	return se, nil
 }
 


### PR DESCRIPTION
Deprecate `json_logs` in favor of `transform` processor