### PR TITLE
refactor(exporter/sumologic): rename deprecated `CompressionType` type

### DIFF
--- a/pkg/exporter/sumologicexporter/config.go
+++ b/pkg/exporter/sumologicexporter/config.go
@@ -37,7 +37,7 @@ type Config struct {
 	// Compression encoding format, either empty string, gzip or deflate (default gzip)
 	// Empty string means no compression
 	// NOTE: CompressEncoding is deprecated and will be removed in an upcoming release
-	CompressEncoding configcompression.CompressionType `mapstructure:"compress_encoding"`
+	CompressEncoding configcompression.Type `mapstructure:"compress_encoding"`
 	// Max HTTP request body size in bytes before compression (if applied).
 	// By default 1MB is recommended.
 	MaxRequestBodySize int `mapstructure:"max_request_body_size"`
@@ -205,7 +205,7 @@ const (
 	// OTLPTraceFormat represents trace_format: otlp
 	OTLPTraceFormat TraceFormatType = "otlp"
 	// NoCompression represents disabled compression
-	NoCompression configcompression.CompressionType = ""
+	NoCompression configcompression.Type = ""
 	// MetricsPipeline represents metrics pipeline
 	MetricsPipeline PipelineType = "metrics"
 	// LogsPipeline represents metrics pipeline
@@ -217,7 +217,7 @@ const (
 	// DefaultCompress defines default Compress
 	DefaultCompress bool = true
 	// DefaultCompressEncoding defines default CompressEncoding
-	DefaultCompressEncoding configcompression.CompressionType = "gzip"
+	DefaultCompressEncoding configcompression.Type = "gzip"
 	// DefaultMaxRequestBodySize defines default MaxRequestBodySize in bytes
 	DefaultMaxRequestBodySize int = 1 * 1024 * 1024
 	// DefaultLogFormat defines default LogFormat

--- a/pkg/exporter/sumologicexporter/sender_test.go
+++ b/pkg/exporter/sumologicexporter/sender_test.go
@@ -54,7 +54,7 @@ type senderTest struct {
 // Provided cfgOpts additionally configure the sender after the sendible default
 // for tests have been applied.
 // The enclosed httptest.Server is closed automatically using test.Cleanup.
-func prepareSenderTest(t *testing.T, compression configcompression.CompressionType, cb []func(w http.ResponseWriter, req *http.Request), cfgOpts ...func(*Config)) *senderTest {
+func prepareSenderTest(t *testing.T, compression configcompression.Type, cb []func(w http.ResponseWriter, req *http.Request), cfgOpts ...func(*Config)) *senderTest {
 	var reqCounter int32
 	// generate a test server so we can capture and inspect the request
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
See deprecations in [core v0.94.0](https://github.com/open-telemetry/opentelemetry-collector/blob/main/CHANGELOG-API.md#v110v0940).