### PR TITLE
fix(opamp): Add the Default provider to the provider list in ConfigProviderSettings

### DIFF
--- a/.changelog/1632.fixed.txt
+++ b/.changelog/1632.fixed.txt
@@ -1,0 +1,1 @@
+fix(opamp): Add the Default(env) provider to the provider list in ConfigProviderSettings

--- a/otelcolbuilder/cmd/configprovider.go
+++ b/otelcolbuilder/cmd/configprovider.go
@@ -23,6 +23,7 @@ import (
 
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/converter/expandconverter"
+	"go.opentelemetry.io/collector/confmap/provider/envprovider"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/otelcol"
 
@@ -83,7 +84,7 @@ func NewOpAmpConfigProviderSettings(location string) otelcol.ConfigProviderSetti
 	return otelcol.ConfigProviderSettings{
 		ResolverSettings: confmap.ResolverSettings{
 			URIs:               []string{location},
-			ProviderFactories:  []confmap.ProviderFactory{opampprovider.NewFactory()},
+			ProviderFactories:  []confmap.ProviderFactory{opampprovider.NewFactory(), envprovider.NewFactory()},
 			ConverterFactories: []confmap.ConverterFactory{expandconverter.NewFactory()},
 		},
 	}


### PR DESCRIPTION
Add the Default provider to the provider list in ConfigProviderSettings. When the Scheme for a config URI isn't specified, the DefaultScheme is set to the env, therefore this provider now needs to be included in the provider list.

Related to this upstream breaking change - https://github.com/open-telemetry/opentelemetry-collector/pull/10435