### PR TITLE
Add support for setting base API URL to otelcol-config

### DIFF
--- a/pkg/tools/otelcol-config/api_url.go
+++ b/pkg/tools/otelcol-config/api_url.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/mikefarah/yq/v4/pkg/yqlib"
+	"gopkg.in/yaml.v3"
+)
+
+func SetAPIURLAction(ctx *actionContext) error {
+	u, err := url.Parse(ctx.Flags.SetAPIURL)
+	if err != nil {
+		return fmt.Errorf("couldn't set api base url: invalid url: %s", err)
+	}
+
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return errors.New("couldn't set api base url: url must have http or https scheme")
+	}
+
+	conf, err := ReadConfigDir(ctx.ConfigDir)
+	if err != nil {
+		return err
+	}
+
+	var writer func([]byte) (int, error)
+	var doc []byte
+
+	switch {
+	case conf.SumologicRemote != nil || ctx.Flags.EnableRemoteControl:
+		writer = ctx.WriteSumologicRemote
+		doc = conf.SumologicRemote
+	case ctx.Flags.Override:
+		writer = ctx.WriteConfDOverrides
+		doc = conf.ConfD[ConfDOverrides]
+	default:
+		writer = ctx.WriteConfD
+		doc = conf.ConfD[ConfDSettings]
+	}
+
+	encoder := yqlib.YamlFormat.EncoderFactory()
+	decoder := yqlib.YamlFormat.DecoderFactory()
+	eval := yqlib.NewStringEvaluator()
+
+	if len(doc) == 0 {
+		buf := new(bytes.Buffer)
+		enc := yaml.NewEncoder(buf)
+		enc.SetIndent(2)
+		settings := map[string]any{
+			"extensions": map[string]any{
+				"sumologic": map[string]any{
+					"api_base_url": ctx.Flags.SetAPIURL,
+				},
+			},
+		}
+		if err := enc.Encode(settings); err != nil {
+			// shouldn't ever happen
+			panic(err)
+		}
+		doc = buf.Bytes()
+	} else {
+		expression := fmt.Sprintf(".extensions.sumologic.api_base_url = %q", ctx.Flags.SetAPIURL)
+		result, err := eval.EvaluateAll(expression, string(doc), encoder, decoder)
+		if err != nil {
+			return fmt.Errorf("couldn't write api base url: %s", err)
+		}
+		doc = []byte(result)
+	}
+
+	_, err = writer(doc)
+	if err != nil {
+		return fmt.Errorf("couldn't write api base url: %s", err)
+	}
+
+	return nil
+}

--- a/pkg/tools/otelcol-config/api_url_test.go
+++ b/pkg/tools/otelcol-config/api_url_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"io"
+	"io/fs"
+	"path"
+	"testing"
+	"testing/fstest"
+)
+
+func TestSetSetAPIURLAction(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Flags    []string
+		Conf     fs.FS
+		ExpWrite []byte
+		ExpErr   bool
+	}{
+		{
+			Name:     "no existing settings",
+			Flags:    []string{"--set-api-url", "http://example.com"},
+			Conf:     fstest.MapFS{},
+			ExpWrite: []byte("extensions:\n  sumologic:\n    api_base_url: http://example.com\n"),
+		},
+		{
+			Name:  "existing settings",
+			Flags: []string{"--set-api-url", "https://example.com"},
+			Conf: fstest.MapFS{
+				path.Join(ConfDotD, ConfDSettings): &fstest.MapFile{
+					Data: []byte("extensions:\n  sumologic:\n    api_base_url: https://example.com\n    foo: bar\n"),
+				},
+			},
+			ExpWrite: []byte("extensions:\n  sumologic:\n    api_base_url: https://example.com\n    foo: bar\n"),
+		},
+		{
+			Name:     "no existing settings, override",
+			Flags:    []string{"--set-api-url", "http://example.com", "--override"},
+			Conf:     fstest.MapFS{},
+			ExpWrite: []byte("extensions:\n  sumologic:\n    api_base_url: http://example.com\n"),
+		},
+		{
+			Name:  "existing settings, override",
+			Flags: []string{"--set-api-url", "http://example.com", "--override"},
+			Conf: fstest.MapFS{
+				path.Join(ConfDotD, ConfDOverrides): &fstest.MapFile{
+					Data: []byte("extensions:\n  sumologic:\n    api_base_url: http://example.com\n    foo: bar\n"),
+				},
+			},
+			ExpWrite: []byte("extensions:\n  sumologic:\n    api_base_url: http://example.com\n    foo: bar\n"),
+		},
+		{
+			Name:  "remote control with existing file",
+			Flags: []string{"--set-api-url", "http://example.com"},
+			Conf: fstest.MapFS{
+				SumologicRemoteDotYaml: &fstest.MapFile{
+					Data: []byte("extensions:\n  opamp:\n    enabled: true\n"),
+				},
+			},
+			ExpWrite: []byte("extensions:\n  opamp:\n    enabled: true\n  sumologic:\n    api_base_url: http://example.com\n"),
+		},
+		{
+			Name:     "remote control with no existing file, but flag exists",
+			Flags:    []string{"--set-api-url", "http://example.com", "--enable-remote-control"},
+			Conf:     fstest.MapFS{},
+			ExpWrite: []byte("extensions:\n  sumologic:\n    api_base_url: http://example.com\n"),
+		},
+		{
+			Name:   "invalid URL scheme",
+			Flags:  []string{"--set-api-url", "ws://example.com"},
+			Conf:   fstest.MapFS{},
+			ExpErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			writer := newTestWriter(test.ExpWrite).Write
+			errWriter := errWriter{}.Write
+
+			flagValues := newFlagValues()
+			fs := makeFlagSet(flagValues)
+
+			if err := fs.Parse(test.Flags); err != nil {
+				t.Fatal(err)
+			}
+
+			var settingsWriter, overridesWriter, sumologicRemoteWriter func([]byte) (int, error)
+
+			if flagValues.Override {
+				settingsWriter = errWriter
+				sumologicRemoteWriter = errWriter
+				overridesWriter = writer
+			} else if flagValues.EnableRemoteControl || remoteControlEnabled(t, test.Conf) {
+				settingsWriter = errWriter
+				overridesWriter = errWriter
+				sumologicRemoteWriter = writer
+			} else {
+				overridesWriter = errWriter
+				sumologicRemoteWriter = errWriter
+				settingsWriter = writer
+			}
+
+			ctx := &actionContext{
+				ConfigDir:            test.Conf,
+				Flags:                flagValues,
+				Stdout:               io.Discard,
+				Stderr:               io.Discard,
+				WriteConfD:           settingsWriter,
+				WriteConfDOverrides:  overridesWriter,
+				WriteSumologicRemote: sumologicRemoteWriter,
+			}
+
+			err := SetAPIURLAction(ctx)
+
+			if err != nil && !test.ExpErr {
+				t.Fatal(err)
+			}
+			if err == nil && test.ExpErr {
+				t.Fatal("expected non-nil error")
+			}
+
+		})
+	}
+}

--- a/pkg/tools/otelcol-config/flag.go
+++ b/pkg/tools/otelcol-config/flag.go
@@ -40,6 +40,7 @@ const (
 	writeKVUsage              = `write key-value in conf.d with yq expression (eg: --write-kv '.extensions.sumologic.foo = "bar"')`
 	getKVUsage                = "read key-value from conf.d with yq path (eg: --read-kv .extensions.sumologic.foo)"
 	overrideUsage             = "for write-kv, override all other user settings"
+	setAPIURLUsage            = "sets the base_api_url field in the sumologic extension"
 )
 
 type flagValues struct {
@@ -58,6 +59,7 @@ type flagValues struct {
 	WriteKV              []string
 	ReadKV               []string
 	Override             bool
+	SetAPIURL            string
 }
 
 func newFlagValues() *flagValues {
@@ -83,6 +85,7 @@ func makeFlagSet(fv *flagValues) *pflag.FlagSet {
 	flags.StringArrayVar(&fv.WriteKV, flagWriteKV, nil, writeKVUsage)
 	flags.StringArrayVar(&fv.ReadKV, flagReadKV, nil, getKVUsage)
 	flags.BoolVar(&fv.Override, flagOverride, false, overrideUsage)
+	flags.StringVar(&fv.SetAPIURL, flagSetAPIURL, "", setAPIURLUsage)
 
 	return flags
 }

--- a/pkg/tools/otelcol-config/flag_actions.go
+++ b/pkg/tools/otelcol-config/flag_actions.go
@@ -22,7 +22,7 @@ var flagActions = map[string]action{
 	flagDisableHostmetrics:   DisableHostmetricsAction,
 	flagEnableEphemeral:      EnableEphemeralAction,
 	flagDisableEphemeral:     DisableEphemeralAction,
-	flagSetAPIURL:            notImplementedAction,
+	flagSetAPIURL:            SetAPIURLAction,
 	flagEnableRemoteControl:  EnableRemoteControlAction,
 	flagDisableRemoteControl: DisableRemoteControlAction,
 	flagSetOpAmpEndpoint:     SetOpAmpEndpointAction,
@@ -35,7 +35,9 @@ func nullAction(*actionContext) error {
 	return nil
 }
 
-// actionOrder specifies the order in which actions will be applied
+// actionOrder specifies the order in which actions will be applied.
+// This order has been chosen specifically so that actions do not conflict
+// with one another. Use care when adding to this list or reordering it.
 var actionOrder = []string{
 	flagHelp,
 	flagConfigDir,


### PR DESCRIPTION
This commit adds support for the --set-api-url action. It works similarly to the --set-installation-token action.