### PR TITLE
fix(ci): modify getting sumo version to return version with sumo channel

### DIFF
--- a/ci/get_version.sh
+++ b/ci/get_version.sh
@@ -3,7 +3,7 @@
 declare -i major_version
 declare -i minor_version
 declare -i patch_version
-declare -i build_version
+declare build_version
 declare ot_channel
 declare -i ot_channel_version
 declare sumo_channel
@@ -76,7 +76,7 @@ parse_version_tag() {
 
     if [[ $ot_channel == "sumo" ]]; then
         if [[ $sumo_channel != "" ]]; then
-            build_version="${sumo_channel_version}"
+            build_version="${ot_channel_version}-${sumo_channel}.${sumo_channel_version}"
         else
             build_version="${ot_channel_version}"
         fi
@@ -90,7 +90,6 @@ parse_version_tag() {
             echo "Error: OVERRIDE_BUILD_VERSION is not a number" >&2
             exit 1
         fi
-
         build_version="${OVERRIDE_BUILD_VERSION}"
     fi
 }
@@ -149,12 +148,12 @@ validate() {
         exit 1
     fi
 
-    if [[ $build_version -lt 0 ]]; then
+    if [[ $ot_channel_version -lt 0 ]]; then
         echo "Build version cannot be less than 0"
         exit 1
     fi
 
-    if [[ $build_version -gt 65535 ]]; then
+    if [[ $ot_channel_version -gt 65535 ]]; then
         echo "Build version cannot be greater than 65,535"
         exit 1
     fi


### PR DESCRIPTION
This is required to trigger packaging for release candidates, please see below that sumo version was set to `0` but the sumo version was `0-rc.0`


<img width="1265" alt="Screenshot 2024-05-06 at 15 48 19" src="https://github.com/SumoLogic/sumologic-otel-collector/assets/73836361/f642d57f-046d-4312-9163-171193059e24">

https://github.com/SumoLogic/sumologic-otel-collector/actions/runs/8846781071/job/24293335494

with the fix in this pull request the output will be following:

```
% export VERSION_TAG=v3.99.4-sumo-5-rc.6
% ./get_version.sh sumo                
5-rc.6
% export VERSION_TAG=v3.99.4-sumo-5     
% ./get_version.sh sumo      
5            
```

packaging repository is now prepared for release candidates, please see pull request: https://github.com/SumoLogic/sumologic-otel-collector-packaging/pull/81

