### PR TITLE
chore: fix some shellcheck problems

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -104,7 +104,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-20.04
     env:
-      SHELLCHECK_VERSION: 0.8.0
+      SHELLCHECK_VERSION: 0.10.0
     steps:
       - uses: actions/checkout@v4
       - name: install shellcheck

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ markdown-link-check:
 	./ci/markdown_link_check.sh
 
 shellcheck:
-	./ci/shellcheck.sh
+	shellcheck --severity=info ci/*.sh scripts/install.sh
 
 .PHONY: install-pre-commit
 install-pre-commit:

--- a/ci/build-push-multiplatform.sh
+++ b/ci/build-push-multiplatform.sh
@@ -31,7 +31,7 @@ if [[ -z "${REPO_URL}" ]]; then
     exit 1
 fi
 
-if [[ ! -z "${BASE_IMAGE_TAG}" ]]; then
+if [[ -n "${BASE_IMAGE_TAG}" ]]; then
     BASE_IMAGE_TAG="-${BASE_IMAGE_TAG}"
 fi
 

--- a/ci/get_version.sh
+++ b/ci/get_version.sh
@@ -32,7 +32,6 @@ bad_usage() {
     echo "${1}"
     echo
     usage
-    exit 1
 }
 
 parse_params() {
@@ -54,6 +53,7 @@ parse_params() {
 }
 
 parse_version_tag() {
+    # shellcheck disable=SC2153
     version_tag="${VERSION_TAG}"
     if [ -z "${version_tag}" ]; then
         version_tag=$(git tag -l --sort -version:refname | head -n 1)

--- a/ci/push_docker_multiplatform_manifest.sh
+++ b/ci/push_docker_multiplatform_manifest.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 # check for arm support only if we try to build it
-if echo "${PLATFORM}" | grep -q arm && ! docker buildx ls | grep -q arm ; then
+if echo "${PLATFORMS}" | grep -q arm && ! docker buildx ls | grep -q arm ; then
     echo "Your Buildx seems to lack ARM architecture support"
     echo
     docker buildx ls

--- a/ci/shellcheck.sh
+++ b/ci/shellcheck.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-
-find "$SCRIPT_DIR" -type f -name "*.sh" -exec "shellcheck" "-x" {} \;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -537,27 +537,6 @@ get_versions_from() {
     return 0
 }
 
-get_package_versions_from() {
-    local versions
-    readonly versions="${1}"
-
-    local from
-    readonly from="${2}"
-
-    # Return if there is no installed version
-    if [[ "${from}" == "" ]]; then
-        return 0
-    fi
-
-    local line
-    readonly line="$(( $(echo "${versions}" | sed 's/ /\n/g' | grep -n "${from}$" | sed 's/:.*//g') - 1 ))"
-
-    if [[ "${line}" -gt "0" ]]; then
-        echo "${versions}" | sed 's/ /\n/g' | head -n "${line}" | sort
-    fi
-    return 0
-}
-
 # Get OS type (linux or darwin)
 function get_os_type() {
     local os_type
@@ -655,7 +634,8 @@ function print_breaking_changes() {
     readonly versions="${1}"
 
     local changelog
-    readonly changelog="$(echo -e "$(curl --retry 5 --connect-timeout 5 --max-time 30 --retry-delay 0 --retry-max-time 150 -sS https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector/main/CHANGELOG.md)")"
+    changelog="$(echo -e "$(curl --retry 5 --connect-timeout 5 --max-time 30 --retry-delay 0 --retry-max-time 150 -sS https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector/main/CHANGELOG.md)")"
+    declare -r changelog
 
     local is_breaking_change
     local message
@@ -1033,9 +1013,6 @@ function unescape_yaml() {
     local fields
     readonly fields="${1}"
 
-    local unescaped
-    unescaped=""
-
     # Process the string line by line
     echo -e "${fields}" | while IFS= read -r line; do
         # strip `\` from the end of the line
@@ -1159,7 +1136,8 @@ function get_user_tags() {
 function get_fields_to_compare() {
     local fields
     # replace \/ with /
-    readonly fields="$(echo "${FIELDS}" | sed -e 's|\\/|/|')"
+    fields="$(echo "${FIELDS}" | sed -e 's|\\/|/|')"
+    declare -r fields
 
     unescape_yaml "${fields}" \
         | grep -vE '^$' \


### PR DESCRIPTION
* Update shellcheck to the latest 0.10.0
* Run shellcheck on the install script. This was not the case until now, probably by mistake.
* Delete shellcheck.sh and instead explicitly list the files we're checking in the Makefile target.
* Fix some warning and info messages in our scripts.