### PR TITLE
ci: fix rc version handling

### DIFF
--- a/ci/get_version.sh
+++ b/ci/get_version.sh
@@ -57,7 +57,7 @@ parse_version_tag() {
     # shellcheck disable=SC2153
     version_tag="${VERSION_TAG}"
     if [ -z "${version_tag}" ]; then
-        version_tag=$(git tag -l --sort -version:refname | head -n 1)
+        version_tag=$(git describe --tags --abbrev=0 --match "v[0-9]*" | head -n 1)
     fi
 
     version_regex="^v([0-9]+).([0-9]+).([0-9]+)((-(alpha|beta|rc|sumo)[-.]([0-9]+))(-(alpha|beta|rc).([0-9])+)?)?$"


### PR DESCRIPTION
The get_versions.sh script used to determine the version to use for packaging, was prioritizing rc versions over stable ones. Fixed this so it always returns the most recent stable version.