### PR TITLE
feat: build windows containers

### DIFF
--- a/.changelog/1467.added.txt
+++ b/.changelog/1467.added.txt
@@ -1,0 +1,1 @@
+feat: build windows containers

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 'dev-build/*'
+      - drosiek-windows-container
 
 defaults:
   run:
@@ -191,11 +192,54 @@ jobs:
             PLATFORM=${{ matrix.arch_os }} \
             BUILD_TYPE_SUFFIX="-ubi"
 
+  build-windows-container-images:
+    name: Build Windows container
+    runs-on: windows-2022
+    needs:
+      - build
+    strategy:
+      matrix:
+        arch_os: [ 'windows_amd64']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract tag
+        id: extract_tag
+        run: echo "tag=$(git rev-parse HEAD)" > $GITHUB_OUTPUT
+
+      - name: Print tag
+        run: echo "Running dev build for ${{ steps.extract_tag.outputs.tag }}"
+
+      - name: Login to Open Source ECR
+        run: |
+          USERNAME=$(powershell.exe "echo \$Env:UserName")
+          # remove wincred entry and fix json format by replacing }, with }
+          cat "C:\\Users\\${USERNAME}\\.docker\\config.json" | grep -v "wincred" | sed 's/},$/}/' > "C:\\Users\\${USERNAME}\\.docker\\config.json.tmp"
+          mv "C:\\Users\\${USERNAME}\\.docker\\config.json.tmp" "C:\\Users\\${USERNAME}\\.docker\\config.json"
+          make login
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_DEV }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEV }}
+
+      - name: Download binary action artifact from build phase
+        uses: actions/download-artifact@v4
+        with:
+          name: otelcol-sumo-${{matrix.arch_os}}.exe
+          path: artifacts/
+
+      - name: Build and push image to Open Source ECR
+        run: |
+          cp artifacts/otelcol-sumo-${{matrix.arch_os}}.exe otelcol-sumo.exe
+          make build-push-container-windows-dev \
+            BUILD_TAG=${{ steps.extract_tag.outputs.tag }} \
+            PLATFORM=${{ matrix.arch_os }}
+
   push-docker-manifest:
     name: Push joint container manifest
     runs-on: ubuntu-20.04
     needs:
       - build-container-images
+      - build-windows-container-images
     steps:
       - uses: actions/checkout@v4
 
@@ -240,7 +284,7 @@ jobs:
         run: |
           make push-container-manifest-dev \
             BUILD_TAG=${{ steps.extract_tag.outputs.tag }} \
-            PLATFORMS="linux/amd64 linux/arm64"
+            PLATFORMS="linux/amd64 linux/arm64 windows/amd64"
 
       - name: Push joint UBI-based container manifest for all platforms to Open Source ECR
         run: |

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -194,7 +194,7 @@ jobs:
 
   build-windows-container-images:
     name: Build Windows container
-    runs-on: ${{ matrix.runs_on }}
+    runs-on: ${{ matrix.runs-on }}
     needs:
       - build
     strategy:

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - 'dev-build/*'
-      - drosiek-windows-container
 
 defaults:
   run:

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -199,7 +199,11 @@ jobs:
       - build
     strategy:
       matrix:
-        arch_os: [ 'windows_amd64']
+        include:
+          - arch_os: windows_amd64
+            base_image_tag: ltsc2022
+          - arch_os: windows_amd64
+            base_image_tag: ltsc2019
     steps:
       - uses: actions/checkout@v4
 
@@ -227,12 +231,12 @@ jobs:
           name: otelcol-sumo-${{matrix.arch_os}}.exe
           path: artifacts/
 
-      - name: Build and push image to Open Source ECR
+      - name: Build and push images to Open Source ECR
         run: |
           cp artifacts/otelcol-sumo-${{matrix.arch_os}}.exe otelcol-sumo.exe
           make build-push-container-windows-dev \
             BUILD_TAG=${{ steps.extract_tag.outputs.tag }} \
-            PLATFORM=${{ matrix.arch_os }}
+            PLATFORM=${{ matrix.arch_os }}_${{ matrix.base_image_tag }}
 
   push-docker-manifest:
     name: Push joint container manifest
@@ -284,7 +288,7 @@ jobs:
         run: |
           make push-container-manifest-dev \
             BUILD_TAG=${{ steps.extract_tag.outputs.tag }} \
-            PLATFORMS="linux/amd64 linux/arm64 windows/amd64"
+            PLATFORMS="linux/amd64 linux/arm64 windows/amd64/ltsc2022 windows/amd64/ltsc2019"
 
       - name: Push joint UBI-based container manifest for all platforms to Open Source ECR
         run: |

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -194,7 +194,7 @@ jobs:
 
   build-windows-container-images:
     name: Build Windows container
-    runs-on: windows-2022
+    runs-on: ${{ matrix.runs_on }}
     needs:
       - build
     strategy:
@@ -202,8 +202,10 @@ jobs:
         include:
           - arch_os: windows_amd64
             base_image_tag: ltsc2022
+            runs-on: windows-2022
           - arch_os: windows_amd64
             base_image_tag: ltsc2019
+            runs-on: windows-2019
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -364,6 +364,7 @@ jobs:
     name: Build windows container
     needs:
       - build
+    runs-on: ${{ matrix.runs_on }}
     strategy:
       matrix:
         include:
@@ -373,10 +374,6 @@ jobs:
           - arch_os: windows_amd64
             base_image_tag: ltsc2019
             runs-on: windows-2019
-    with:
-      arch_os: ${{ matrix.arch_os }}
-      runs-on: ${{ matrix.runs-on }}
-      base_image_tag: ${{ matrix.base_image_tag }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -359,3 +359,45 @@ jobs:
       - name: Test built FIPS image
         if: steps.changed-files.outputs.any_changed == 'true' && matrix.arch_os == 'linux_amd64'
         run: make test-built-image BUILD_TAG="latest-fips"
+
+  build-windows-container:
+    name: Build windows container
+    runs-on: windows-2022
+    needs:
+      - build
+    strategy:
+      matrix:
+        arch_os: [ 'windows_amd64']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check if build related files changed
+        id: changed-files
+        uses: tj-actions/changed-files@v41
+        with:
+          files: |
+            **/go.mod
+            **/go.sum
+            **/*.go
+            **/*.yaml
+            **/*.yml
+            **/Makefile
+            **/Makefile.common
+            **/Dockerfile*
+
+      - name: Download binary action artifact from build phase
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: otelcol-sumo-${{matrix.arch_os}}
+          path: artifacts/
+
+      - name: Build the container image
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          cp artifacts/otelcol-sumo-${{matrix.arch_os}} otelcol-sumo.exe
+          make build-push-container-windows
+
+      - name: Test built image
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: make test-built-image

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -403,3 +403,17 @@ jobs:
       - name: Test built image
         if: steps.changed-files.outputs.any_changed == 'true'
         run: make test-built-image
+
+      # ToDo: build windows FIPS image
+      # - name: Build the FIPS container image
+      #   if: steps.changed-files.outputs.any_changed == 'true'
+      #   run: |
+      #     cp artifacts/otelcol-sumo-fips-${{matrix.arch_os}}.exe otelcol-sumo.exe
+      #     make build-container-multiplatform \
+      #       PLATFORM=${{ matrix.arch_os }} \
+      #       DOCKERFILE=Dockerfile_windows \
+      #       BUILD_TYPE_SUFFIX="-fips"
+
+      # - name: Test built FIPS image
+      #   if: steps.changed-files.outputs.any_changed == 'true'
+      #   run: make test-built-image BUILD_TAG="latest-fips"

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -364,7 +364,7 @@ jobs:
     name: Build windows container
     needs:
       - build
-    runs-on: ${{ matrix.runs_on }}
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:
         include:

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -389,7 +389,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/download-artifact@v4
         with:
-          name: otelcol-sumo-${{matrix.arch_os}}
+          name: otelcol-sumo-${{matrix.arch_os}}.exe
           path: artifacts/
 
       - name: Build the container image

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -362,12 +362,21 @@ jobs:
 
   build-windows-container:
     name: Build windows container
-    runs-on: windows-2022
     needs:
       - build
     strategy:
       matrix:
-        arch_os: [ 'windows_amd64']
+        include:
+          - arch_os: windows_amd64
+            base_image_tag: ltsc2022
+            runs-on: windows-2022
+          - arch_os: windows_amd64
+            base_image_tag: ltsc2019
+            runs-on: windows-2019
+    with:
+      arch_os: ${{ matrix.arch_os }}
+      runs-on: ${{ matrix.runs-on }}
+      base_image_tag: ${{ matrix.base_image_tag }}
     steps:
       - uses: actions/checkout@v4
 
@@ -397,21 +406,10 @@ jobs:
         run: |
           cp artifacts/otelcol-sumo-${{matrix.arch_os}}.exe otelcol-sumo.exe
           make build-container-windows \
-            PLATFORM=${{ matrix.arch_os }}
+            PLATFORM=${{ matrix.arch_os }}_${{ matrix.base_image_tag }}
 
       - name: Test built image
         if: steps.changed-files.outputs.any_changed == 'true'
         run: make test-built-image
 
       # ToDo: build windows FIPS image
-      # - name: Build the FIPS container image
-      #   if: steps.changed-files.outputs.any_changed == 'true'
-      #   run: |
-      #     cp artifacts/otelcol-sumo-fips-${{matrix.arch_os}}.exe otelcol-sumo.exe
-      #     make build-container-windows \
-      #       PLATFORM=${{ matrix.arch_os }}
-      #       BUILD_TYPE_SUFFIX="-fips"
-
-      # - name: Test built FIPS image
-      #   if: steps.changed-files.outputs.any_changed == 'true'
-      #   run: make test-built-image BUILD_TAG="latest-fips"

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -396,7 +396,9 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           cp artifacts/otelcol-sumo-${{matrix.arch_os}}.exe otelcol-sumo.exe
-          make build-push-container-windows
+          make build-container-multiplatform \
+            PLATFORM=${{ matrix.arch_os }} \
+            DOCKERFILE=Dockerfile_windows
 
       - name: Test built image
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -386,7 +386,7 @@ jobs:
             **/Dockerfile*
 
       - name: Download binary action artifact from build phase
-        # if: steps.changed-files.outputs.any_changed == 'true'
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/download-artifact@v4
         with:
           name: otelcol-sumo-${{matrix.arch_os}}
@@ -395,7 +395,7 @@ jobs:
       - name: Build the container image
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-          cp artifacts/otelcol-sumo-${{matrix.arch_os}} otelcol-sumo.exe
+          cp artifacts/otelcol-sumo-${{matrix.arch_os}}.exe otelcol-sumo.exe
           make build-push-container-windows
 
       - name: Test built image

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -396,9 +396,8 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           cp artifacts/otelcol-sumo-${{matrix.arch_os}}.exe otelcol-sumo.exe
-          make build-container-multiplatform \
-            PLATFORM=${{ matrix.arch_os }} \
-            DOCKERFILE=Dockerfile_windows
+          make build-container-windows \
+            PLATFORM=${{ matrix.arch_os }}
 
       - name: Test built image
         if: steps.changed-files.outputs.any_changed == 'true'
@@ -409,9 +408,8 @@ jobs:
       #   if: steps.changed-files.outputs.any_changed == 'true'
       #   run: |
       #     cp artifacts/otelcol-sumo-fips-${{matrix.arch_os}}.exe otelcol-sumo.exe
-      #     make build-container-multiplatform \
-      #       PLATFORM=${{ matrix.arch_os }} \
-      #       DOCKERFILE=Dockerfile_windows \
+      #     make build-container-windows \
+      #       PLATFORM=${{ matrix.arch_os }}
       #       BUILD_TYPE_SUFFIX="-fips"
 
       # - name: Test built FIPS image

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -386,7 +386,7 @@ jobs:
             **/Dockerfile*
 
       - name: Download binary action artifact from build phase
-        if: steps.changed-files.outputs.any_changed == 'true'
+        # if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/download-artifact@v4
         with:
           name: otelcol-sumo-${{matrix.arch_os}}

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -392,7 +392,11 @@ jobs:
       - build
     strategy:
       matrix:
-        arch_os: [ 'windows_amd64']
+        include:
+          - arch_os: windows_amd64
+            base_image_tag: ltsc2022
+          - arch_os: windows_amd64
+            base_image_tag: ltsc2019
     steps:
       - uses: actions/checkout@v4
 
@@ -425,7 +429,7 @@ jobs:
           cp artifacts/otelcol-sumo-${{matrix.arch_os}}.exe otelcol-sumo.exe
           make build-push-container-windows \
             BUILD_TAG=${{ steps.extract_tag.outputs.tag }} \
-            PLATFORM=${{ matrix.arch_os }}
+            PLATFORM=${{ matrix.arch_os }}_${{ matrix.base_image_tag }}
 
   push-docker-manifest:
     name: Push joint container manifest
@@ -480,7 +484,7 @@ jobs:
         run: |
           make push-container-manifest \
             BUILD_TAG=${{ steps.extract_tag.outputs.tag }} \
-            PLATFORMS="linux/amd64 linux/arm64 windows/amd64"
+            PLATFORMS="linux/amd64 linux/arm64 windows/amd64/ltsc2022 windows/amd64/ltsc2019"
 
       - name: Push joint UBI-based container manifest for all platforms to Open Source ECR
         run: |

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -385,52 +385,6 @@ jobs:
             PLATFORM=${{ matrix.arch_os }}
             BUILD_TYPE_SUFFIX="-ubi"
 
-  build-windows-container-images:
-    name: Build Windows container
-    runs-on: windows-2022
-    needs:
-      - build
-    strategy:
-      matrix:
-        include:
-          - arch_os: windows_amd64
-            base_image_tag: ltsc2022
-          - arch_os: windows_amd64
-            base_image_tag: ltsc2019
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Extract tag
-        id: extract_tag
-        run: echo "tag=$(git rev-parse HEAD)" > $GITHUB_OUTPUT
-
-      - name: Print tag
-        run: echo "Running dev build for ${{ steps.extract_tag.outputs.tag }}"
-
-      - name: Login to Open Source ECR
-        run: |
-          USERNAME=$(powershell.exe "echo \$Env:UserName")
-          # remove wincred entry and fix json format by replacing }, with }
-          cat "C:\\Users\\${USERNAME}\\.docker\\config.json" | grep -v "wincred" | sed 's/},$/}/' > "C:\\Users\\${USERNAME}\\.docker\\config.json.tmp"
-          mv "C:\\Users\\${USERNAME}\\.docker\\config.json.tmp" "C:\\Users\\${USERNAME}\\.docker\\config.json"
-          make login
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_DEV }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEV }}
-
-      - name: Download binary action artifact from build phase
-        uses: actions/download-artifact@v4
-        with:
-          name: otelcol-sumo-${{matrix.arch_os}}.exe
-          path: artifacts/
-
-      - name: Build and push image to Open Source ECR
-        run: |
-          cp artifacts/otelcol-sumo-${{matrix.arch_os}}.exe otelcol-sumo.exe
-          make build-push-container-windows \
-            BUILD_TAG=${{ steps.extract_tag.outputs.tag }} \
-            PLATFORM=${{ matrix.arch_os }}_${{ matrix.base_image_tag }}
-
   push-docker-manifest:
     name: Push joint container manifest
     runs-on: ubuntu-20.04
@@ -439,7 +393,6 @@ jobs:
       # when darwin build fails.
       - build-darwin
       - build-container-images
-      - build-windows-container-images
     steps:
       - uses: actions/checkout@v4
 
@@ -484,7 +437,7 @@ jobs:
         run: |
           make push-container-manifest \
             BUILD_TAG=${{ steps.extract_tag.outputs.tag }} \
-            PLATFORMS="linux/amd64 linux/arm64 windows/amd64/ltsc2022 windows/amd64/ltsc2019"
+            PLATFORMS="linux/amd64 linux/arm64"
 
       - name: Push joint UBI-based container manifest for all platforms to Open Source ECR
         run: |

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -385,6 +385,48 @@ jobs:
             PLATFORM=${{ matrix.arch_os }}
             BUILD_TYPE_SUFFIX="-ubi"
 
+  build-windows-container-images:
+    name: Build Windows container
+    runs-on: windows-2022
+    needs:
+      - build
+    strategy:
+      matrix:
+        arch_os: [ 'windows_amd64']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract tag
+        id: extract_tag
+        run: echo "tag=$(git rev-parse HEAD)" > $GITHUB_OUTPUT
+
+      - name: Print tag
+        run: echo "Running dev build for ${{ steps.extract_tag.outputs.tag }}"
+
+      - name: Login to Open Source ECR
+        run: |
+          USERNAME=$(powershell.exe "echo \$Env:UserName")
+          # remove wincred entry and fix json format by replacing }, with }
+          cat "C:\\Users\\${USERNAME}\\.docker\\config.json" | grep -v "wincred" | sed 's/},$/}/' > "C:\\Users\\${USERNAME}\\.docker\\config.json.tmp"
+          mv "C:\\Users\\${USERNAME}\\.docker\\config.json.tmp" "C:\\Users\\${USERNAME}\\.docker\\config.json"
+          make login
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_DEV }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEV }}
+
+      - name: Download binary action artifact from build phase
+        uses: actions/download-artifact@v4
+        with:
+          name: otelcol-sumo-${{matrix.arch_os}}.exe
+          path: artifacts/
+
+      - name: Build and push image to Open Source ECR
+        run: |
+          cp artifacts/otelcol-sumo-${{matrix.arch_os}}.exe otelcol-sumo.exe
+          make build-push-container-windows \
+            BUILD_TAG=${{ steps.extract_tag.outputs.tag }} \
+            PLATFORM=${{ matrix.arch_os }}
+
   push-docker-manifest:
     name: Push joint container manifest
     runs-on: ubuntu-20.04
@@ -393,6 +435,7 @@ jobs:
       # when darwin build fails.
       - build-darwin
       - build-container-images
+      - build-windows-container-images
     steps:
       - uses: actions/checkout@v4
 
@@ -437,7 +480,7 @@ jobs:
         run: |
           make push-container-manifest \
             BUILD_TAG=${{ steps.extract_tag.outputs.tag }} \
-            PLATFORMS="linux/amd64 linux/arm64"
+            PLATFORMS="linux/amd64 linux/arm64 windows/amd64"
 
       - name: Push joint UBI-based container manifest for all platforms to Open Source ECR
         run: |

--- a/Dockerfile_windows
+++ b/Dockerfile_windows
@@ -1,3 +1,7 @@
-FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+ARG BUILD_TAG=latest
+ENV TAG $BUILD_TAG
+
 ADD /otelcol-sumo.exe /otelcol-sumo.exe
 ENTRYPOINT ["/otelcol-sumo.exe"]
+CMD ["--config", "/etc/otel/config.yaml"]

--- a/Dockerfile_windows
+++ b/Dockerfile_windows
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
+ADD /otelcol-sumo.exe /otelcol-sumo.exe
+ENTRYPOINT ["/otelcol-sumo.exe"]

--- a/Dockerfile_windows
+++ b/Dockerfile_windows
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2022
+ARG BASE_IMAGE_TAG=ltsc2022
+FROM mcr.microsoft.com/windows/servercore:${BASE_IMAGE_TAG}
 ARG BUILD_TAG=latest
 ENV TAG $BUILD_TAG
 

--- a/Dockerfile_windows
+++ b/Dockerfile_windows
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
 ARG BUILD_TAG=latest
 ENV TAG $BUILD_TAG
 

--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,10 @@ build-container-multiplatform-dev: build-container-multiplatform
 build-push-container-multiplatform-dev: REPO_URL = "$(OPENSOURCE_REPO_URL_DEV)"
 build-push-container-multiplatform-dev: build-push-container-multiplatform
 
+.PHONY: build-push-container-windows-dev
+build-push-container-windows-dev: DOCKERFILE = Dockerfile_windows
+build-push-container-windows-dev: build-push-container-multiplatform-dev
+
 .PHONY: push-container-manifest-dev
 push-container-manifest-dev: REPO_URL = "$(OPENSOURCE_REPO_URL_DEV)"
 push-container-manifest-dev: push-container-manifest
@@ -303,6 +307,14 @@ _build-container-multiplatform:
 .PHONY: build-container-multiplatform
 build-container-multiplatform: _build-container-multiplatform
 
+.PHONY: build-container-windows
+build-container-windows: DOCKERFILE = Dockerfile_windows
+build-container-windows: _build-container-multiplatform
+
+.PHONY: build-push-container-windows
+build-push-container-windows: PUSH = --push
+build-push-container-windows: build-container-windows
+
 .PHONY: build-push-container-multiplatform
 build-push-container-multiplatform: PUSH = --push
 build-push-container-multiplatform: _build-container-multiplatform
@@ -311,11 +323,6 @@ build-push-container-multiplatform: _build-container-multiplatform
 build-push-container-ubi: PUSH = --push
 build-push-container-ubi: DOCKERFILE = Dockerfile_ubi
 build-push-container-ubi: _build-container-multiplatform
-
-.PHONY: build-push-container-windows
-build-push-container-windows: PUSH = --push
-build-push-container-windows: DOCKERFILE = Dockerfile_windows
-build-push-container-windows: _build-container-multiplatform
 
 .PHONY: test-built-image
 test-built-image:

--- a/Makefile
+++ b/Makefile
@@ -300,15 +300,6 @@ _build-container-multiplatform:
 		PLATFORM="$(PLATFORM)" \
 		./ci/build-push-multiplatform.sh $(PUSH)
 
-.PHONY: _build-container-windows
-_build-container-windows:
-	docker \
-		build \
-		-f $(DOCKERFILE) \
-		. \
-		-t ${REPO_URL}/${BUILD_TAG}-windows \
-		--platform="$(PLATFORM)"
-
 .PHONY: build-container-multiplatform
 build-container-multiplatform: _build-container-multiplatform
 
@@ -324,7 +315,7 @@ build-push-container-ubi: _build-container-multiplatform
 .PHONY: build-push-container-windows
 build-push-container-windows: PUSH = --push
 build-push-container-windows: DOCKERFILE = Dockerfile_windows
-build-push-container-windows: _build-container-windows
+build-push-container-windows: _build-container-multiplatform
 
 .PHONY: test-built-image
 test-built-image:

--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,7 @@ OPENSOURCE_ECR_URL = public.ecr.aws/sumologic
 OPENSOURCE_REPO_URL = $(OPENSOURCE_ECR_URL)/$(IMAGE_NAME)
 OPENSOURCE_REPO_URL_DEV = $(OPENSOURCE_ECR_URL)/$(IMAGE_NAME_DEV)
 REPO_URL = $(OPENSOURCE_REPO_URL)
+BASE_IMAGE_TAG ?= ""
 
 DOCKERFILE = Dockerfile
 
@@ -302,14 +303,21 @@ _build-container-multiplatform:
 		REPO_URL="$(REPO_URL)" \
 		DOCKERFILE="$(DOCKERFILE)" \
 		PLATFORM="$(PLATFORM)" \
+		BASE_IMAGE_TAG="${BASE_IMAGE_TAG}" \
 		./ci/build-push-multiplatform.sh $(PUSH)
 
 .PHONY: build-container-multiplatform
 build-container-multiplatform: _build-container-multiplatform
 
 .PHONY: build-container-windows
-build-container-windows: DOCKERFILE = Dockerfile_windows
-build-container-windows: _build-container-multiplatform
+build-container-windows:
+	$(MAKE) _build-container-multiplatform \
+		DOCKERFILE=Dockerfile_windows \
+		BASE_IMAGE_TAG=ltsc2022
+
+	$(MAKE) _build-container-multiplatform \
+		DOCKERFILE=Dockerfile_windows \
+		BASE_IMAGE_TAG=ltsc2019
 
 .PHONY: build-push-container-windows
 build-push-container-windows: PUSH = --push

--- a/Makefile
+++ b/Makefile
@@ -300,6 +300,15 @@ _build-container-multiplatform:
 		PLATFORM="$(PLATFORM)" \
 		./ci/build-push-multiplatform.sh $(PUSH)
 
+.PHONY: _build-container-windows
+_build-container-windows:
+	docker \
+		build \
+		-f $(DOCKERFILE) \
+		. \
+		-t ${REPO_URL}/${BUILD_TAG}-windows \
+		--platform="$(PLATFORM)"
+
 .PHONY: build-container-multiplatform
 build-container-multiplatform: _build-container-multiplatform
 
@@ -311,6 +320,11 @@ build-push-container-multiplatform: _build-container-multiplatform
 build-push-container-ubi: PUSH = --push
 build-push-container-ubi: DOCKERFILE = Dockerfile_ubi
 build-push-container-ubi: _build-container-multiplatform
+
+.PHONY: build-push-container-windows
+build-push-container-windows: PUSH = --push
+build-push-container-windows: DOCKERFILE = Dockerfile_windows
+build-push-container-windows: _build-container-windows
 
 .PHONY: test-built-image
 test-built-image:

--- a/ci/build-push-multiplatform.sh
+++ b/ci/build-push-multiplatform.sh
@@ -149,6 +149,7 @@ function build_push() {
                 --platform="${PLATFORM}" \
                 --load \
                 --tag "${REPO_URL}:latest${BUILD_TYPE_SUFFIX}" \
+                --provenance=false \
                 .
         fi
     fi

--- a/ci/build-push-multiplatform.sh
+++ b/ci/build-push-multiplatform.sh
@@ -134,16 +134,11 @@ function build_push() {
         if [[ "${BUILD_PLATFORM}" == "windows" ]]; then
             docker build \
                 --file "${DOCKERFILE}" \
-                --build-arg BUILD_TAG="${BUILD_TAG}" \
+                --build-arg BUILD_TAG="latest${BUILD_TYPE_SUFFIX}" \
                 --build-arg BUILDKIT_INLINE_CACHE=1 \
                 --platform="${PLATFORM}" \
                 --tag "${REPO_URL}:latest${BUILD_TYPE_SUFFIX}" \
                 .
-
-            docker tag "${LATEST_TAG}" "${TAG}"
-
-            docker push "${LATEST_TAG}"
-            docker push "${TAG}"
         else
             # load flag is needed so that docker loads this image
             # for subsequent steps on github actions

--- a/ci/build-push-multiplatform.sh
+++ b/ci/build-push-multiplatform.sh
@@ -2,16 +2,7 @@
 
 set -eo pipefail
 
-if echo "${PLATFORM}" | grep windows; then
-    while ! docker images; do
-        echo "Cannot connect to docker daemon"
-        sleep 1
-    done
-else
-    while ! docker buildx ls; do
-        echo "Cannot connect to docker daemon"
-        sleep 1
-    done
+if echo "${PLATFORM}" | grep -v windows; then
 
     DOCKER_BUILDX_LS_OUT=$(docker buildx ls <<-END
 END

--- a/ci/build-push-multiplatform.sh
+++ b/ci/build-push-multiplatform.sh
@@ -101,6 +101,7 @@ function build_push() {
     local LATEST_TAG
     readonly LATEST_TAG="${REPO_URL}:latest${BUILD_TYPE_SUFFIX}-${BUILD_PLATFORM}-${BUILD_ARCH}"
 
+    # --provenance=false for docker buildx ensures that we create manifest instead of manifest list
     if [[ "${PUSH}" == true ]]; then
         echo "Building tags: ${TAG}, ${LATEST_TAG}"
 

--- a/ci/build-push-multiplatform.sh
+++ b/ci/build-push-multiplatform.sh
@@ -127,6 +127,7 @@ function build_push() {
                 --platform="${PLATFORM}" \
                 --tag "${LATEST_TAG}" \
                 --tag "${TAG}" \
+                --provenance=false \
                 .
         fi
     else

--- a/ci/build-push-multiplatform.sh
+++ b/ci/build-push-multiplatform.sh
@@ -3,11 +3,10 @@
 set -eo pipefail
 
 if echo "${PLATFORM}" | grep windows; then
-    echo ''
-    # while ! docker images; do
-    #     echo "Cannot connect to docker daemon"
-    #     sleep 1
-    # done
+    while ! docker images; do
+        echo "Cannot connect to docker daemon"
+        sleep 1
+    done
 else
     while ! docker buildx ls; do
         echo "Cannot connect to docker daemon"

--- a/ci/push_docker_multiplatform_manifest.sh
+++ b/ci/push_docker_multiplatform_manifest.sh
@@ -74,13 +74,20 @@ function push_manifest() {
 
     echo
     set -x
-    docker buildx imagetools create --tag \
+    # Use docker manifest as docker buildx didn't create "${REPO_URL}:${BUILD_TAG}" correctly. It was containing only linux/amd64 image
+    docker manifest create \
         "${REPO_URL}:${BUILD_TAG}" \
         "${TAGS_IN_MANIFEST[@]}"
 
-    docker buildx imagetools create --tag \
+    docker manifest push \
+        "${REPO_URL}:${BUILD_TAG}"
+
+    docker manifest create \
         "${REPO_URL}:latest${BUILD_TYPE_SUFFIX}" \
         "${TAGS_IN_MANIFEST[@]}"
+
+    docker manifest push \
+        "${REPO_URL}:latest${BUILD_TYPE_SUFFIX}"
 }
 
 push_manifest

--- a/ci/push_docker_multiplatform_manifest.sh
+++ b/ci/push_docker_multiplatform_manifest.sh
@@ -39,23 +39,23 @@ function push_manifest() {
         echo "${platform}"
         case "${platform}" in
         "linux/amd64")
-            readonly BUILD_ARCH="amd64"
-            readonly BUILD_PLATFORM="linux"
+            BUILD_ARCH="amd64"
+            BUILD_PLATFORM="linux"
             ;;
 
         "linux/arm64")
-            readonly BUILD_ARCH="arm64"
-            readonly BUILD_PLATFORM="linux"
+            BUILD_ARCH="arm64"
+            BUILD_PLATFORM="linux"
             ;;
 
         "linux/arm/v7")
-            readonly BUILD_ARCH="arm_v7"
-            readonly BUILD_PLATFORM="linux"
+            BUILD_ARCH="arm_v7"
+            BUILD_PLATFORM="linux"
             ;;
 
         "windows/amd64")
-            readonly BUILD_ARCH="amd64"
-            readonly BUILD_PLATFORM="windows"
+            BUILD_ARCH="amd64"
+            BUILD_PLATFORM="windows"
             ;;
         *)
             echo "Unsupported platform ${platform}"

--- a/ci/push_docker_multiplatform_manifest.sh
+++ b/ci/push_docker_multiplatform_manifest.sh
@@ -39,24 +39,31 @@ function push_manifest() {
         echo "${platform}"
         case "${platform}" in
         "linux/amd64")
-            BUILD_ARCH="amd64"
+            readonly BUILD_ARCH="amd64"
+            readonly BUILD_PLATFORM="linux"
             ;;
 
         "linux/arm64")
-            BUILD_ARCH="arm64"
+            readonly BUILD_ARCH="arm64"
+            readonly BUILD_PLATFORM="linux"
             ;;
 
         "linux/arm/v7")
-            BUILD_ARCH="arm_v7"
+            readonly BUILD_ARCH="arm_v7"
+            readonly BUILD_PLATFORM="linux"
             ;;
 
+        "windows/amd64")
+            readonly BUILD_ARCH="amd64"
+            readonly BUILD_PLATFORM="windows"
+            ;;
         *)
             echo "Unsupported platform ${platform}"
             exit 1
             ;;
         esac
 
-        TAGS_IN_MANIFEST+=("${REPO_URL}:${BUILD_TAG}-${BUILD_ARCH}")
+        TAGS_IN_MANIFEST+=("${REPO_URL}:${BUILD_TAG}-${BUILD_PLATFORM}-${BUILD_ARCH}")
     done
 
     echo "Tags in the manifest:"

--- a/ci/push_docker_multiplatform_manifest.sh
+++ b/ci/push_docker_multiplatform_manifest.sh
@@ -63,7 +63,7 @@ function push_manifest() {
             ;;
         esac
 
-        TAGS_IN_MANIFEST+=("${REPO_URL}:${BUILD_TAG}-${BUILD_PLATFORM}-${BUILD_ARCH}")
+        TAGS_IN_MANIFEST+=("${REPO_URL}:${BUILD_TAG}${BUILD_TYPE_SUFFIX}-${BUILD_PLATFORM}-${BUILD_ARCH}")
     done
 
     echo "Tags in the manifest:"
@@ -76,11 +76,11 @@ function push_manifest() {
     set -x
     # Use docker manifest as docker buildx didn't create "${REPO_URL}:${BUILD_TAG}" correctly. It was containing only linux/amd64 image
     docker manifest create \
-        "${REPO_URL}:${BUILD_TAG}" \
+        "${REPO_URL}:${BUILD_TAG}${BUILD_TYPE_SUFFIX}" \
         "${TAGS_IN_MANIFEST[@]}"
 
     docker manifest push \
-        "${REPO_URL}:${BUILD_TAG}"
+        "${REPO_URL}:${BUILD_TAG}${BUILD_TYPE_SUFFIX}"
 
     docker manifest create \
         "${REPO_URL}:latest${BUILD_TYPE_SUFFIX}" \

--- a/ci/push_docker_multiplatform_manifest.sh
+++ b/ci/push_docker_multiplatform_manifest.sh
@@ -53,9 +53,16 @@ function push_manifest() {
             BUILD_PLATFORM="linux"
             ;;
 
-        "windows/amd64")
+        "windows/amd64/ltsc2022")
             BUILD_ARCH="amd64"
             BUILD_PLATFORM="windows"
+            BASE_IMAGE_TAG_SUFFIX="-ltsc2022"
+            ;;
+
+        "windows/amd64/ltsc2019")
+            BUILD_ARCH="amd64"
+            BUILD_PLATFORM="windows"
+            BASE_IMAGE_TAG_SUFFIX="-ltsc2019"
             ;;
         *)
             echo "Unsupported platform ${platform}"
@@ -63,7 +70,7 @@ function push_manifest() {
             ;;
         esac
 
-        TAGS_IN_MANIFEST+=("${REPO_URL}:${BUILD_TAG}${BUILD_TYPE_SUFFIX}-${BUILD_PLATFORM}-${BUILD_ARCH}")
+        TAGS_IN_MANIFEST+=("${REPO_URL}:${BUILD_TAG}${BUILD_TYPE_SUFFIX}-${BUILD_PLATFORM}-${BUILD_ARCH}${BASE_IMAGE_TAG_SUFFIX}")
     done
 
     echo "Tags in the manifest:"


### PR DESCRIPTION
Adds building windows containers. This PR uses docker command in order to build manifest, as for some reason `docker buildx` was not always working, also buildx is not supported on windows

```
➜  ~ docker manifest inspect public.ecr.aws/sumologic/sumologic-otel-collector-dev:latest
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1093,
         "digest": "sha256:1fde89d7412f56cac8e295ec067895780d36755c1e0c442e2832024c54b09d4f",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1093,
         "digest": "sha256:5815d396401f4f24d69d90c7df4b918c030212719178d368d7d25ccda1b4fbb8",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1788,
         "digest": "sha256:79230acc35c7a076a9eab9e851839971a6f43c74d4ef184811962f1904ac5f2c",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.17763.5458"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1788,
         "digest": "sha256:711ab12580c5d2c1bd18785be0e9e675b62d6df01bf13d5c22793d567f0c71a3",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.20348.2322"
         }
      }
   ]
}
```