### PR TITLE
ci: consolidate change detection logic for builds

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -13,6 +13,25 @@ env:
   GO_VERSION: "1.21.4"
 
 jobs:
+  build-changed:
+    runs-on: ubuntu-22.04
+    outputs:
+      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check if build related files changed
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            **/go.mod
+            **/go.sum
+            **/*.go
+            **/*.yaml
+            **/*.yml
+            **/Makefile
+            **/Makefile.common
+            **/Dockerfile*
 
   markdownlint:
     runs-on: ubuntu-20.04
@@ -196,40 +215,26 @@ jobs:
   lint:
     name: Lint (golangci-lint)
     runs-on: ubuntu-20.04
+    needs: [ build-changed ]
+    if: needs.build-changed.outputs.any_changed == 'true'
     strategy:
       matrix:
         arch_os: [ 'linux_amd64' ]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check if files changed that need linting
-        id: changed-files
-        uses: tj-actions/changed-files@v41
-        with:
-          files: |
-            **/go.mod
-            **/go.sum
-            **/*.go
-            **/*.yaml
-            **/*.yml
-            **/Makefile
-            **/Makefile.common
-
       - name: Setup go
-        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
 
       - name: Get GOCACHE and GOMODCACHE
-        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           echo "GOMODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_ENV"
           echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
 
       - uses: actions/cache/restore@v4
-        if: steps.changed-files.outputs.any_changed == 'true'
         with:
           path: |
             ${{ env.GOMODCACHE }}/cache
@@ -247,15 +252,12 @@ jobs:
             golangci-lint-${{ env.GO_VERSION }}-${{matrix.arch_os}}-
 
       - name: Install golangci-lint
-        if: steps.changed-files.outputs.any_changed == 'true'
         run: make install-golangci-lint
 
       - name: Add opentelemetry-collector-builder installation dir to PATH
-        if: steps.changed-files.outputs.any_changed == 'true'
         run: echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Run golangci-lint
-        if: steps.changed-files.outputs.any_changed == 'true'
         run: make golint
 
   build:
@@ -284,86 +286,69 @@ jobs:
       arch_os: ${{ matrix.arch_os }}
       runs-on: ${{ matrix.runs-on }}
       fips: ${{ matrix.fips == true }}
-      only-if-changed: true
 
   build-and-test-container-images:
     name: Build container
     runs-on: ubuntu-20.04
     needs:
+      - build-changed
       - build
+    if: needs.build-changed.outputs.any_changed == 'true'
     strategy:
       matrix:
         arch_os: [ 'linux_amd64', 'linux_arm64']
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check if build related files changed
-        id: changed-files
-        uses: tj-actions/changed-files@v41
-        with:
-          files: |
-            **/go.mod
-            **/go.sum
-            **/*.go
-            **/*.yaml
-            **/*.yml
-            **/Makefile
-            **/Makefile.common
-            **/Dockerfile*
-
       - name: Set up QEMU
-        if: steps.changed-files.outputs.any_changed == 'true'
         uses: docker/setup-qemu-action@v3.0.0
 
       - name: Set up Buildx
-        if: steps.changed-files.outputs.any_changed == 'true'
         id: buildx
         uses: docker/setup-buildx-action@v3.3.0
 
       - name: Show Buildx platforms
-        if: steps.changed-files.outputs.any_changed == 'true'
         run: echo ${{ steps.buildx.outputs.platforms }}
 
       - name: Download binary action artifact from build phase
-        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/download-artifact@v4
         with:
           name: otelcol-sumo-${{matrix.arch_os}}
           path: artifacts/
 
       - name: Build the container image
-        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           cp artifacts/otelcol-sumo-${{matrix.arch_os}} otelcol-sumo
           make build-container-multiplatform \
             PLATFORM=${{ matrix.arch_os }}
 
       - name: Test built image
-        if: steps.changed-files.outputs.any_changed == 'true'
         run: make test-built-image
 
       - name: Download FIPS binary action artifact from build phase
-        if: steps.changed-files.outputs.any_changed == 'true' && matrix.arch_os == 'linux_amd64'
+        if: matrix.arch_os == 'linux_amd64'
         uses: actions/download-artifact@v4
         with:
           name: otelcol-sumo-fips-${{matrix.arch_os}}
           path: artifacts/
 
       - name: Build the FIPS container image
-        if: steps.changed-files.outputs.any_changed == 'true' && matrix.arch_os == 'linux_amd64'
+        if: matrix.arch_os == 'linux_amd64'
         run: |
           cp artifacts/otelcol-sumo-fips-${{matrix.arch_os}} otelcol-sumo
           make build-container-multiplatform \
             PLATFORM=${{ matrix.arch_os }} BUILD_TYPE_SUFFIX="-fips"
 
       - name: Test built FIPS image
-        if: steps.changed-files.outputs.any_changed == 'true' && matrix.arch_os == 'linux_amd64'
+        if: matrix.arch_os == 'linux_amd64'
         run: make test-built-image BUILD_TAG="latest-fips"
 
   build-windows-container:
     name: Build windows container
     needs:
+      - build-changed
       - build
+    if: needs.build-changed.outputs.any_changed == 'true'
     runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:
@@ -377,36 +362,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check if build related files changed
-        id: changed-files
-        uses: tj-actions/changed-files@v41
-        with:
-          files: |
-            **/go.mod
-            **/go.sum
-            **/*.go
-            **/*.yaml
-            **/*.yml
-            **/Makefile
-            **/Makefile.common
-            **/Dockerfile*
-
       - name: Download binary action artifact from build phase
-        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/download-artifact@v4
         with:
           name: otelcol-sumo-${{matrix.arch_os}}.exe
           path: artifacts/
 
       - name: Build the container image
-        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           cp artifacts/otelcol-sumo-${{matrix.arch_os}}.exe otelcol-sumo.exe
           make build-container-windows \
             PLATFORM=${{ matrix.arch_os }}_${{ matrix.base_image_tag }}
 
       - name: Test built image
-        if: steps.changed-files.outputs.any_changed == 'true'
         run: make test-built-image
 
       # ToDo: build windows FIPS image

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -14,10 +14,6 @@ on:
       runs-on:
         default: ubuntu-20.04
         type: string
-      only-if-changed:
-        description: Run only if relevant files changed.
-        default: false
-        type: boolean
       save-cache:
         description: Save the module and build caches.
         default: false
@@ -40,39 +36,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check if build related files changed
-        id: changed-files
-        uses: tj-actions/changed-files@v41
-        with:
-          files: |
-            **/go.mod
-            **/go.sum
-            **/*.go
-            **/*.yaml
-            **/*.yml
-            **/Makefile
-            **/Makefile.common
-            **/Dockerfile*
-
       - name: Fetch current branch
-        if: steps.changed-files.outputs.any_changed == 'true'
         run: ./ci/fetch_current_branch.sh
 
       - name: Setup go
-        if: |
-          ! (contains(inputs.arch_os, 'windows') && inputs.fips) &&
-          (! inputs.only-if-changed ||
-          steps.changed-files.outputs.any_changed == 'true')
+        if: (! (contains(inputs.arch_os, 'windows') && inputs.fips))
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
 
       - name: Setup go (Microsoft fork) and enable FIPS on Windows
-        if: |
-          (contains(inputs.arch_os, 'windows') && inputs.fips) &&
-          (! inputs.only-if-changed ||
-          steps.changed-files.outputs.any_changed == 'true')
+        if: contains(inputs.arch_os, 'windows') && inputs.fips
         run: |
           curl -Lo go.zip https://aka.ms/golang/release/latest/go${{ env.GO_VERSION }}.windows-amd64.zip &&
           powershell -command "Expand-Archive go.zip D:\\a\\_work\\1\\s" &&
@@ -80,7 +55,6 @@ jobs:
           powershell -command "Set-ItemProperty -Path HKLM:\System\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy -Name Enabled -Value \$true"
 
       - name: Get Go env values
-        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           echo "GOMODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_ENV"
           echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
@@ -90,14 +64,12 @@ jobs:
 
       - name: Get cache key
         id: get-cache-key
-        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           echo "cache-key=go-build-${{ env.GO_VERSION }}${OTELCOL_FIPS_SUFFIX}-${{inputs.arch_os}}-${{ hashFiles('pkg/**/go.sum', 'otelcolbuilder/.otelcol-builder.yaml') }}" >> $GITHUB_OUTPUT
           echo "restore-keys=go-build-${{ env.GO_VERSION }}${OTELCOL_FIPS_SUFFIX}-${{inputs.arch_os}}-" >> $GITHUB_OUTPUT
           echo "toolchain-cache-key=toolchain-${{inputs.arch_os}}-${{ hashFiles('otelcolbuilder/build-fips/config.mak', 'otelcolbuilder/build-fips/Makefile') }}" >> $GITHUB_OUTPUT
 
       - uses: actions/cache/restore@v4
-        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
         with:
           path: |
             ${{ env.GOMODCACHE }}/cache
@@ -107,26 +79,23 @@ jobs:
             ${{ steps.get-cache-key.outputs.restore-keys }}
 
       - name: Set default BUILDER_BIN_PATH
-        if: ${{ (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
         run: echo "BUILDER_BIN_PATH=${HOME}/bin" >> $GITHUB_ENV
 
       - name: Add opentelemetry-collector-builder installation dir to PATH
-        if: ${{ (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
         run: echo "$BUILDER_BIN_PATH" >> $GITHUB_PATH
 
       - name: Install opentelemetry-collector-builder
-        if: ${{ (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
         run: make install-builder
         working-directory: ./otelcolbuilder
 
       - name: Build
-        if: ${{ ! inputs.fips && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
+        if: '! inputs.fips'
         run: make otelcol-sumo-${{inputs.arch_os}}
         working-directory: ./otelcolbuilder
 
       - uses: actions/cache/restore@v4
         id: restore-toolchain-cache
-        if: ${{ inputs.fips && contains(inputs.arch_os, 'linux') && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
+        if: inputs.fips && contains(inputs.arch_os, 'linux')
         with:
           path: |
             /opt/toolchain
@@ -139,7 +108,7 @@ jobs:
         working-directory: ./otelcolbuilder
 
       - name: Build (FIPS)
-        if: ${{ inputs.fips && contains(inputs.arch_os, 'linux') && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
+        if: inputs.fips && contains(inputs.arch_os, 'linux')
         run: |
           CC=$(find /opt/toolchain/bin -type f -name "*-linux-musl-gcc")
           test "$CC"
@@ -152,39 +121,30 @@ jobs:
         working-directory: ./otelcolbuilder
 
       - name: Build (FIPS)
-        if: ${{ inputs.fips && ! contains(inputs.arch_os, 'linux') && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
+        if: inputs.fips && ! contains(inputs.arch_os, 'linux')
         run: make otelcol-sumo-${{inputs.arch_os}} FIPS_SUFFIX="-fips" CGO_ENABLED=1
         working-directory: ./otelcolbuilder
 
       - name: Set binary name
         id: set-binary-name
-        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
         run: echo "binary_name=otelcol-sumo${OTELCOL_FIPS_SUFFIX}-${{inputs.arch_os}}${OTELCOL_BINARY_EXTENSION}" >> $GITHUB_OUTPUT
 
       - name: Show BoringSSL symbols
-        if: |
-          inputs.fips &&
-          contains(inputs.arch_os, 'linux') &&
-          (! inputs.only-if-changed ||
-          steps.changed-files.outputs.any_changed == 'true')
+        if: inputs.fips && contains(inputs.arch_os, 'linux')
         working-directory: ./otelcolbuilder/cmd
         run: |
           go tool nm ${{ steps.set-binary-name.outputs.binary_name }} | \
           grep "_Cfunc__goboringcrypto_"
 
       - name: Show Microsoft Cryptography Next-Generation symbols
-        if: |
-          inputs.fips &&
-          contains(inputs.arch_os, 'windows') &&
-          (! inputs.only-if-changed ||
-          steps.changed-files.outputs.any_changed == 'true')
+        if: inputs.fips && contains(inputs.arch_os, 'windows')
         working-directory: ./otelcolbuilder/cmd
         run: |
           go tool nm ${{ steps.set-binary-name.outputs.binary_name }} | \
           grep "vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt.GetFipsAlgorithmMode"
 
       - name: Test binary
-        if: ${{ (inputs.arch_os == env.ARCH_OS) && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
+        if: inputs.arch_os == env.ARCH_OS
         working-directory: ./otelcolbuilder/cmd
         run: |
           ./${{ steps.set-binary-name.outputs.binary_name }} help
@@ -192,7 +152,6 @@ jobs:
           ./${{ steps.set-binary-name.outputs.binary_name }} completion bash
 
       - name: Store binary as action artifact
-        if: ${{ ! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.set-binary-name.outputs.binary_name }}
@@ -207,7 +166,7 @@ jobs:
           key: ${{ steps.get-cache-key.outputs.toolchain-cache-key }}
 
       - uses: actions/cache/save@v4
-        if: ${{ inputs.save-cache && (! inputs.only-if-changed || steps.changed-files.outputs.any_changed == 'true') }}
+        if: inputs.save-cache
         with:
           path: |
             ${{ env.GOMODCACHE }}/cache


### PR DESCRIPTION
Instead of every job doing its own check for changes to build-relevant files, do the check once and use the result of that check.