### PR TITLE
fix(ci): allow to amend an existing manifest list

### DIFF
--- a/ci/push_docker_multiplatform_manifest.sh
+++ b/ci/push_docker_multiplatform_manifest.sh
@@ -82,14 +82,14 @@ function push_manifest() {
     echo
     set -x
     # Use docker manifest as docker buildx didn't create "${REPO_URL}:${BUILD_TAG}" correctly. It was containing only linux/amd64 image
-    docker manifest create \
+    docker manifest create --amend \
         "${REPO_URL}:${BUILD_TAG}${BUILD_TYPE_SUFFIX}" \
         "${TAGS_IN_MANIFEST[@]}"
 
     docker manifest push \
         "${REPO_URL}:${BUILD_TAG}${BUILD_TYPE_SUFFIX}"
 
-    docker manifest create \
+    docker manifest create --amend \
         "${REPO_URL}:latest${BUILD_TYPE_SUFFIX}" \
         "${TAGS_IN_MANIFEST[@]}"
 


### PR DESCRIPTION
fix(ci): allow to amend an existing manifest list
ref: https://docs.docker.com/reference/cli/docker/manifest/#manifest-create

due to the first failure of the release build, the 2nd also failed because update of existing manifest is not possible without `--amend`
```
 docker manifest create public.ecr.aws/sumologic/sumologic-otel-collector:0.96.0-sumo-0 public.ecr.aws/sumologic/sumologic-otel-collector:0.96.0-sumo-0-linux-amd64 public.ecr.aws/sumologic/sumologic-otel-collector:0.96.0-sumo-0-linux-arm64
refusing to amend an existing manifest list with no --amend flag
make: *** [Makefile:341: push-container-manifest] Error 1
Error: Process completed with exit code 2.
```
https://github.com/SumoLogic/sumologic-otel-collector/actions/runs/8251637581/job/22570130363