### PR TITLE
ci: fix typo in release workflow

### DIFF
--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -367,7 +367,7 @@ jobs:
         run: |
           cp artifacts/${{ steps.set_filename_fips.outputs.filename_fips }} otelcol-sumo
           make build-push-container-multiplatform \
-            BUILD_TAG=v${{ needs.get-version.outputs.version }} \
+            BUILD_TAG=${{ needs.get-version.outputs.version }} \
             PLATFORM=${{ matrix.arch_os }} \
             BUILD_TYPE_SUFFIX="-fips"
 


### PR DESCRIPTION
Minor fix to #1562. There was an unnecessary `v` prefix in a container tag.