### PR TITLE
ci: download FIPS binary from separate artifact

### DIFF
--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -326,10 +326,17 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Download binary action artifact from build phase (regular binary and FIPS binary)
+      - name: Download binary action artifact from build phase
         uses: actions/download-artifact@v4
         with:
           name: ${{matrix.arch_os}}
+          path: artifacts/
+
+      - name: Download binary action artifact from build phase (FIPS)
+        if: matrix.arch_os == 'linux_amd64'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{matrix.arch_os}}_fips
           path: artifacts/
 
       - name: Build and push FIPS image to Open Source ECR


### PR DESCRIPTION
Another change required after upgrading the `upload-artifact` action to `v4`. Since we are now uploading the FIPS binary to a separate artifact, we need to also download it using that separate artifact name.

Related CI failure: https://github.com/SumoLogic/sumologic-otel-collector/actions/runs/7474329473/job/20341159569