### PR TITLE
fix(ci): set build version in Windows ProductVersion to ot_channel_version

### DIFF
--- a/ci/get_version.sh
+++ b/ci/get_version.sh
@@ -174,7 +174,7 @@ sumo_version() {
 # https://learn.microsoft.com/en-us/windows/win32/msi/productversion
 # MAJOR.MINOR.PATCH.BUILD -> MAJOR.MINOR.BUILD.INTERNAL
 windows_product_version() {
-    echo "${major_version}.${minor_version}.${patch_version}.${build_version}"
+    echo "${major_version}.${minor_version}.${patch_version}.${ot_channel_version}"
 }
 
 parse_params "$@"


### PR DESCRIPTION
related CI failure: https://github.com/SumoLogic/sumologic-otel-collector/actions/runs/8970924338/job/24636297516
doc: https://learn.microsoft.com/en-us/windows/win32/msi/productversion

so the output for will be following:
```
% export VERSION_TAG=v3.99.4-sumo-5-rc.6
% ./get_version.sh productversion                                                               
3.99.4.5
% export VERSION_TAG=v3.99.4-sumo-5     
% ./get_version.sh productversion  
3.99.4.5
```
so as it was before - no difference in Windows ProductVersion for release candidate and regular release