### PR TITLE
Fix non-FIPS release MSI files

### DIFF
--- a/.changelog/1419.fixed.txt
+++ b/.changelog/1419.fixed.txt
@@ -1,0 +1,5 @@
+use non-FIPS Windows binary in non-FIPS MSI package
+
+This fixes a bug where the non-FIPS MSI package was bundling the FIPS Windows binary.
+Starting from now, the non-FIPS MSI package bundles the non-FIPS binary.
+The FIPS MSI package continues to correctly bundle the FIPS Windows binary, no change here.

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -432,10 +432,10 @@ jobs:
       - name: Print tag
         run: echo "${{ steps.extract_tag.outputs.tag }}"
 
-      - name: Fetch binary artifact for ${{ matrix.arch_os }}
+      - name: Fetch binary artifact for ${{ matrix.arch_os }} ${{ matrix.fips && '(FIPS)' || '' }}
         uses: actions/download-artifact@v4
         with:
-          name: windows_amd64_fips
+          name: windows_amd64${{ matrix.fips && '_fips' || '' }}
           path: ./otelcolbuilder/cmd
 
       - name: Rename binary artifact for ${{ matrix.arch_os }}


### PR DESCRIPTION
While packaging Windows MSI files, the release workflow was mistakenly using the FIPS binary in all cases. This lead to issues for people using the non-FIPS MSI file or the PowerShell installation script, e.g. #1387.

This change makes the workflow grab the right executable in the right case (FIPS vs non-FIPS) and should fix the issue for releases going forward.