### PR TITLE
fix(sumologicexporter): fix prometheus formatter for non-string data point labels

### DIFF
--- a/.changelog/1428.fixed.txt
+++ b/.changelog/1428.fixed.txt
@@ -1,1 +1,1 @@
-fix: fix prometheus formatter for non-string data point labels
+fix(sumologicexporter): fix prometheus formatter for non-string data point

--- a/.changelog/1428.fixed.txt
+++ b/.changelog/1428.fixed.txt
@@ -1,0 +1,1 @@
+fix: fix prometheus formatter for non-string data point labels

--- a/.changelog/3646.fixed.txt
+++ b/.changelog/3646.fixed.txt
@@ -1,1 +1,0 @@
-fix: fix prometheus formatter for non-string data point labels

--- a/.changelog/3646.fixed.txt
+++ b/.changelog/3646.fixed.txt
@@ -1,0 +1,1 @@
+fix: fix prometheus formatter for non-string data point labels

--- a/pkg/exporter/sumologicexporter/prometheus_formatter.go
+++ b/pkg/exporter/sumologicexporter/prometheus_formatter.go
@@ -68,7 +68,7 @@ func (f *prometheusFormatter) tags2String(attr pcommon.Map, labels pcommon.Map) 
 
 	attr.CopyTo(mergedAttributes)
 	labels.Range(func(k string, v pcommon.Value) bool {
-		mergedAttributes.PutStr(k, v.Str())
+		mergedAttributes.PutStr(k, v.AsString())
 		return true
 	})
 	length := mergedAttributes.Len()

--- a/pkg/exporter/sumologicexporter/prometheus_formatter_test.go
+++ b/pkg/exporter/sumologicexporter/prometheus_formatter_test.go
@@ -57,10 +57,16 @@ func TestTags2String(t *testing.T) {
 	require.NoError(t, err)
 
 	_, attributes := exampleIntMetric()
+	attributes.PutInt("int", 200)
+
+	labels := pcommon.NewMap()
+	labels.PutInt("l_int", 200)
+	labels.PutStr("l_str", "two")
+
 	assert.Equal(
 		t,
-		prometheusTags(`{test="test_value",test2="second_value"}`),
-		f.tags2String(attributes, pcommon.NewMap()),
+		prometheusTags(`{test="test_value",test2="second_value",int="200",l_int="200",l_str="two"}`),
+		f.tags2String(attributes, labels),
 	)
 }
 


### PR DESCRIPTION
we have been sending empty values for all non-string data point attributes, eg:
```
Resource SchemaURL: https://opentelemetry.io/schemas/1.9.0
Resource attributes:
     -> status: Int(200)
ScopeMetrics #0
ScopeMetrics SchemaURL: 
InstrumentationScope otelcol/hostmetricsreceiver/load v0.89.0-sumo-2-23-g86be3
Metric #0
Descriptor:
     -> Name: system.cpu.load_average.15m
     -> Description: Average CPU Load over 15 minutes.
     -> Unit: 1
     -> DataType: Gauge
NumberDataPoints #0
Data point attributes:
     -> status-c: Int(202)
StartTimestamp: 2024-01-18 03:22:29 +0000 UTC
Timestamp: 2024-01-18 18:51:04.082256952 +0000 UTC
Value: 0.990000
Metric #1
Descriptor:
     -> Name: system.cpu.load_average.1m
     -> Description: Average CPU Load over 1 minute.
     -> Unit: 1
     -> DataType: Gauge
NumberDataPoints #0
Data point attributes:
     -> status-c: Int(202)
StartTimestamp: 2024-01-18 03:22:29 +0000 UTC
Timestamp: 2024-01-18 18:51:04.082256952 +0000 UTC
Value: 0.630000
Metric #2
Descriptor:
     -> Name: system.cpu.load_average.5m
     -> Description: Average CPU Load over 5 minutes.
     -> Unit: 1
     -> DataType: Gauge
NumberDataPoints #0
Data point attributes:
     -> status-c: Int(202)
StartTimestamp: 2024-01-18 03:22:29 +0000 UTC
Timestamp: 2024-01-18 18:51:04.082256952 +0000 UTC
```

as

```
POST / HTTP/1.1
Host: localhost:54527
User-Agent: Go-http-client/1.1
Content-Length: 216
Content-Type: application/vnd.sumologic.prometheus
X-Sumo-Client: otelcol
Accept-Encoding: gzip

system.cpu.load_average.15m{status="200",status-c=""} 0.98 1705603875594
system.cpu.load_average.1m{status="200",status-c=""} 0.61 1705603875594
system.cpu.load_average.5m{status="200",status-c=""} 0.87 1705603875594
```