### PR TITLE
Don't allow other users to read config files

### DIFF
--- a/.changelog/1408.fixed.txt
+++ b/.changelog/1408.fixed.txt
@@ -1,0 +1,1 @@
+sec: don't allow other users to read configuration files

--- a/pkg/extension/opampextension/opamp_agent.go
+++ b/pkg/extension/opampextension/opamp_agent.go
@@ -374,7 +374,8 @@ func (o *opampAgent) saveEffectiveConfig(dir string) error {
 	for k, v := range o.effectiveConfig {
 		p := filepath.Join(dir, k)
 
-		f, err := os.Create(p)
+		// OpenFile the same way os.Create does it, but with 0600 perms
+		f, err := os.OpenFile(p, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This change is a security fix that prevents other users on the system from being able to read configuration files created as part of OpAMP remote configuration management.

Closes #1386 