### PR TITLE
ci: fix downloading fips binaries

### DIFF
--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -346,10 +346,9 @@ jobs:
           path: artifacts/
 
       - name: Download binary action artifact from build phase (FIPS)
-        if: matrix.arch_os == 'linux_amd64'
         uses: actions/download-artifact@v4
         with:
-          name: ${{matrix.arch_os}}_fips
+          name: ${{matrix.arch_os}}-fips
           path: artifacts/
 
       - name: Build and push FIPS image to Open Source ECR


### PR DESCRIPTION
Artefact name changed in this commit: https://github.com/SumoLogic/sumologic-otel-collector/pull/1416, so we have to use new name to download it (explained here: https://github.com/SumoLogic/sumologic-otel-collector/pull/1416/files#r1448410779)

CI failure: https://github.com/SumoLogic/sumologic-otel-collector/actions/runs/7482929996/job/20377879560