### PR TITLE
Add --set-opamp-endpoint to otelcol-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ go.work*
 # udpdemux binary
 pkg/tools/udpdemux/udpdemux
 
+# otelcol-config binary
+pkg/tools/otelcol-config/otelcol-config
+
 # temporary files
 /tmp
 

--- a/pkg/tools/otelcol-config/flag_actions.go
+++ b/pkg/tools/otelcol-config/flag_actions.go
@@ -25,7 +25,7 @@ var flagActions = map[string]action{
 	flagSetAPIURL:            notImplementedAction,
 	flagEnableRemoteControl:  EnableRemoteControlAction,
 	flagDisableRemoteControl: DisableRemoteControlAction,
-	flagSetOpAmpEndpoint:     notImplementedAction,
+	flagSetOpAmpEndpoint:     SetOpAmpEndpointAction,
 	flagWriteKV:              WriteKVAction,
 	flagReadKV:               ReadKVAction,
 	flagOverride:             nullAction,

--- a/pkg/tools/otelcol-config/opamp.go
+++ b/pkg/tools/otelcol-config/opamp.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/mikefarah/yq/v4/pkg/yqlib"
+)
+
+var errRemoteControlNotEnabled = errors.New("remote control not enabled")
+
+func SetOpAmpEndpointAction(ctx *actionContext) error {
+	endpoint := ctx.Flags.SetOpAmpEndpoint
+	if err := validateEndpoint(endpoint); err != nil {
+		return err
+	}
+	conf, err := ReadConfigDir(ctx.ConfigDir)
+	if err != nil {
+		return err
+	}
+
+	writer := ctx.WriteSumologicRemote
+	doc := conf.SumologicRemote
+
+	if len(doc) == 0 {
+		return fmt.Errorf("cannot set opamp endpoint: %s", errRemoteControlNotEnabled)
+	}
+
+	encoder := yqlib.YamlFormat.EncoderFactory()
+	decoder := yqlib.YamlFormat.DecoderFactory()
+	eval := yqlib.NewStringEvaluator()
+
+	expression := fmt.Sprintf(".extensions.opamp.endpoint = %q", endpoint)
+	result, err := eval.EvaluateAll(expression, string(doc), encoder, decoder)
+	if err != nil {
+		return fmt.Errorf("couldn't write installation token: %s", err)
+	}
+	doc = []byte(result)
+
+	_, err = writer(doc)
+	if err != nil {
+		return fmt.Errorf("couldn't write opamp endpoint: %s", err)
+	}
+
+	return nil
+}
+
+func validateEndpoint(endpoint string) error {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("invalid endpoint: %s", err)
+	}
+	if u.Scheme != "ws" && u.Scheme != "wss" {
+		return fmt.Errorf("invalid endpoint: invalid URL scheme %q: want [ws, wss]", u.Scheme)
+	}
+	return nil
+}

--- a/pkg/tools/otelcol-config/opamp.go
+++ b/pkg/tools/otelcol-config/opamp.go
@@ -34,7 +34,7 @@ func SetOpAmpEndpointAction(ctx *actionContext) error {
 	expression := fmt.Sprintf(".extensions.opamp.endpoint = %q", endpoint)
 	result, err := eval.EvaluateAll(expression, string(doc), encoder, decoder)
 	if err != nil {
-		return fmt.Errorf("couldn't write installation token: %s", err)
+		return fmt.Errorf("couldn't set opamp endpoint: %s", err)
 	}
 	doc = []byte(result)
 

--- a/pkg/tools/otelcol-config/opamp_test.go
+++ b/pkg/tools/otelcol-config/opamp_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"io"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+)
+
+func TestSetOpAmpEndpointAction(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Flags    []string
+		Conf     fs.FS
+		ExpWrite []byte
+		ExpErr   bool
+	}{
+		{
+			Name:   "no sumologic-remote.yaml",
+			Flags:  []string{"--set-opamp-endpoint", "wss://example.com"},
+			Conf:   fstest.MapFS{},
+			ExpErr: true,
+		},
+		{
+			Name:  "success",
+			Flags: []string{"--set-opamp-endpoint", "wss://example.com"},
+			Conf: fstest.MapFS{
+				SumologicRemoteDotYaml: &fstest.MapFile{
+					Data: []byte("extensions:\n  opamp:\n    enabled: true\n    endpoint: wss://example.com/wrong\n"),
+				},
+			},
+			ExpWrite: []byte("extensions:\n  opamp:\n    enabled: true\n    endpoint: wss://example.com\n"),
+		},
+		{
+			Name:   "invalid URL",
+			Flags:  []string{"--set-opamp-endpoint", "https://example.com"},
+			Conf:   fstest.MapFS{},
+			ExpErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			flagValues := newFlagValues()
+			fs := makeFlagSet(flagValues)
+
+			if err := fs.Parse(test.Flags); err != nil {
+				t.Fatal(err)
+			}
+			ctx := &actionContext{
+				ConfigDir:            test.Conf,
+				Flags:                flagValues,
+				Stdout:               io.Discard,
+				Stderr:               io.Discard,
+				WriteConfD:           errWriter{}.Write,
+				WriteConfDOverrides:  errWriter{}.Write,
+				WriteSumologicRemote: newTestWriter(test.ExpWrite).Write,
+			}
+
+			err := SetOpAmpEndpointAction(ctx)
+			if err != nil && !test.ExpErr {
+				t.Fatal(err)
+			}
+			if err == nil && test.ExpErr {
+				t.Fatal("expected non-nil error")
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
This commit adds the set-opamp-endpoint action to otelcol-config. The set-opamp-endpoint action sets the OpAmp endpoint in sumologic-remote.yaml. If sumologic-remote.yaml does not exist, then an error is printed. The action also validates that the URL being set has a valid websocket scheme.