### PR TITLE
fix(windows): Recognize opamp as a config provider

### DIFF
--- a/.changelog/1570.fixed.txt
+++ b/.changelog/1570.fixed.txt
@@ -1,0 +1,1 @@
+fix(windows): Recognize opamp as a config provider

--- a/otelcolbuilder/cmd/collector_windows.go
+++ b/otelcolbuilder/cmd/collector_windows.go
@@ -241,7 +241,7 @@ func updateSettingsUsingFlags(set *otelcol.CollectorSettings, flags *flag.FlagSe
 		// Provide a default set of providers and converters if none have been specified.
 		// TODO: Remove this after CollectorSettings.ConfigProvider is removed and instead
 		// do it in the builder.
-		if len(resolverSet.Providers) == 0 && len(resolverSet.Converters) == 0 {
+		if len(resolverSet.ProviderFactories) == 0 && len(resolverSet.ConverterFactories) == 0 {
 			set.ConfigProviderSettings = newDefaultConfigProviderSettings(resolverSet.URIs)
 		}
 	}


### PR DESCRIPTION
Bring upstream changes to the windows service
Related issue: https://github.com/open-telemetry/opentelemetry-collector/pull/9516