### PR TITLE
Remove opamp remote config dir readable validation

### DIFF
--- a/.changelog/1385.changed.txt
+++ b/.changelog/1385.changed.txt
@@ -1,0 +1,1 @@
+Removed OpAMP extension remote configuration directory readable validation.

--- a/pkg/extension/opampextension/config.go
+++ b/pkg/extension/opampextension/config.go
@@ -16,8 +16,6 @@ package opampextension
 
 import (
 	"errors"
-	"fmt"
-	"os"
 
 	"github.com/oklog/ulid/v2"
 	"go.opentelemetry.io/collector/component"
@@ -61,11 +59,6 @@ func (cfg *Config) Validate() error {
 
 	if cfg.RemoteConfigurationDirectory == "" {
 		return errors.New("opamp remote_configuration_directory must be provided")
-	}
-
-	d := cfg.RemoteConfigurationDirectory
-	if _, err := os.Stat(d); err != nil {
-		return fmt.Errorf("opamp remote_configuration_directory %s must be readable: %v", d, err)
 	}
 
 	return nil

--- a/pkg/extension/opampextension/config_test.go
+++ b/pkg/extension/opampextension/config_test.go
@@ -17,7 +17,6 @@ package opampextension
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,10 +61,6 @@ func TestConfigValidate(t *testing.T) {
 	err := cfg.Validate()
 	require.Error(t, err)
 	assert.Equal(t, "opamp remote_configuration_directory must be provided", err.Error())
-
-	cfg.RemoteConfigurationDirectory = "/tmp/opamp.d"
-	err = cfg.Validate()
-	assert.True(t, strings.HasPrefix(err.Error(), "opamp remote_configuration_directory /tmp/opamp.d must be readable:"))
 
 	d, err := os.MkdirTemp("", "opamp.d")
 	assert.NoError(t, err)


### PR DESCRIPTION
The `opamp` extension configuration was added to `sumologic.yaml` as part of https://github.com/SumoLogic/sumologic-otel-collector/pull/1343. The extension is not enabled by default. This initial configuration is intended to aid in the reliability and formatting of setting up remote management via the installation script (`install.sh`). Unfortunately, the extension validation currently ensures the `remote_configuration_directory` is readable, causing regular installations to fail, for example:

```
Dec 12 14:06:40 ip-172-31-27-232 otelcol-sumo[1449]: Error: invalid configuration: extensions::opamp: opamp remote_configuration_directory /etc/otelcol-sumo/opamp.d must be readable: stat /etc/otelcol-sumo/opamp.d: no such file or directory
Dec 12 14:06:40 ip-172-31-27-232 otelcol-sumo[1449]: 2023/12/12 14:06:40 collector server run finished with error: invalid configuration: extensions::opamp: opamp remote_configuration_directory /etc/otelcol-sumo/opamp.d must be readable: stat /etc…such file or directory
```

This pull-request removes this validation, as the extension does this as part of effective configuration loading, see: https://github.com/SumoLogic/sumologic-otel-collector/blob/6f3f2905e81607cb068433517fb57d3ab7f1e5d6/pkg/extension/opampextension/opamp_agent.go#L318-L321

We will need to do a release after merging this pull-request (if accepted) in order to fix standard collector installation.

Alternatively, we can remove `opamp` extension configuration from `sumologic.yaml`, however, we still need a release and we lose the extra reliability and formatting of setting up remote management via the installation script.
