### PR TITLE
Add --delete-tag to otelcol-config

### DIFF
--- a/pkg/tools/otelcol-config/delete_tag.go
+++ b/pkg/tools/otelcol-config/delete_tag.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/mikefarah/yq/v4/pkg/yqlib"
+)
+
+// DeleteTagAction deletes a collector tag from conf.d.
+// If the --override flag is present, it will delete the tag from both the
+// overrides file and the settings file. If the --override flag is present and
+// the tag exists in a user-controlled file, an error will be returned.
+func DeleteTagAction(ctx *actionContext) error {
+	conf, err := ReadConfigDir(ctx.ConfigDir)
+	if err != nil {
+		return err
+	}
+
+	if conf.SumologicRemote != nil {
+		return errors.New("delete-tag not supported for remote-controlled collectors")
+	}
+
+	if ctx.Flags.Override {
+		return deleteTagOverride(ctx, conf)
+	} else {
+		return deleteTag(ctx, conf, ConfDSettings, ctx.WriteConfD)
+	}
+}
+
+func deleteTagOverride(ctx *actionContext, conf ConfDir) error {
+	readOrder := sort.StringSlice{}
+	for key := range conf.ConfD {
+		readOrder = append(readOrder, key)
+	}
+	sort.Sort(sort.Reverse(readOrder))
+
+	// Check if there are matching tags in user-controlled files. If there are,
+	// refuse to continue on the grounds that we don't support edits to user
+	// created files.
+	eval := yqlib.NewStringEvaluator()
+	encoder := yqlib.YamlFormat.EncoderFactory()
+	decoder := yqlib.YamlFormat.DecoderFactory()
+	for _, tagName := range ctx.Flags.DeleteTags {
+		key := fmt.Sprintf(".extensions.sumologic.collector_fields.%s", tagName)
+		for _, confKey := range readOrder {
+			doc := string(conf.ConfD[confKey])
+			result, err := eval.Evaluate(key, doc, encoder, decoder)
+			if err != nil {
+				return fmt.Errorf("error evaluating yq expression: %s", err)
+			}
+			if len(result) > 0 && result != nullResult {
+				if confKey != ConfDSettings && confKey != ConfDOverrides {
+					return fmt.Errorf("can't delete tag %s: user setting in %s cannot be overridden", tagName, confKey)
+				}
+			}
+		}
+	}
+
+	if err := deleteTag(ctx, conf, ConfDOverrides, ctx.WriteConfDOverrides); err != nil {
+		return err
+	}
+
+	return deleteTag(ctx, conf, ConfDSettings, ctx.WriteConfD)
+}
+
+func deleteTag(ctx *actionContext, conf ConfDir, docName string, writeDoc func([]byte) (int, error)) error {
+	encoder := yqlib.YamlFormat.EncoderFactory()
+	decoder := yqlib.YamlFormat.DecoderFactory()
+	eval := yqlib.NewStringEvaluator()
+	doc := conf.ConfD[docName]
+
+	if len(doc) == 0 {
+		// tag does not exist, nor any other config for that matter
+		return nil
+	}
+
+	const keyFmt = "del(.extensions.sumologic.collector_fields.%s)"
+
+	for _, tagName := range ctx.Flags.DeleteTags {
+		expression := fmt.Sprintf(keyFmt, tagName)
+
+		result, err := eval.EvaluateAll(expression, string(doc), encoder, decoder)
+		if err != nil {
+			return fmt.Errorf("can't delete tag %s: %s", tagName, err)
+		}
+
+		doc = []byte(result)
+	}
+
+	if _, err := writeDoc(doc); err != nil {
+		return fmt.Errorf("error writing %s: %s", docName, err)
+	}
+
+	return nil
+}

--- a/pkg/tools/otelcol-config/delete_tag_test.go
+++ b/pkg/tools/otelcol-config/delete_tag_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"io/fs"
+	"path"
+	"testing"
+	"testing/fstest"
+)
+
+func TestDeleteTagAction(t *testing.T) {
+	tests := []struct {
+		Name                   string
+		Conf                   fs.FS
+		Flags                  []string
+		ExpConfDWrite          []byte
+		ExpConfDOverridesWrite []byte
+		ExpErr                 bool
+	}{
+		{
+			Name:  "doc missing",
+			Conf:  fstest.MapFS{},
+			Flags: []string{"--delete-tag", "foo"},
+		},
+		{
+			Name: "doc missing, overrides present",
+			Conf: fstest.MapFS{
+				path.Join(ConfDotD, ConfDOverrides): &fstest.MapFile{
+					Data: []byte("extensions:\n  sumologic:\n    collector_fields:\n      foo: bar\n"),
+				},
+			},
+			Flags: []string{"--delete-tag", "foo"},
+		},
+		{
+			Name: "tag deleted",
+			Conf: fstest.MapFS{
+				path.Join(ConfDotD, ConfDSettings): &fstest.MapFile{
+					Data: []byte("extensions:\n  sumologic:\n    collector_fields:\n      foo: bar\n      bar: baz\n"),
+				},
+			},
+			Flags:         []string{"--delete-tag", "foo"},
+			ExpConfDWrite: []byte("extensions:\n  sumologic:\n    collector_fields:\n      bar: baz\n"),
+		},
+		{
+			Name: "delete override",
+			Conf: fstest.MapFS{
+				path.Join(ConfDotD, ConfDOverrides): &fstest.MapFile{
+					Data: []byte("extensions:\n  sumologic:\n    collector_fields:\n      foo: bar\n      bar: baz\n"),
+				},
+			},
+			Flags:                  []string{"--override", "--delete-tag", "foo"},
+			ExpConfDOverridesWrite: []byte("extensions:\n  sumologic:\n    collector_fields:\n      bar: baz\n"),
+		},
+		{
+			Name: "delete settings with override",
+			Conf: fstest.MapFS{
+				path.Join(ConfDotD, ConfDSettings): &fstest.MapFile{
+					Data: []byte("extensions:\n  sumologic:\n    collector_fields:\n      foo: bar\n      bar: baz\n"),
+				},
+			},
+			Flags:         []string{"--override", "--delete-tag", "foo"},
+			ExpConfDWrite: []byte("extensions:\n  sumologic:\n    collector_fields:\n      bar: baz\n"),
+		},
+		{
+			Name: "delete both settings and overrides",
+			Conf: fstest.MapFS{
+				path.Join(ConfDotD, ConfDSettings): &fstest.MapFile{
+					Data: []byte("extensions:\n  sumologic:\n    collector_fields:\n      foo: bar\n      bar: baz\n"),
+				},
+				path.Join(ConfDotD, ConfDOverrides): &fstest.MapFile{
+					Data: []byte("extensions:\n  sumologic:\n    collector_fields:\n      foo: bar\n      bar: baz\n"),
+				},
+			},
+			Flags:                  []string{"--override", "--delete-tag", "foo"},
+			ExpConfDWrite:          []byte("extensions:\n  sumologic:\n    collector_fields:\n      bar: baz\n"),
+			ExpConfDOverridesWrite: []byte("extensions:\n  sumologic:\n    collector_fields:\n      bar: baz\n"),
+		},
+		{
+			Name: "error when key exists in a user-controlled file and override is used",
+			Conf: fstest.MapFS{
+				path.Join(ConfDotD, ConfDSettings): &fstest.MapFile{
+					Data: []byte("extensions:\n  sumologic:\n    collector_fields:\n      foo: bar\n      bar: baz\n"),
+				},
+				path.Join(ConfDotD, "user-settings.yaml"): &fstest.MapFile{
+					Data: []byte("extensions:\n  sumologic:\n    collector_fields:\n      foo: bar\n      bar: baz\n"),
+				},
+			},
+			Flags:  []string{"--override", "--delete-tag", "foo"},
+			ExpErr: true,
+		},
+		{
+			Name: "no error when key exists in a user-controlled file and override is not used",
+			Conf: fstest.MapFS{
+				path.Join(ConfDotD, ConfDSettings): &fstest.MapFile{
+					Data: []byte("extensions:\n  sumologic:\n    collector_fields:\n      foo: bar\n      bar: baz\n"),
+				},
+				path.Join(ConfDotD, "user-settings.yaml"): &fstest.MapFile{
+					Data: []byte("extensions:\n  sumologic:\n    collector_fields:\n      foo: bar\n      bar: baz\n"),
+				},
+			},
+			Flags:         []string{"--delete-tag", "foo"},
+			ExpConfDWrite: []byte("extensions:\n  sumologic:\n    collector_fields:\n      bar: baz\n"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			var settingsWriter, overridesWriter func([]byte) (int, error)
+
+			if test.ExpConfDWrite != nil {
+				settingsWriter = newTestWriter(test.ExpConfDWrite).Write
+			} else {
+				settingsWriter = errWriter{}.Write
+			}
+
+			if test.ExpConfDOverridesWrite != nil {
+				overridesWriter = newTestWriter(test.ExpConfDOverridesWrite).Write
+			} else {
+				overridesWriter = errWriter{}.Write
+			}
+
+			stdoutBuf := new(bytes.Buffer)
+			stderrBuf := new(bytes.Buffer)
+
+			actionContext := makeTestActionContext(t,
+				test.Conf,
+				test.Flags,
+				stdoutBuf,
+				stderrBuf,
+				settingsWriter,
+				overridesWriter,
+			)
+
+			err := DeleteTagAction(actionContext)
+			if test.ExpErr && err == nil {
+				t.Fatal("expected non-nil error")
+			}
+			if !test.ExpErr && err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/pkg/tools/otelcol-config/flag_actions.go
+++ b/pkg/tools/otelcol-config/flag_actions.go
@@ -16,7 +16,7 @@ var flagActions = map[string]action{
 	flagHelp:                 helpAction,
 	flagConfigDir:            nullAction,
 	flagAddTag:               AddTagAction,
-	flagDeleteTag:            notImplementedAction,
+	flagDeleteTag:            DeleteTagAction,
 	flagSetInstallationToken: SetInstallationTokenAction,
 	flagEnableHostmetrics:    notImplementedAction,
 	flagDisableHostmetrics:   notImplementedAction,


### PR DESCRIPTION
This commit adds the delete-tag action to otelcol-config.

The delete-tag action deletes a key out of the collector_fields object in conf.d settings. If the --override flag is provided, then the action deletes the tag out of conf.d overrides.

If a user has manually added a tag to conf.d, and tries to delete it with this tool in override mode, then an error will be returned, and otelcol-config will refuse to proceed.