### PR TITLE
ci: fix trigger packaging argument encoding

### DIFF
--- a/.github/workflows/workflow-trigger-packaging.yml
+++ b/.github/workflows/workflow-trigger-packaging.yml
@@ -57,7 +57,7 @@ jobs:
               "workflow_id": "${{ inputs.workflow_id }}",
               "otc_version": "${{ steps.version-core.outputs.version }}",
               "otc_sumo_version": "${{ steps.sumo-version.outputs.version }}",
-              "release": ${{ inputs.create_release }}
+              "release": "${{ inputs.create_release }}"
             }
           EOF
 


### PR DESCRIPTION
github-cli serializes all workflow arguments as strings, so we need to quote all of them.

This fixes failures like the following: https://github.com/SumoLogic/sumologic-otel-collector/actions/runs/8710092270/job/23891784907