### PR TITLE
ci: fix packaging trigger for release builds

### DIFF
--- a/.github/workflows/workflow-trigger-packaging.yml
+++ b/.github/workflows/workflow-trigger-packaging.yml
@@ -22,9 +22,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Fetch tags
-        run: git fetch --tags origin
+        with:
+          fetch-depth: 0
+          filter: 'tree:0'
 
       - name: Determine version core
         id: version-core


### PR DESCRIPTION
The workflow used to manually fetch all the tags, leading to an error if it was already triggered for a tag. Instead, do a treeless checkout, which should make things faster in general.