### PR TITLE
chore(k8sprocessor): Improve logging of missing data events

### DIFF
--- a/.changelog/1448.changed.txt
+++ b/.changelog/1448.changed.txt
@@ -1,0 +1,1 @@
+chore(k8sprocessor): Improve logging of missing data events

--- a/pkg/processor/k8sprocessor/kube/client.go
+++ b/pkg/processor/k8sprocessor/kube/client.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sprocessor/observability"
 )
 
@@ -321,6 +322,9 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) map[string]string {
 	}
 
 	if c.Rules.NodeName {
+		if len(pod.Spec.NodeName) == 0 {
+			c.logger.Warn("missing Node name for Pod, cache may be out of sync", zap.String("pod", pod.Name))
+		}
 		tags[c.Rules.Tags.NodeName] = pod.Spec.NodeName
 	}
 
@@ -340,6 +344,9 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) map[string]string {
 	if len(pod.Status.ContainerStatuses) > 0 {
 		cs := pod.Status.ContainerStatuses[0]
 		if c.Rules.ContainerID {
+			if len(cs.ContainerID) == 0 {
+				c.logger.Warn("missing container ID for Pod, cache may be out of sync", zap.String("pod", pod.Name), zap.String("container_name", cs.Name))
+			}
 			tags[c.Rules.Tags.ContainerID] = cs.ContainerID
 		}
 	}

--- a/pkg/processor/k8sprocessor/kube/owner.go
+++ b/pkg/processor/k8sprocessor/kube/owner.go
@@ -612,6 +612,22 @@ func (op *OwnerCache) GetOwners(pod *Pod) []*ObjectOwner {
 					visited[ownerUID] = true
 				}
 			}
+		} else {
+			// try to find the owner
+			var ownerReference meta_v1.OwnerReference
+			for _, or := range *pod.OwnerReferences {
+				if or.UID == uid {
+					ownerReference = or
+				}
+			}
+			// ownerReference may be empty
+			op.logger.Warn(
+				"missing owner data for Pod, cache may be out of sync",
+				zap.String("pod", pod.Name),
+				zap.String("owner_id", string(uid)),
+				zap.String("owner_kind", ownerReference.Kind),
+				zap.String("owner_name", ownerReference.Name),
+			)
 		}
 		op.ownersMutex.RUnlock()
 	}


### PR DESCRIPTION
Log warnings when we're missing data we should have. This usually means the cache is out of sync. Right now we don't have any observability for these kinds of events.