### PR TITLE
ci: trigger packaging for a release after publishing

### DIFF
--- a/.github/workflows/release-packaging.yml
+++ b/.github/workflows/release-packaging.yml
@@ -1,0 +1,13 @@
+name: Trigger packaging for release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  trigger-packaging:
+    name: Trigger Packaging for release ${{ github.event.release.name }}
+    uses: ./.github/workflows/workflow-trigger-packaging.yml
+    secrets: inherit
+    with:
+      create_release: true

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -637,10 +637,3 @@ jobs:
           artifacts: "artifacts/*/*"
           artifactErrorsFailBuild: true
           replacesArtifacts: true
-
-  trigger-packaging:
-    name: Trigger Packaging
-    uses: ./.github/workflows/workflow-trigger-packaging.yml
-    secrets: inherit
-    with:
-      create_release: true


### PR DESCRIPTION
Packaging for releases should only be triggered after the release is published, as otherwise the packaging workflow can't fetch the artifacts.