### PR TITLE
feat(k8sprocessor): add new owner metrics

### DIFF
--- a/.changelog/1426.added.txt
+++ b/.changelog/1426.added.txt
@@ -1,0 +1,1 @@
+feat(k8sprocessor): add new owner metrics

--- a/pkg/processor/k8sprocessor/kube/owner.go
+++ b/pkg/processor/k8sprocessor/kube/owner.go
@@ -436,6 +436,7 @@ func (op *OwnerCache) addServiceToPod(pod string, serviceName string) {
 		// If there's no services/endpoints for a given pod then just update the cache
 		// with the provided enpoint.
 		op.podServices[pod] = []string{serviceName}
+		observability.RecordServiceTableSize(int64(len(op.podServices)))
 		return
 	}
 
@@ -480,6 +481,7 @@ func (op *OwnerCache) deleteServiceFromPod(pod string, serviceName string) {
 
 	if len(services) == 0 {
 		delete(op.podServices, pod)
+		observability.RecordServiceTableSize(int64(len(op.podServices)))
 	} else {
 		sort.Strings(services)
 		op.podServices[pod] = services

--- a/pkg/processor/k8sprocessor/kube/owner.go
+++ b/pkg/processor/k8sprocessor/kube/owner.go
@@ -401,7 +401,9 @@ func (op *OwnerCache) deleteObject(obj interface{}) {
 
 	op.ownersMutex.Lock()
 	delete(op.objectOwners, string(metaObj.GetUID()))
+	ownerTableSize := len(op.objectOwners)
 	op.ownersMutex.Unlock()
+	observability.RecordOwnerTableSize(int64(ownerTableSize))
 }
 
 func (op *OwnerCache) cacheObject(kind string, obj interface{}) {
@@ -420,7 +422,9 @@ func (op *OwnerCache) cacheObject(kind string, obj interface{}) {
 
 	op.ownersMutex.Lock()
 	op.objectOwners[string(oo.UID)] = &oo
+	ownerTableSize := len(op.objectOwners)
 	op.ownersMutex.Unlock()
+	observability.RecordOwnerTableSize(int64(ownerTableSize))
 }
 
 func (op *OwnerCache) addServiceToPod(pod string, serviceName string) {

--- a/pkg/processor/k8sprocessor/kube/owner.go
+++ b/pkg/processor/k8sprocessor/kube/owner.go
@@ -308,15 +308,15 @@ func (op *OwnerCache) addNamespaceInformer(factory informers.SharedInformerFacto
 	informer := factory.Core().V1().Namespaces().Informer()
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			observability.RecordOtherAdded()
+			observability.RecordOtherAdded("Namespace")
 			op.upsertNamespace(obj)
 		},
 		UpdateFunc: func(_, obj interface{}) {
-			observability.RecordOtherUpdated()
+			observability.RecordOtherUpdated("Namespace")
 			op.upsertNamespace(obj)
 		},
 		DeleteFunc: op.deferredDelete(func(obj interface{}) {
-			observability.RecordOtherDeleted()
+			observability.RecordOtherDeleted("Namespace")
 			op.deleteNamespace(obj)
 		}),
 	})
@@ -351,15 +351,15 @@ func (op *OwnerCache) addOwnerInformer(
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			cacheFunc(kind, obj)
-			observability.RecordOtherAdded()
+			observability.RecordOtherAdded(kind)
 		},
 		UpdateFunc: func(_, obj interface{}) {
 			cacheFunc(kind, obj)
-			observability.RecordOtherUpdated()
+			observability.RecordOtherUpdated(kind)
 		},
 		DeleteFunc: op.deferredDelete(func(obj any) {
 			deleteFunc(obj)
-			observability.RecordOtherDeleted()
+			observability.RecordOtherDeleted(kind)
 		}),
 	})
 	if err != nil {

--- a/pkg/processor/k8sprocessor/observability/observability.go
+++ b/pkg/processor/k8sprocessor/observability/observability.go
@@ -19,6 +19,7 @@ import (
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
 )
 
 func init() {
@@ -48,6 +49,8 @@ var (
 	mOtherDeleted = stats.Int64("otelsvc/k8s/other_deleted", "Number of other delete events received", "1")
 
 	mIPLookupMiss = stats.Int64("otelsvc/k8s/ip_lookup_miss", "Number of times pod by IP lookup failed.", "1")
+
+	resourceKind, _ = tag.NewKey("kind") // nolint:errcheck
 )
 
 var viewPodsUpdated = &view.View{
@@ -75,6 +78,7 @@ var viewOtherUpdated = &view.View{
 	Name:        mOtherUpdated.Name(),
 	Description: mOtherUpdated.Description(),
 	Measure:     mOtherUpdated,
+	TagKeys:     []tag.Key{resourceKind},
 	Aggregation: view.Sum(),
 }
 
@@ -82,6 +86,7 @@ var viewOtherAdded = &view.View{
 	Name:        mOtherAdded.Name(),
 	Description: mOtherAdded.Description(),
 	Measure:     mOtherAdded,
+	TagKeys:     []tag.Key{resourceKind},
 	Aggregation: view.Sum(),
 }
 
@@ -89,6 +94,7 @@ var viewOtherDeleted = &view.View{
 	Name:        mOtherDeleted.Name(),
 	Description: mOtherDeleted.Description(),
 	Measure:     mOtherDeleted,
+	TagKeys:     []tag.Key{resourceKind},
 	Aggregation: view.Sum(),
 }
 
@@ -121,18 +127,33 @@ func RecordPodDeleted() {
 }
 
 // RecordOtherUpdated increments the metric that records other update events received.
-func RecordOtherUpdated() {
-	stats.Record(context.Background(), mOtherUpdated.M(int64(1)))
+func RecordOtherUpdated(kind string) {
+	stats.RecordWithTags( // nolint:errcheck
+		context.Background(),
+		[]tag.Mutator{
+			tag.Insert(resourceKind, kind),
+		},
+		mOtherUpdated.M(int64(1)))
 }
 
 // RecordOtherAdded increments the metric that records other add events receiver.
-func RecordOtherAdded() {
-	stats.Record(context.Background(), mOtherAdded.M(int64(1)))
+func RecordOtherAdded(kind string) {
+	stats.RecordWithTags( // nolint:errcheck
+		context.Background(),
+		[]tag.Mutator{
+			tag.Insert(resourceKind, kind),
+		},
+		mOtherAdded.M(int64(1)))
 }
 
 // RecordOtherDeleted increments the metric that records other events deleted.
-func RecordOtherDeleted() {
-	stats.Record(context.Background(), mOtherDeleted.M(int64(1)))
+func RecordOtherDeleted(kind string) {
+	stats.RecordWithTags( // nolint:errcheck
+		context.Background(),
+		[]tag.Mutator{
+			tag.Insert(resourceKind, kind),
+		},
+		mOtherAdded.M(int64(1)))
 }
 
 // RecordIPLookupMiss increments the metric that records Pod lookup by IP misses.

--- a/pkg/processor/k8sprocessor/observability/observability.go
+++ b/pkg/processor/k8sprocessor/observability/observability.go
@@ -34,6 +34,7 @@ func init() {
 		viewOtherAdded,
 		viewOtherDeleted,
 		viewOwnerTableSize,
+		viewServiceTableSize,
 		viewIPLookupMiss,
 		viewPodTableSize,
 	)
@@ -45,10 +46,11 @@ var (
 	mPodsDeleted  = stats.Int64("otelsvc/k8s/pod_deleted", "Number of pod delete events received", "1")
 	mPodTableSize = stats.Int64("otelsvc/k8s/pod_table_size", "Size of table containing pod info", "1")
 
-	mOtherUpdated   = stats.Int64("otelsvc/k8s/other_updated", "Number of other update events received", "1")
-	mOtherAdded     = stats.Int64("otelsvc/k8s/other_added", "Number of other add events received", "1")
-	mOtherDeleted   = stats.Int64("otelsvc/k8s/other_deleted", "Number of other delete events received", "1")
-	mOwnerTableSize = stats.Int64("otelsvc/k8s/owner_table_size", "Size of table containing owner info", "1")
+	mOtherUpdated     = stats.Int64("otelsvc/k8s/other_updated", "Number of other update events received", "1")
+	mOtherAdded       = stats.Int64("otelsvc/k8s/other_added", "Number of other add events received", "1")
+	mOtherDeleted     = stats.Int64("otelsvc/k8s/other_deleted", "Number of other delete events received", "1")
+	mOwnerTableSize   = stats.Int64("otelsvc/k8s/owner_table_size", "Size of table containing owner info", "1")
+	mServiceTableSize = stats.Int64("otelsvc/k8s/service_table_size", "Size of table containing service info", "1")
 
 	mIPLookupMiss = stats.Int64("otelsvc/k8s/ip_lookup_miss", "Number of times pod by IP lookup failed.", "1")
 
@@ -104,6 +106,13 @@ var viewOwnerTableSize = &view.View{
 	Name:        mOwnerTableSize.Name(),
 	Description: mOwnerTableSize.Description(),
 	Measure:     mOwnerTableSize,
+	Aggregation: view.LastValue(),
+}
+
+var viewServiceTableSize = &view.View{
+	Name:        mServiceTableSize.Name(),
+	Description: mServiceTableSize.Description(),
+	Measure:     mServiceTableSize,
 	Aggregation: view.LastValue(),
 }
 
@@ -168,6 +177,11 @@ func RecordOtherDeleted(kind string) {
 // RecordPodTableSize store size of the Pod owner table.
 func RecordOwnerTableSize(ownerTableSize int64) {
 	stats.Record(context.Background(), mOwnerTableSize.M(ownerTableSize))
+}
+
+// RecordServiceTableSize store size of the Pod to Service table.
+func RecordServiceTableSize(serviceTableSize int64) {
+	stats.Record(context.Background(), mServiceTableSize.M(serviceTableSize))
 }
 
 // RecordIPLookupMiss increments the metric that records Pod lookup by IP misses.

--- a/pkg/processor/k8sprocessor/observability/observability.go
+++ b/pkg/processor/k8sprocessor/observability/observability.go
@@ -33,6 +33,7 @@ func init() {
 		viewOtherUpdated,
 		viewOtherAdded,
 		viewOtherDeleted,
+		viewOwnerTableSize,
 		viewIPLookupMiss,
 		viewPodTableSize,
 	)
@@ -44,9 +45,10 @@ var (
 	mPodsDeleted  = stats.Int64("otelsvc/k8s/pod_deleted", "Number of pod delete events received", "1")
 	mPodTableSize = stats.Int64("otelsvc/k8s/pod_table_size", "Size of table containing pod info", "1")
 
-	mOtherUpdated = stats.Int64("otelsvc/k8s/other_updated", "Number of other update events received", "1")
-	mOtherAdded   = stats.Int64("otelsvc/k8s/other_added", "Number of other add events received", "1")
-	mOtherDeleted = stats.Int64("otelsvc/k8s/other_deleted", "Number of other delete events received", "1")
+	mOtherUpdated   = stats.Int64("otelsvc/k8s/other_updated", "Number of other update events received", "1")
+	mOtherAdded     = stats.Int64("otelsvc/k8s/other_added", "Number of other add events received", "1")
+	mOtherDeleted   = stats.Int64("otelsvc/k8s/other_deleted", "Number of other delete events received", "1")
+	mOwnerTableSize = stats.Int64("otelsvc/k8s/owner_table_size", "Size of table containing owner info", "1")
 
 	mIPLookupMiss = stats.Int64("otelsvc/k8s/ip_lookup_miss", "Number of times pod by IP lookup failed.", "1")
 
@@ -96,6 +98,13 @@ var viewOtherDeleted = &view.View{
 	Measure:     mOtherDeleted,
 	TagKeys:     []tag.Key{resourceKind},
 	Aggregation: view.Sum(),
+}
+
+var viewOwnerTableSize = &view.View{
+	Name:        mOwnerTableSize.Name(),
+	Description: mOwnerTableSize.Description(),
+	Measure:     mOwnerTableSize,
+	Aggregation: view.LastValue(),
 }
 
 var viewIPLookupMiss = &view.View{
@@ -154,6 +163,11 @@ func RecordOtherDeleted(kind string) {
 			tag.Insert(resourceKind, kind),
 		},
 		mOtherAdded.M(int64(1)))
+}
+
+// RecordPodTableSize store size of the Pod owner table.
+func RecordOwnerTableSize(ownerTableSize int64) {
+	stats.Record(context.Background(), mOwnerTableSize.M(ownerTableSize))
 }
 
 // RecordIPLookupMiss increments the metric that records Pod lookup by IP misses.

--- a/pkg/processor/k8sprocessor/observability/observability_test.go
+++ b/pkg/processor/k8sprocessor/observability/observability_test.go
@@ -87,6 +87,12 @@ func TestMetrics(t *testing.T) {
 				RecordOwnerTableSize(1)
 			},
 		},
+		{
+			"otelsvc/k8s/service_table_size",
+			func() {
+				RecordServiceTableSize(1)
+			},
+		},
 	}
 
 	var (

--- a/pkg/processor/k8sprocessor/observability/observability_test.go
+++ b/pkg/processor/k8sprocessor/observability/observability_test.go
@@ -81,6 +81,12 @@ func TestMetrics(t *testing.T) {
 			"otelsvc/k8s/ip_lookup_miss",
 			RecordIPLookupMiss,
 		},
+		{
+			"otelsvc/k8s/owner_table_size",
+			func() {
+				RecordOwnerTableSize(1)
+			},
+		},
 	}
 
 	var (


### PR DESCRIPTION
Add new and update existing metrics for the k8sprocessor:

* the `other` metrics counting events for non-Pod resources now have a `kind` dimension indicating the resource
* add a `owner_table_size` metric
* add a `service_table_size` for the size of the Pod to Services map