### PR TITLE
fix(build): opampextension replace statement

### DIFF
--- a/.changelog/1539.fixed.txt
+++ b/.changelog/1539.fixed.txt
@@ -1,0 +1,1 @@
+fix(build): opampextension replace statement

--- a/otelcolbuilder/.otelcol-builder.yaml
+++ b/otelcolbuilder/.otelcol-builder.yaml
@@ -237,7 +237,7 @@ replaces:
   # version which gets then translated into a replace in go.mod file.
   # This does not replace the version that sumologicexporter depends on.
   - github.com/SumoLogic/sumologic-otel-collector/pkg/extension/sumologicextension => ../../pkg/extension/sumologicextension
-  - github.com/SumoLogic/sumologic-otel-collector/pkg/extension/opampextension => ../../pkg/configprovider/opampextension
+  - github.com/SumoLogic/sumologic-otel-collector/pkg/extension/opampextension => ../../pkg/extension/opampextension
   - github.com/SumoLogic/sumologic-otel-collector/pkg/configprovider/globprovider => ../../pkg/configprovider/globprovider
   - github.com/SumoLogic/sumologic-otel-collector/pkg/configprovider/opampprovider => ../../pkg/configprovider/opampprovider
 


### PR DESCRIPTION
The replace was pointing to a directory which didn't exist. Somehow, this didn't break the build.