### PR TITLE
Use musl toolchain to build static fips release binary

### DIFF
--- a/.changelog/1416.changed.txt
+++ b/.changelog/1416.changed.txt
@@ -1,0 +1,1 @@
+feat: FIPS binary can now be used irrespective of host system's libc & add linux_arm64 FIPS binary.

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -229,7 +229,9 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        arch_os: [ 'linux_amd64' ]
+        arch_os:
+          - 'linux_amd64'
+          - 'linux_arm64'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -256,11 +256,22 @@ jobs:
       - name: Prepare tags in otelcolbuilder's config
         run: make prepare-tag TAG=${{ steps.extract_tag.outputs.tag }}
 
+      - name: Build Toolchains
+        run: make toolchain-${{ matrix.arch_os }} OUTPUT=/opt/toolchain -j3
+        working-directory: ./otelcolbuilder
+
       - name: Build (FIPS)
-        id: containerized-build
-        uses: ./ci/build-fips-action
-        with:
-          go-version: ${{ env.GO_VERSION }}
+        if: ${{ contains(matrix.arch_os, 'linux') }}
+        run: |
+          CC=$(find /opt/toolchain/bin -type f -name "*-linux-musl-gcc")
+          test "$CC"
+          echo "Using toolchain: $CC"
+          make otelcol-sumo-${{matrix.arch_os}} \
+            FIPS_SUFFIX="-fips" \
+            CGO_ENABLED="1" \
+            CC="$CC" \
+            EXTRA_LDFLAGS="-linkmode external -extldflags '-static'"
+        working-directory: ./otelcolbuilder
 
       - name: Set filename
         id: set_filename
@@ -279,7 +290,7 @@ jobs:
       - name: Store binary as action artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{matrix.arch_os}}_fips
+          name: "${{matrix.arch_os}}-fips"
           path: ./otelcolbuilder/cmd/${{ steps.set_filename.outputs.filename }}
           if-no-files-found: error
 


### PR DESCRIPTION
Updates the release CI job to use the musl toolchain to build FIPS binaries. This should fix an issue where users with older GLIBC versions could not run the FIPS distribution of otelcol-sumo.

A test run can be found on this fork: https://github.com/sensu/sumologic-otel-collector/actions/runs/7468333702/job/20323564335

Running ldd on the resulting binary produces the following output:

```
[root@rhel-7-9 ~]# ldd otelcol-sumo-0.90.1-sumo-10000-fips-linux_amd64 
        not a dynamic executable
```