### PR TITLE
feat(sumologic.yaml): Set retry_on_failure.max_elapsed_time to 0 in s…

### DIFF
--- a/examples/sumologic-windows.yaml
+++ b/examples/sumologic-windows.yaml
@@ -18,6 +18,9 @@ extensions:
   ## The File Storage extension can persist state to the local file system
   ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage
   file_storage:
+    compaction:
+      directory: ${PROGRAMDATA}\Sumo Logic\OpenTelemetry Collector\data\file_storage
+      on_rebound: true
     directory: ${PROGRAMDATA}\Sumo Logic\OpenTelemetry Collector\data\file_storage
 
 receivers:
@@ -39,6 +42,8 @@ exporters:
     sending_queue:
       enabled: true
       storage: file_storage
+    retry_on_failure:
+        max_elapsed_time: 0
 
 processors:
 

--- a/examples/sumologic.yaml
+++ b/examples/sumologic.yaml
@@ -18,6 +18,9 @@ extensions:
   ## The File Storage extension can persist state to the local file system
   ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage
   file_storage:
+    compaction:
+      directory: /var/lib/otelcol-sumo/file_storage
+      on_rebound: true
     directory: /var/lib/otelcol-sumo/file_storage
 
   ## Configuration for OpAMP Extension
@@ -46,6 +49,8 @@ exporters:
     sending_queue:
       enabled: true
       storage: file_storage
+    retry_on_failure:
+        max_elapsed_time: 0
 
 processors:
 


### PR DESCRIPTION
…umologic exporter

Set retry_on_failure.max_elapsed_time to 0 in sumologic exporter to prevent data loss after 5 minutes. Details could be found here: https://github.com/SumoLogic/sumologic-otel-collector/blob/main/docs/upgrading.md#exporters-changed-retry-logic-when-using-persistent-queue

Add compaction to file storage by default.