### PR TITLE
feat(sumologicexporter): ensure immutability

### DIFF
--- a/.changelog/1383.changed.txt
+++ b/.changelog/1383.changed.txt
@@ -1,0 +1,1 @@
+feat(sumologicexporter): ensure immutability

--- a/pkg/exporter/sumologicexporter/sender.go
+++ b/pkg/exporter/sumologicexporter/sender.go
@@ -552,7 +552,7 @@ func (s *sender) sendNonOTLPMetrics(ctx context.Context, md pmetric.Metrics) (pm
 				if err := s.send(ctx, MetricsPipeline, body.toCountingReader(), previousFields); err != nil {
 					errs = append(errs, err)
 					for _, resource := range currentResources {
-						resource.MoveTo(droppedMetrics.ResourceMetrics().AppendEmpty())
+						resource.CopyTo(droppedMetrics.ResourceMetrics().AppendEmpty())
 					}
 				}
 				body.Reset()
@@ -589,7 +589,7 @@ func (s *sender) sendNonOTLPMetrics(ctx context.Context, md pmetric.Metrics) (pm
 				// failed at sending, add the resource to the dropped metrics
 				// move instead of copy here to avoid duplicating data in memory on failure
 				for _, resource := range currentResources {
-					resource.MoveTo(droppedMetrics.ResourceMetrics().AppendEmpty())
+					resource.CopyTo(droppedMetrics.ResourceMetrics().AppendEmpty())
 				}
 			}
 		}
@@ -607,7 +607,7 @@ func (s *sender) sendNonOTLPMetrics(ctx context.Context, md pmetric.Metrics) (pm
 		if err := s.send(ctx, MetricsPipeline, body.toCountingReader(), flds); err != nil {
 			errs = append(errs, err)
 			for _, resource := range currentResources {
-				resource.MoveTo(droppedMetrics.ResourceMetrics().AppendEmpty())
+				resource.CopyTo(droppedMetrics.ResourceMetrics().AppendEmpty())
 			}
 		}
 	}

--- a/pkg/exporter/sumologicexporter/sender_test.go
+++ b/pkg/exporter/sumologicexporter/sender_test.go
@@ -888,6 +888,8 @@ func TestSendLogsOTLP(t *testing.T) {
 		logRecords[i].MoveTo(ls.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty())
 	}
 
+	l.MarkReadOnly()
+
 	assert.NoError(t, test.s.sendOTLPLogs(context.Background(), l))
 	assert.EqualValues(t, 1, *test.reqCounter)
 }
@@ -1126,6 +1128,7 @@ func TestSendMetrics(t *testing.T) {
 		attrs,
 		metricSum, metricGauge,
 	)
+	metrics.MarkReadOnly()
 
 	_, errs := test.s.sendNonOTLPMetrics(context.Background(), metrics)
 	assert.Empty(t, errs)
@@ -1153,6 +1156,7 @@ func TestSendMetricsSplit(t *testing.T) {
 		attrs,
 		metricSum, metricGauge,
 	)
+	metrics.MarkReadOnly()
 
 	_, errs := test.s.sendNonOTLPMetrics(context.Background(), metrics)
 	assert.Empty(t, errs)
@@ -1179,6 +1183,7 @@ func TestSendOTLPHistogram(t *testing.T) {
 	rms := metrics.ResourceMetrics().AppendEmpty()
 	attrs.CopyTo(rms.Resource().Attributes())
 	metricHistogram.CopyTo(rms.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty())
+	metrics.MarkReadOnly()
 
 	err := test.s.sendOTLPMetrics(context.Background(), metrics)
 	assert.NoError(t, err)
@@ -1216,6 +1221,7 @@ func TestSendMetricsSplitBySource(t *testing.T) {
 	attrs.CopyTo(rmsGauge.Resource().Attributes())
 	rmsGauge.Resource().Attributes().PutStr("_sourceHost", "value2")
 	metricGauge.CopyTo(rmsGauge.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty())
+	metrics.MarkReadOnly()
 
 	_, errs := test.s.sendNonOTLPMetrics(context.Background(), metrics)
 	assert.Empty(t, errs)
@@ -1253,6 +1259,7 @@ func TestSendMetricsSplitFailedOne(t *testing.T) {
 	rmsGauge := metrics.ResourceMetrics().AppendEmpty()
 	attrs.CopyTo(rmsGauge.Resource().Attributes())
 	metricGauge.CopyTo(rmsGauge.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty())
+	metrics.MarkReadOnly()
 
 	dropped, errs := test.s.sendNonOTLPMetrics(context.Background(), metrics)
 	assert.Len(t, errs, 1)
@@ -1295,6 +1302,7 @@ func TestSendMetricsSplitFailedAll(t *testing.T) {
 	rmsGauge := metrics.ResourceMetrics().AppendEmpty()
 	attrs.CopyTo(rmsGauge.Resource().Attributes())
 	metricGauge.CopyTo(rmsGauge.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty())
+	metrics.MarkReadOnly()
 
 	dropped, errs := test.s.sendNonOTLPMetrics(context.Background(), metrics)
 	assert.Len(t, errs, 2)
@@ -1320,6 +1328,7 @@ func TestSendMetricsUnexpectedFormat(t *testing.T) {
 
 	metricSum, attrs := exampleIntMetric()
 	metrics := metricAndAttrsToPdataMetrics(attrs, metricSum)
+	metrics.MarkReadOnly()
 
 	dropped, errs := test.s.sendNonOTLPMetrics(context.Background(), metrics)
 	assert.Len(t, errs, 1)

--- a/pkg/exporter/sumologicexporter/test_data_test.go
+++ b/pkg/exporter/sumologicexporter/test_data_test.go
@@ -265,6 +265,7 @@ func metricPairToMetrics(mp ...metricPair) pmetric.Metrics {
 		record.metric.CopyTo(rms.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty())
 	}
 
+	metrics.MarkReadOnly()
 	return metrics
 }
 
@@ -316,5 +317,6 @@ func exampleTrace() ptrace.Traces {
 	span.SetStartTimestamp(1544712660000000000)
 	span.SetEndTimestamp(1544712661000000000)
 	span.Attributes().PutInt("attr1", 55)
+	td.MarkReadOnly()
 	return td
 }

--- a/pkg/exporter/syslogexporter/exporter.go
+++ b/pkg/exporter/syslogexporter/exporter.go
@@ -112,9 +112,9 @@ func (se *syslogexporter) pushLogsData(ctx context.Context, ld plog.Logs) error 
 		for i := range dropped {
 			rls := ld.ResourceLogs().AppendEmpty()
 			logRecords := rls.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
-			dropped[i].resource.MoveTo(rls.Resource())
+			dropped[i].resource.CopyTo(rls.Resource())
 			for j := 0; j < len(dropped[i].records); j++ {
-				dropped[i].records[j].MoveTo(logRecords)
+				dropped[i].records[j].CopyTo(logRecords)
 			}
 		}
 		errs = deduplicateErrors(errs)


### PR DESCRIPTION
Ensure immutability by marking logs, traces and metrics read only in unit tests