### PR TITLE
fix(sourceprocessor): don't ignore empty annotation values

### DIFF
--- a/.changelog/1569.fixed.txt
+++ b/.changelog/1569.fixed.txt
@@ -1,0 +1,1 @@
+fix(sourceprocessor): don't ignore empty annotation values

--- a/pkg/processor/sourceprocessor/source_category_filler_test.go
+++ b/pkg/processor/sourceprocessor/source_category_filler_test.go
@@ -66,6 +66,33 @@ func TestFillWithAnnotations(t *testing.T) {
 	assertAttribute(t, attrs, "_sourceCategory", "ABC#123asd#Prefix:sc#from#annot#ns#1#123asd")
 }
 
+func TestFillWithEmptyAnnotations(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.SourceCategoryPrefix = "prefix"
+
+	attrs := pcommon.NewMap()
+	attrs.PutStr("k8s.namespace.name", "ns-1")
+	attrs.PutStr("k8s.pod.uid", "123asd")
+	attrs.PutStr("k8s.pod.pod_name", "ABC")
+
+	filler := newSourceCategoryFiller(cfg, zap.NewNop())
+
+	// can replace prefix with an empty string
+	attrs.PutStr("k8s.pod.annotation.sumologic.com/sourceCategoryPrefix", "")
+	filler.fill(&attrs)
+	assertAttribute(t, attrs, "_sourceCategory", "ns/1/ABC")
+
+	// can replace dash with an empty string
+	attrs.PutStr("k8s.pod.annotation.sumologic.com/sourceCategoryReplaceDash", "")
+	filler.fill(&attrs)
+	assertAttribute(t, attrs, "_sourceCategory", "ns1/ABC")
+
+	// can replace source category with empty string
+	attrs.PutStr("k8s.pod.annotation.sumologic.com/sourceCategory", "")
+	filler.fill(&attrs)
+	assertAttribute(t, attrs, "_sourceCategory", "")
+}
+
 func TestFillWithNamespaceAnnotations(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 


### PR DESCRIPTION
Annotation values which are empty strings should be treated like any other value, and not ignored as if they didn't exist.