### PR TITLE
chore(deps): update microsoft/setup-msbuild to v2 manually

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -270,7 +270,7 @@ jobs:
         run: ./ci/fetch_current_branch.sh
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.3
+        uses: microsoft/setup-msbuild@v2
 
       - name: Fetch binary artifact for ${{ matrix.arch_os }}
         uses: actions/download-artifact@v4

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -179,7 +179,7 @@ jobs:
         run: ./ci/fetch_current_branch.sh
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.3
+        uses: microsoft/setup-msbuild@v2
 
       - name: Restore NuGet packages
         working-directory: ./packaging/msi/SumoLogic.wixext/SumoLogicTests

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -467,7 +467,7 @@ jobs:
         run: ./ci/fetch_current_branch.sh
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.3
+        uses: microsoft/setup-msbuild@v2
 
       - name: Extract tag
         id: extract_tag


### PR DESCRIPTION
For some reason dependabot doesn't see the latest microsoft/setup-msbuild release (v2). That's why I update manually