### PR TITLE
ci: use github cli for triggering package workflow

### DIFF
--- a/.github/workflows/workflow-trigger-packaging.yml
+++ b/.github/workflows/workflow-trigger-packaging.yml
@@ -44,26 +44,24 @@ jobs:
           cat /tmp/sumo_version &&
           echo version=$(cat /tmp/sumo_version) >> $GITHUB_OUTPUT
 
+      # TODO: output the workflow url
       - name: Trigger packaging workflow
         id: trigger-packaging-workflow
-        uses: aurelien-baudet/workflow-dispatch@v2
-        with:
-          workflow: build_packages.yml
-          repo: SumoLogic/sumologic-otel-collector-packaging
-          token: ${{ secrets.PACKAGING_GH_TOKEN }}
-          ref: main
-          wait-for-completion: false
-          display-workflow-run-url: true
-          display-workflow-run-url-interval: 1s
-          inputs: |-
+        env:
+          GITHUB_TOKEN: ${{ secrets.PACKAGING_GH_TOKEN }}
+          REPO: SumoLogic/sumologic-otel-collector-packaging
+          WORKFLOW: build_packages.yml
+        run: |
+          gh workflow run --repo ${REPO} ${WORKFLOW} --json << EOF
             {
               "workflow_id": "${{ inputs.workflow_id }}",
               "otc_version": "${{ steps.version-core.outputs.version }}",
               "otc_sumo_version": "${{ steps.sumo-version.outputs.version }}",
               "release": ${{ inputs.create_release }}
             }
+          EOF
 
       # Outputs the Packaging Workflow URL as an Annotation in the UI after the
       # packaging workflow has completed.
       - name: Packaging Workflow URL
-        run: echo ::notice title=Packaging Workflow URL::${{ steps.trigger-packaging-workflow.outputs.workflow-url }}
+        run: echo ::notice title=Packaging Workflow URL::https://github.com/SumoLogic/sumologic-otel-collector-packaging/actions/workflows/build_packages.yml


### PR DESCRIPTION
The action we've been using is unmaintained. Triggering the workflow using the github cli is quite easy. It's not as easy to get the workflow url, so I changed the url to point to the workflow list for now.