### PR TITLE
fix(k8stagger)!: change default pod id attribute name to k8s.pod.uid

### DIFF
--- a/.changelog/1401.fixed.txt
+++ b/.changelog/1401.fixed.txt
@@ -1,0 +1,1 @@
+fix(k8stagger)!: change default pod id attribute name to k8s.pod.uid

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,7 +1,10 @@
 # Upgrading
 
 - [Upgrading](#upgrading)
-  - [Upgrading to v0.90.1-sumo-0](#upgrading-to-v0910-sumo-0)
+  - [Upgrading to v0.91.0-sumo-0](#upgrading-to-v0910-sumo-0)
+    - [Sumo Logic Schema processor replaced with Sumo Logic processor](#sumo-logic-schema-processor-replaced-with-sumo-logic-processor)
+    - [`k8s_tagger` processor: default name of podID attribute has changed](#k8s_tagger-processor-default-name-of-podid-attribute-has-changed)
+  - [Upgrading to v0.90.1-sumo-0](#upgrading-to-v0901-sumo-0)
     - [Change configuration for `syslogexporter`](#change-configuration-for-syslogexporter)
     - [`sumologic` exporter: deprecate `clear_logs_timestamp`](#sumologic-exporter-deprecate-clear_logs_timestamp)
     - [`sumologic` exporter: remove `routing_attributes_to_drop`](#sumologic-exporter-remove-routing_attributes_to_drop)
@@ -76,6 +79,20 @@ service:
 
 [sumologicschema]: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/processor/sumologicschemaprocessor
 [sumologicprocessor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/sumologicprocessor
+
+### `k8s_tagger` processor: default name of podID attribute has changed
+
+By a mistake, in the [k8s_tagger][k8staggerprocessor], the default name for podID was set to `k8s.pod.id`. It has been changed to `k8s.pod.uid`.
+If you want to still use the old name, add the following option to the config of the `k8s_tagger`:
+
+```yaml
+processors:
+  k8s_tagger:
+    tags:
+      podID: k8s.pod.id
+```
+
+[k8staggerprocessor]: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/processor/k8sprocessor
 
 ## Upgrading to v0.90.1-sumo-0
 

--- a/pkg/processor/k8sprocessor/README.md
+++ b/pkg/processor/k8sprocessor/README.md
@@ -91,7 +91,7 @@ processors:
         jobName: k8s.job.name
         namespaceName: k8s.namespace.name
         nodeName: k8s.node.name
-        podID: k8s.pod.id
+        podID: k8s.pod.uid
         podName: k8s.pod.name
         replicaSetName: k8s.replicaset.name
         serviceName: k8s.service.name

--- a/pkg/processor/k8sprocessor/kube/client_test.go
+++ b/pkg/processor/k8sprocessor/kube/client_test.go
@@ -759,7 +759,7 @@ func TestExtractionRules(t *testing.T) {
 				"k8s.container.name":  "auth-service-container-name",
 				"k8s.deployment.name": "dearest-deploy",
 				"k8s.pod.hostname":    "auth-hostname3",
-				"k8s.pod.id":          "33333",
+				"k8s.pod.uid":         "33333",
 				"k8s.pod.name":        "auth-service-abc12-xyz3",
 				"k8s.pod.startTime":   pod.GetCreationTimestamp().String(),
 				"k8s.replicaset.name": "dearest-deploy-77c99ccb96",

--- a/pkg/processor/k8sprocessor/kube/kube.go
+++ b/pkg/processor/k8sprocessor/kube/kube.go
@@ -40,7 +40,7 @@ const (
 	defaultTagCronJobName     = "k8s.cronjob.name"
 	defaultTagJobName         = "k8s.job.name"
 	defaultTagNodeName        = "k8s.node.name"
-	defaultTagPodUID          = "k8s.pod.id"
+	defaultTagPodUID          = "k8s.pod.uid"
 	defaultTagReplicaSetName  = "k8s.replicaset.name"
 	defaultTagServiceName     = "k8s.service.name"
 	defaultTagStatefulSetName = "k8s.statefulset.name"


### PR DESCRIPTION
Fixed #1379 
The previous name was k8s.pod.id.