### PR TITLE
ci: rename FIPS build job

### DIFF
--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -225,7 +225,7 @@ jobs:
 
   # pipeline to build FIPS compliance binary on Go+BoringCrypto
   build-fips:
-    name: Build
+    name: Build FIPS
     runs-on: ubuntu-20.04
     strategy:
       matrix:


### PR DESCRIPTION
To avoid duplicate "Build" job