### PR TITLE
Use sumologic extension base URL to determine the appropriate OpAMP endpoint

### DIFF
--- a/.changelog/1399.changed.txt
+++ b/.changelog/1399.changed.txt
@@ -1,0 +1,1 @@
+feat: Use sumologic extension base URL to determine the appropriate OpAMP endpoint

--- a/pkg/extension/opampextension/go.mod
+++ b/pkg/extension/opampextension/go.mod
@@ -3,7 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/extension/opamp
 go 1.20
 
 require (
-	github.com/SumoLogic/sumologic-otel-collector/pkg/extension/sumologicextension v0.91.0-sumo-0-rc.0
+	github.com/SumoLogic/sumologic-otel-collector/pkg/extension/sumologicextension v0.91.0-sumo-0
 	github.com/google/uuid v1.3.1
 	github.com/knadh/koanf/parsers/yaml v0.1.0
 	github.com/knadh/koanf/providers/rawbytes v0.1.0

--- a/pkg/extension/opampextension/go.mod
+++ b/pkg/extension/opampextension/go.mod
@@ -3,7 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/extension/opamp
 go 1.20
 
 require (
-	github.com/SumoLogic/sumologic-otel-collector/pkg/extension/sumologicextension v0.77.0-sumo-0
+	github.com/SumoLogic/sumologic-otel-collector/pkg/extension/sumologicextension v0.91.0-sumo-0-rc.0
 	github.com/google/uuid v1.3.1
 	github.com/knadh/koanf/parsers/yaml v0.1.0
 	github.com/knadh/koanf/providers/rawbytes v0.1.0

--- a/pkg/extension/opampextension/opamp_agent.go
+++ b/pkg/extension/opampextension/opamp_agent.go
@@ -240,8 +240,6 @@ func (o *opampAgent) setEndpoint() {
 	e = strings.Replace(e, "open-events", "opamp-events", 1)
 	e = strings.Replace(e, "open-collectors", "opamp-collectors", 1)
 	o.endpoint = strings.TrimRight(e, "/") + "/v1/opamp"
-
-	return
 }
 
 func newOpampAgent(cfg *Config, logger *zap.Logger, build component.BuildInfo, res pcommon.Resource) (*opampAgent, error) {

--- a/pkg/extension/opampextension/opamp_agent.go
+++ b/pkg/extension/opampextension/opamp_agent.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -251,7 +250,7 @@ func (o *opampAgent) setEndpoint(baseURL string) error {
 	}
 
 	u.Scheme = "wss"
-	u.Path = path.Join(u.Path, "/v1/opamp")
+	u.Path = "/v1/opamp"
 
 	// These replacements are specific to Sumo Logic's current domain naming,
 	// and are made provisionally for the OTRM beta. In the future, the backend

--- a/pkg/extension/opampextension/opamp_agent.go
+++ b/pkg/extension/opampextension/opamp_agent.go
@@ -242,7 +242,6 @@ func (o *opampAgent) watchCredentials(ctx context.Context, callback func(ctx con
 // correctly redirect our OpAMP client to the correct URL.
 func (o *opampAgent) setEndpoint(baseURL string) error {
 	if baseURL == "" {
-		// default behaviour
 		o.endpoint = o.cfg.Endpoint
 		return nil
 	}

--- a/pkg/extension/opampextension/opamp_agent_test.go
+++ b/pkg/extension/opampextension/opamp_agent_test.go
@@ -249,6 +249,11 @@ func TestHackSetEndpoint(t *testing.T) {
 			url:          "https://long-open-events.sumologic.net",
 			wantEndpoint: "wss://long-opamp-events.sumologic.net/v1/opamp",
 		},
+		{
+			name:         "real sumologic url b",
+			url:          "https://stag-open-collectors.sumologic.net",
+			wantEndpoint: "wss://stag-opamp-collectors.sumologic.net/v1/opamp",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/extension/opampextension/opamp_agent_test.go
+++ b/pkg/extension/opampextension/opamp_agent_test.go
@@ -245,14 +245,19 @@ func TestHackSetEndpoint(t *testing.T) {
 			wantEndpoint: "wss://example.com/v1/opamp",
 		},
 		{
-			name:         "real sumologic url",
-			url:          "https://long-open-events.sumologic.net",
+			name:         "dev sumologic url",
+			url:          "https://long-open-events.sumologic.net/api/v1",
 			wantEndpoint: "wss://long-opamp-events.sumologic.net/v1/opamp",
 		},
 		{
-			name:         "real sumologic url b",
-			url:          "https://stag-open-collectors.sumologic.net",
-			wantEndpoint: "wss://stag-opamp-collectors.sumologic.net/v1/opamp",
+			name:         "prod sumologic url",
+			url:          "https://open-collectors.sumologic.com/api/v1",
+			wantEndpoint: "wss://opamp-collectors.sumologic.com/v1/opamp",
+		},
+		{
+			name:         "prod sumologic url with region",
+			url:          "https://open-collectors.au.sumologic.com/api/v1/",
+			wantEndpoint: "wss://opamp-collectors.au.sumologic.com/v1/opamp",
 		},
 	}
 

--- a/pkg/extension/opampextension/opamp_agent_test.go
+++ b/pkg/extension/opampextension/opamp_agent_test.go
@@ -244,6 +244,11 @@ func TestHackSetEndpoint(t *testing.T) {
 			url:          "https://example.com",
 			wantEndpoint: "wss://example.com/v1/opamp",
 		},
+		{
+			name:         "real sumologic url",
+			url:          "https://long-open-events.sumologic.net",
+			wantEndpoint: "wss://long-opamp-events.sumologic.net/v1/opamp",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/extension/opampextension/opamp_agent_test.go
+++ b/pkg/extension/opampextension/opamp_agent_test.go
@@ -227,7 +227,7 @@ func TestHackSetEndpoint(t *testing.T) {
 	}{
 		{
 			name:         "empty url defaults to config endpoint",
-			wantEndpoint: "https://example.com",
+			wantEndpoint: "wss://example.com",
 		},
 		{
 			name:         "url variant a",
@@ -250,7 +250,7 @@ func TestHackSetEndpoint(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			agent := &opampAgent{cfg: &Config{
 				HTTPClientSettings: confighttp.HTTPClientSettings{
-					Endpoint: "https://example.com",
+					Endpoint: "wss://example.com",
 				},
 			}}
 			if err := agent.setEndpoint(test.url); err != nil {


### PR DESCRIPTION
The sumologic extension may update/alter the API base URL used, following the collector registration process. This base URL redirection is tied to the installation token which the OpAMP extension isn't aware of. Update the OpAMP extension to leverage the sumologic extension's base URL to determine the appropriate OpAMP endpoint (i.e. region).