### PR TITLE
test(install-script): add basic Windows install script tests

### DIFF
--- a/pkg/scripts_test/check.go
+++ b/pkg/scripts_test/check.go
@@ -1,5 +1,3 @@
-//go:build !windows
-
 package sumologic_scripts_tests
 
 import (

--- a/pkg/scripts_test/check_windows.go
+++ b/pkg/scripts_test/check_windows.go
@@ -1,0 +1,65 @@
+package sumologic_scripts_tests
+
+import (
+	"os/user"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func checkAbortedDueToNoToken(c check) {
+	require.Greater(c.test, len(c.output), 1)
+	require.Greater(c.test, len(c.errorOutput), 1)
+	require.Contains(c.test, c.errorOutput[0], "Installation token has not been provided.")
+	require.Contains(c.test, c.errorOutput[1], "Please set the SUMOLOGIC_INSTALLATION_TOKEN environment variable.")
+}
+
+func checkEphemeralNotInConfig(p string) func(c check) {
+	return func(c check) {
+		assert.False(c.test, c.installOptions.ephemeral, "ephemeral was specified")
+
+		conf, err := getConfig(p)
+		require.NoError(c.test, err, "error while reading configuration")
+
+		assert.False(c.test, conf.Extensions.Sumologic.Ephemeral, "ephemeral is true")
+	}
+}
+
+func checkEphemeralInConfig(p string) func(c check) {
+	return func(c check) {
+		assert.True(c.test, c.installOptions.ephemeral, "ephemeral was not specified")
+
+		conf, err := getConfig(p)
+		require.NoError(c.test, err, "error while reading configuration")
+
+		assert.True(c.test, conf.Extensions.Sumologic.Ephemeral, "ephemeral is not true")
+	}
+}
+
+func checkTokenInConfig(c check) {
+	require.NotEmpty(c.test, c.installOptions.installToken, "installation token has not been provided")
+
+	conf, err := getConfig(userConfigPath)
+	require.NoError(c.test, err, "error while reading configuration")
+
+	require.Equal(c.test, c.installOptions.installToken, conf.Extensions.Sumologic.InstallationToken, "installation token is different than expected")
+}
+
+func checkTokenInSumoConfig(c check) {
+	require.NotEmpty(c.test, c.installOptions.installToken, "installation token has not been provided")
+
+	conf, err := getConfig(configPath)
+	require.NoError(c.test, err, "error while reading configuration")
+
+	require.Equal(c.test, c.installOptions.installToken, conf.Extensions.Sumologic.InstallationToken, "installation token is different than expected")
+}
+
+func checkUserExists(c check) {
+	_, err := user.Lookup(systemUser)
+	require.NoError(c.test, err, "user has not been created")
+}
+
+func checkUserNotExists(c check) {
+	_, err := user.Lookup(systemUser)
+	require.Error(c.test, err, "user has been created")
+}

--- a/pkg/scripts_test/common.go
+++ b/pkg/scripts_test/common.go
@@ -1,5 +1,3 @@
-//go:build !windows
-
 package sumologic_scripts_tests
 
 type testSpec struct {

--- a/pkg/scripts_test/common_windows.go
+++ b/pkg/scripts_test/common_windows.go
@@ -1,0 +1,89 @@
+//go:build windows
+
+package sumologic_scripts_tests
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These checks always have to be true after a script execution
+var commonPostChecks = []checkFunc{checkNoBakFilesPresent}
+
+func runTest(t *testing.T, spec *testSpec) {
+	ch := check{
+		test:                t,
+		installOptions:      spec.options,
+		expectedInstallCode: spec.installCode,
+	}
+
+	t.Log("Running conditional checks")
+	for _, a := range spec.conditionalChecks {
+		if !a(ch) {
+			t.SkipNow()
+		}
+	}
+
+	defer tearDown(t)
+
+	t.Log("Starting HTTP server")
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.WriteString(w, "200 OK\n")
+		require.NoError(t, err)
+	})
+
+	listener, err := net.Listen("tcp", ":3333")
+	require.NoError(t, err)
+
+	httpServer := &http.Server{
+		Handler: mux,
+	}
+	go func() {
+		err := httpServer.Serve(listener)
+		if err != nil && err != http.ErrServerClosed {
+			require.NoError(t, err)
+		}
+	}()
+	defer func() {
+		require.NoError(t, httpServer.Shutdown(context.Background()))
+	}()
+
+	t.Log("Running pre actions")
+	for _, a := range spec.preActions {
+		a(ch)
+	}
+
+	t.Log("Running pre checks")
+	for _, c := range spec.preChecks {
+		c(ch)
+	}
+
+	ch.code, ch.output, ch.errorOutput, ch.err = runScript(ch)
+
+	checkRun(ch)
+
+	t.Log("Running common post checks")
+	for _, c := range commonPostChecks {
+		c(ch)
+	}
+
+	t.Log("Running post checks")
+	for _, c := range spec.postChecks {
+		c(ch)
+	}
+}
+
+func tearDown(t *testing.T) {
+	cmd := exec.Command("powershell", "Uninstall-Package", "-Name", fmt.Sprintf(`"%s"`, packageName))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Log(string(out))
+	}
+}

--- a/pkg/scripts_test/config.go
+++ b/pkg/scripts_test/config.go
@@ -1,5 +1,3 @@
-//go:build !windows
-
 package sumologic_scripts_tests
 
 import (

--- a/pkg/scripts_test/consts_windows.go
+++ b/pkg/scripts_test/consts_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package sumologic_scripts_tests
+
+const (
+	systemGroup string = "otelcol-sumo"
+	systemUser  string = "otelcol-sumo"
+
+	packageName string = "OpenTelemetry Collector"
+
+	binaryPath            string = `C:\Program Files\Sumo Logic\OpenTelemetry Collector\bin\otelcol-sumo.exe`
+	libPath               string = `C:\ProgramData\Sumo Logic\OpenTelemetry Collector\data`
+	fileStoragePath       string = libPath + `\file_storage`
+	etcPath               string = `C:\ProgramData\Sumo Logic\OpenTelemetry Collector\config`
+	scriptPath            string = "../../scripts/install.ps1"
+	configPath                   = etcPath + `\sumologic.yaml`
+	confDPath                    = etcPath + `\conf.d`
+	opampDPath                   = etcPath + `\opamp.d`
+	userConfigPath               = confDPath + `\common.yaml`
+	hostmetricsConfigPath        = confDPath + `\hostmetrics.yaml`
+
+	installToken    string = "token"
+	installTokenEnv string = "SUMOLOGIC_INSTALLATION_TOKEN"
+	apiBaseURL      string = "https://open-collectors.sumologic.com"
+
+	commonConfigPathFilePermissions uint32 = 0550
+	configPathDirPermissions        uint32 = 0550
+	configPathFilePermissions       uint32 = 0440
+	confDPathFilePermissions        uint32 = 0644
+	etcPathPermissions              uint32 = 0551
+	opampDPermissions               uint32 = 0750
+)

--- a/pkg/scripts_test/install_windows_test.go
+++ b/pkg/scripts_test/install_windows_test.go
@@ -7,7 +7,134 @@ import (
 	"testing"
 )
 
+// TODO: Check file ownership
+// TODO: Set up file permissions to be able to modify config files on Windows
+
 func TestInstallScript(t *testing.T) {
-	// no-op for now to make tests pass
-	t.Skip("not implemented for windows yet")
+	for _, spec := range []testSpec{
+		{
+			name:        "no arguments",
+			options:     installOptions{},
+			preChecks:   []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
+			postChecks:  []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkAbortedDueToNoToken, checkUserNotExists},
+			installCode: 1,
+		},
+		{
+			name: "installation token only",
+			options: installOptions{
+				installToken: installToken,
+			},
+			preChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				// checkConfigFilesOwnershipAndPermissions(rootUser, rootGroup),
+				checkUserConfigCreated,
+				checkEphemeralNotInConfig(userConfigPath),
+				checkTokenInConfig,
+				checkUserNotExists,
+				checkHostmetricsConfigNotCreated,
+			},
+		},
+		{
+			name: "installation token and ephemeral",
+			options: installOptions{
+				installToken: installToken,
+				ephemeral:    true,
+			},
+			preChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				// checkConfigFilesOwnershipAndPermissions(rootUser, rootGroup),
+				checkUserConfigCreated,
+				checkTokenInConfig,
+				checkEphemeralInConfig(userConfigPath),
+				checkUserNotExists,
+				checkHostmetricsConfigNotCreated,
+			},
+		},
+		{
+			name: "installation token and hostmetrics",
+			options: installOptions{
+				installToken:       installToken,
+				installHostmetrics: true,
+			},
+			preChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				// checkConfigFilesOwnershipAndPermissions(rootUser, rootGroup),
+				checkUserConfigCreated,
+				checkTokenInConfig,
+				checkUserNotExists,
+				checkHostmetricsConfigCreated,
+			},
+		},
+		{
+			name: "installation token and remotely-managed",
+			options: installOptions{
+				installToken:    installToken,
+				remotelyManaged: true,
+			},
+			preChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				// checkConfigFilesOwnershipAndPermissions(rootUser, rootGroup),
+				checkRemoteConfigDirectoryCreated,
+				checkTokenInSumoConfig,
+				checkEphemeralNotInConfig(configPath),
+				checkUserNotExists,
+			},
+		},
+		{
+			name: "installation token, remotely-managed, and ephemeral",
+			options: installOptions{
+				installToken:    installToken,
+				remotelyManaged: true,
+				ephemeral:       true,
+			},
+			preChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				// checkConfigFilesOwnershipAndPermissions(rootUser, rootGroup),
+				checkRemoteConfigDirectoryCreated,
+				checkTokenInSumoConfig,
+				checkEphemeralInConfig(configPath),
+				checkUserNotExists,
+			},
+		},
+		{
+			name: "configuration with tags",
+			options: installOptions{
+				installToken: installToken,
+				tags: map[string]string{
+					"lorem":     "ipsum",
+					"foo":       "bar",
+					"escape_me": "'\\/",
+					"slash":     "a/b",
+					"numeric":   "1_024",
+				},
+			},
+			preChecks: []checkFunc{checkBinaryNotCreated, checkConfigNotCreated, checkUserConfigNotCreated, checkUserNotExists},
+			postChecks: []checkFunc{
+				checkBinaryCreated,
+				checkBinaryIsRunning,
+				checkConfigCreated,
+				// checkConfigFilesOwnershipAndPermissions(rootUser, rootGroup),
+				checkTags,
+			},
+		},
+	} {
+		t.Run(spec.name, func(t *testing.T) {
+			runTest(t, &spec)
+		})
+	}
 }


### PR DESCRIPTION
Add some basic Windows install script tests. These basically just check if we end up with the right configuration for a given command line flag set.

The script runner and checks are actually quite similar to unix, and there might be a way to unify them, but that can happen in a followup PR.