### PR TITLE
fix(k8stagger): allow uppercase characters inside tag keys

### DIFF
--- a/.changelog/1400.fixed.txt
+++ b/.changelog/1400.fixed.txt
@@ -1,0 +1,1 @@
+fix(k8stagger): allow uppercase characters inside tag keys

--- a/pkg/processor/k8sprocessor/options.go
+++ b/pkg/processor/k8sprocessor/options.go
@@ -156,7 +156,7 @@ func WithExtractTags(tagsMap map[string]string) Option {
 	return func(p *kubernetesprocessor) error {
 		var tags = kube.NewExtractionFieldTags()
 		for field, tag := range tagsMap {
-			switch field {
+			switch strings.ToLower(field) {
 			case strings.ToLower(metadataContainerID):
 				tags.ContainerID = tag
 			case strings.ToLower(metadataContainerName):

--- a/pkg/processor/k8sprocessor/options_test.go
+++ b/pkg/processor/k8sprocessor/options_test.go
@@ -756,3 +756,23 @@ func TestWithExcludes(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractTags(t *testing.T) {
+	p := &kubernetesprocessor{}
+	tags := map[string]string{
+		"containerid": "cntrid",
+		"podId":       "the id",
+		"hOsTnAmE":    "host",
+		"SERVICENAME": "blep",
+	}
+	assert.NoError(t, WithExtractTags(tags)(p))
+	assert.Equal(t, "cntrid", p.rules.Tags.ContainerID)
+	assert.Equal(t, "the id", p.rules.Tags.PodUID)
+	assert.Equal(t, "host", p.rules.Tags.HostName)
+	assert.Equal(t, "blep", p.rules.Tags.ServiceName)
+
+	p = &kubernetesprocessor{}
+	err := WithExtractTags(map[string]string{"randomfield": "randomvalue"})(p)
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), `"randomfield" is not a supported metadata field`)
+}


### PR DESCRIPTION
Fixes #1380 
Note: this change causes all possible case variants to be correct (see the newly added test)