### PR TITLE
Restore ci/build-fips-action to fix release builds

### DIFF
--- a/ci/build-fips-action/Dockerfile
+++ b/ci/build-fips-action/Dockerfile
@@ -1,0 +1,15 @@
+FROM amazonlinux:2
+
+ARG TARGETARCH
+
+ENV TARGETARCH=$TARGETARCH
+
+RUN yum groupinstall -y "Development Tools" && yum install -y curl git
+
+RUN curl -Lo go.tar.gz https://go.dev/dl/go1.21.4.linux-$TARGETARCH.tar.gz
+RUN tar -zxvf go.tar.gz -C /usr/local
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/ci/build-fips-action/action.yml
+++ b/ci/build-fips-action/action.yml
@@ -1,0 +1,9 @@
+name: 'Build FIPS'
+description: 'Build the otelcol-sumo FIPS binary'
+inputs:
+  go-version:
+    description: 'The version of Go to use'
+    required: true
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/ci/build-fips-action/entrypoint.sh
+++ b/ci/build-fips-action/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+git config --global --add safe.directory /github/workspace
+
+# Install builder
+cd otelcolbuilder || exit 1
+mkdir "${HOME}/bin"
+export PATH="${HOME}/bin:${PATH}"
+make install-builder
+
+# Build otelcol-sumo
+make otelcol-sumo-linux_amd64 FIPS_SUFFIX="-fips" CGO_ENABLED="1"


### PR DESCRIPTION
Restore ci/build-fips-action to fix release builds. This is a temporary remedy until we have time to properly (and carefully) incorporate the new fips toolchain static builds from https://github.com/SumoLogic/sumologic-otel-collector/pull/1381 