### PR TITLE
Upgrade opamp-go to tip

### DIFF
--- a/.changelog/1481.added.txt
+++ b/.changelog/1481.added.txt
@@ -1,0 +1,1 @@
+opampextension: add support for redirection on websocket connect

--- a/pkg/extension/opampextension/go.mod
+++ b/pkg/extension/opampextension/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/knadh/koanf/providers/rawbytes v0.1.0
 	github.com/knadh/koanf/v2 v2.1.0
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/open-telemetry/opamp-go v0.10.0
+	github.com/open-telemetry/opamp-go v0.12.1-0.20240229161006-7e92da0f17ef
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver v0.96.0
@@ -75,7 +75,7 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/gorilla/websocket v1.5.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 // indirect
 	github.com/haimrubinstein/go-syslog/v3 v3.0.0 // indirect
 	github.com/hashicorp/consul/api v1.27.0 // indirect

--- a/pkg/extension/opampextension/go.sum
+++ b/pkg/extension/opampextension/go.sum
@@ -264,8 +264,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
-github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
+github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 h1:Wqo399gCIufwto+VfwCSvsnfGpF/w5E9CNxSwbpD6No=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0/go.mod h1:qmOFXW2epJhM0qSnUUYpldc7gVz2KMQwJ/QYCDIa7XU=
@@ -454,8 +454,8 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.29.0 h1:KIA/t2t5UBzoirT4H9tsML45GEbo3ouUnBHsCfD2tVg=
 github.com/onsi/gomega v1.29.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
-github.com/open-telemetry/opamp-go v0.10.0 h1:3PdhoKcKY1lPrfdXnsxeLlXluE+Xe1Uc/CpJ4I8uUJ0=
-github.com/open-telemetry/opamp-go v0.10.0/go.mod h1:Pfmm5EdWqZCG0dZAJjAinlra3yEpqK5StCblxpbEp6Q=
+github.com/open-telemetry/opamp-go v0.12.1-0.20240229161006-7e92da0f17ef h1:4doR37wy5rKwhSS33cUfCs6AYyguuvL75jRZmCmsQU8=
+github.com/open-telemetry/opamp-go v0.12.1-0.20240229161006-7e92da0f17ef/go.mod h1:bk3WZ4RjbVdzsHT3gaPZscUdGvoz9Bi2+AvG8/5X824=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.96.0 h1:7ZLtvso1fCli8/Bhk2ib0c0/iT4OacRPcx8e6j74ClY=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.96.0/go.mod h1:hcpQL/YtUYT4XF8Q6xzhW0n1GjvT5ewRF3I8uKoxTdI=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil v0.96.0 h1:GI8hvKwMD4YE+CUeDT+v+Fce6lD+ppaq6MQ08mVUGh8=


### PR DESCRIPTION
```
    Upgrade opamp-go to tip
    
    Upgrade to an untagged opamp-go in order to take advantage of the recent
    support for HTTP redirection that has been added.
    
    The project has broken several things since 0.10.x, and this breakage
    has been reflected as minor changes to the opamp extension as well.
    
    opamp-go should be upgraded to a tagged version on a subsequent release.
```