### PR TITLE
ci: fix packaging trigger for releases

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -380,4 +380,5 @@ jobs:
     uses: ./.github/workflows/workflow-trigger-packaging.yml
     secrets: inherit
     with:
+      workflow_id: ${{ github.run_id }}
       create_release: false

--- a/.github/workflows/workflow-trigger-packaging.yml
+++ b/.github/workflows/workflow-trigger-packaging.yml
@@ -7,6 +7,10 @@ on:
         description: The packaging workflow will create a draft release in the packaging repository.
         required: true
         type: boolean
+      workflow_id:
+        description: ID of the workflow to fetch artifacts from. If empty, artifacts will be fetched from the latest release.
+        type: number
+        required: false
 
 defaults:
   run:
@@ -53,7 +57,7 @@ jobs:
           display-workflow-run-url-interval: 1s
           inputs: |-
             {
-              "workflow_id": "${{ github.run_id }}",
+              "workflow_id": "${{ inputs.workflow_id }}",
               "otc_version": "${{ steps.version-core.outputs.version }}",
               "otc_sumo_version": "${{ steps.sumo-version.outputs.version }}",
               "release": ${{ inputs.create_release }}


### PR DESCRIPTION
Our reusable workflow would unconditionally pass the workflow id as the parameter to the triggered packaging workflow.
This causes the packaging workflow to fetch artifacts from the workflow with that id, which is correct for dev builds, but incorrect for release builds. Fix this by making the workflow id an input.