### PR TITLE
chore: Add basic Windows dev environments

### DIFF
--- a/vagrant/windows/README.md
+++ b/vagrant/windows/README.md
@@ -1,0 +1,49 @@
+# Vagrant Windows environments
+
+These environments are intended for development and troubleshooting of Windows-specific functionality.
+
+## Prerequisites
+
+See [the following document](../README.md) on how to install Vagrant.
+
+## Structure
+
+There's a Vagrantfile provided for each supported Windows version. To use a particular image, just `cd` into the
+directory of your choice.
+
+## Setting up
+
+You can set up the Vagrant environment with just one command:
+
+```bash
+vagrant up
+```
+
+After successfull installation you can ssh to the virtual machine with:
+
+```bash
+vagrant ssh
+```
+
+> [!NOTE]:
+> The directory with sumologic-otel-collector repository on the host is synced with the `C:\sumologic\` directory on the virtual machine.
+
+### Shell
+
+The default shell is Powershell. Bash is also available, and required if you actually want to build Otelcol in the
+Windows VM. You can start `bash` by running:
+
+```powershell
+bash
+```
+
+## Building the application
+
+After starting `bash` as per the previous section, you can use the same command as on Unix. So:
+
+```bash
+make install-builder
+make build
+```
+
+to build the binary.

--- a/vagrant/windows/Vagrantfile.common
+++ b/vagrant/windows/Vagrantfile.common
@@ -1,0 +1,26 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure('2') do |config|
+  config.vm.disk :disk, size: "30GB", primary: true
+  config.vm.box_check_update = false
+  # Vbox 6.1.28+ restricts host-only adapters to 192.168.56.0/21
+  # See: https://www.virtualbox.org/manual/ch06.html#network_hostonly
+  config.vm.network :private_network, ip: "192.168.56.13"
+
+  # See: https://github.com/hashicorp/vagrant/issues/13242
+  config.winrm.transport = :plaintext
+  config.winrm.basic_auth_only = true
+
+  config.ssh.shell = "powershell"
+
+  config.vm.provider 'virtualbox' do |vb|
+    vb.gui = false
+    vb.cpus = 8
+    vb.memory = 16384
+  end
+
+  config.vm.provision 'shell', path: '../provision.ps1', privileged: false
+
+  config.vm.synced_folder "../../..", "/sumologic"
+end

--- a/vagrant/windows/provision.ps1
+++ b/vagrant/windows/provision.ps1
@@ -1,0 +1,25 @@
+# Set PowerShell as the default shell
+$powerShellPath = get-command powershell
+New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value $powerShellPath.Path -PropertyType String -Force
+
+# Install Chocolatey
+Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iwr https://community.chocolatey.org/install.ps1 -UseBasicParsing | iex
+choco upgrade chocolatey -r
+
+# Install Golang
+choco install golang --version 1.21.2 -yr --no-progress
+
+# Install tools necessary to build otel
+choco install gnuwin32-coreutils.install -yr --no-progress
+choco install make git -yr --no-progress
+
+# Ensure bash is on the PATH
+$path = [Environment]::GetEnvironmentVariable("Path", "User")
+$path += ';C:\Program Files\Git\bin'
+[Environment]::SetEnvironmentVariable("Path", $path, "User")
+
+# Make git stop complaining about permissions in the shared directory
+C:\Program` Files\Git\cmd\git.exe config --global --add safe.directory '%(prefix)///vboxsvr/sumologic/'
+
+# Restart SSH daemon to ensure it loads the new environment variables
+Restart-Service sshd

--- a/vagrant/windows/windows-server-2012/Vagrantfile
+++ b/vagrant/windows/windows-server-2012/Vagrantfile
@@ -1,0 +1,13 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+common_vagrantfile = "../Vagrantfile.common"
+load common_vagrantfile
+
+Vagrant.configure('2') do |config|
+  config.vm.box = 'devopsgroup-io/boxes/windows_server-2012r2-standard-amd64-nocm'
+  config.vm.host_name = 'windows-server-2012'
+  config.vm.provider 'virtualbox' do |vb|
+    vb.name = 'windows-server-2012'
+  end
+end

--- a/vagrant/windows/windows-server-2016/Vagrantfile
+++ b/vagrant/windows/windows-server-2016/Vagrantfile
@@ -1,0 +1,13 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+common_vagrantfile = "../Vagrantfile.common"
+load common_vagrantfile
+
+Vagrant.configure('2') do |config|
+  config.vm.box = 'dstoliker/winserver2016'
+  config.vm.host_name = 'windows-server-2016'
+  config.vm.provider 'virtualbox' do |vb|
+    vb.name = 'windows-server-2016'
+  end
+end

--- a/vagrant/windows/windows-server-2019/Vagrantfile
+++ b/vagrant/windows/windows-server-2019/Vagrantfile
@@ -1,0 +1,13 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+common_vagrantfile = "../Vagrantfile.common"
+load common_vagrantfile
+
+Vagrant.configure('2') do |config|
+  config.vm.box = 'gusztavvargadr/windows-server-2019-standard'
+  config.vm.host_name = 'windows-server-2019'
+  config.vm.provider 'virtualbox' do |vb|
+    vb.name = 'windows-server-2019'
+  end
+end

--- a/vagrant/windows/windows-server-2022/Vagrantfile
+++ b/vagrant/windows/windows-server-2022/Vagrantfile
@@ -1,0 +1,14 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+common_vagrantfile = "../Vagrantfile.common"
+load common_vagrantfile
+
+Vagrant.configure('2') do |config|
+  config.vm.box = 'gusztavvargadr/windows-server-2022-standard'
+  config.vm.host_name = 'windows-server-2022'
+
+  config.vm.provider 'virtualbox' do |vb|
+    vb.name = 'windows-server-2022'
+  end
+end


### PR DESCRIPTION
The environments are defined as Vagrantfiles in `vagrant/windows`. They include enough tooling to build Otel and run tests.

Currently missing features I'd like to add in subsequent PRs:

* Docker, including being able to build Windows containers
* More documentation on troubleshooting issues with Otel installed via the install script
* Apple Silicon support of some sort
* More platforms, including at least one non-server version