### PR TITLE
tools(vagrant): add box for building Windows containers

### DIFF
--- a/vagrant/windows/README.md
+++ b/vagrant/windows/README.md
@@ -47,3 +47,14 @@ make build
 ```
 
 to build the binary.
+
+## Building Windows containers
+
+Use the [docker](docker/) machine, as it comes with Docker for Windows installed and configured. After building
+the application, you can build a Windows container the following way:
+
+```bash
+cp otelcolbuilder/cmd/otelcol-sumo.exe .
+make build-push-container-windows-dev PLATFORM=windows/amd64/ltsc2022
+docker run public.ecr.aws/sumologic/sumologic-otel-collector-dev:latest-windows-amd64-ltsc2022 --version
+```

--- a/vagrant/windows/docker/Vagrantfile
+++ b/vagrant/windows/docker/Vagrantfile
@@ -1,0 +1,14 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+common_vagrantfile = "../Vagrantfile.common"
+load common_vagrantfile
+
+Vagrant.configure('2') do |config|
+  config.vm.box = 'gusztavvargadr/docker-windows'
+  config.vm.host_name = 'docker-windows'
+
+  config.vm.provider 'virtualbox' do |vb|
+    vb.name = 'docker-windows'
+  end
+end


### PR DESCRIPTION
Found a turnkey image with Docker for Windows configured, where it's easy to build Windows containers.