### PR TITLE
ci: fix trigger packaging workflow

### DIFF
--- a/.github/workflows/workflow-trigger-packaging.yml
+++ b/.github/workflows/workflow-trigger-packaging.yml
@@ -9,7 +9,7 @@ on:
         type: boolean
       workflow_id:
         description: ID of the workflow to fetch artifacts from. If empty, artifacts will be fetched from the latest release.
-        type: number
+        type: string
         required: false
 
 defaults:


### PR DESCRIPTION
Turns out the workflow run id is considered a string by GHA: https://github.com/SumoLogic/sumologic-otel-collector/actions/runs/8635467376