### PR TITLE
fix(install): Fix script to always install the latest stable version

### DIFF
--- a/.changelog/1645.fixed.txt
+++ b/.changelog/1645.fixed.txt
@@ -1,0 +1,1 @@
+fix(install): Fix script to always install the latest stable version

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -447,7 +447,9 @@ function get_latest_version() {
 
     # get latest version directly from website if there is no versions from api
     if [[ -z "${versions}" ]]; then
-        curl --retry 5 --connect-timeout 5 --max-time 30 --retry-delay 0 --retry-max-time 150 -s https://github.com/SumoLogic/sumologic-otel-collector/releases | grep -oE '/SumoLogic/sumologic-otel-collector/releases/tag/(.*)"' | head -n 1 | sed 's%/SumoLogic/sumologic-otel-collector/releases/tag/v\([^"]*\)".*%\1%g'
+        curl --retry 5 --connect-timeout 5 --max-time 30 --retry-delay 5 --retry-max-time 150 -s https://github.com/SumoLogic/sumologic-otel-collector/releases \
+        | grep -Eo '/SumoLogic/sumologic-otel-collector/releases/tag/v[0-9]+\.[0-9]+\.[0-9]+-sumo-[0-9]+[^-]' \
+        | head -n 1 | sed 's%/SumoLogic/sumologic-otel-collector/releases/tag/v\([^"]*\)".*%\1%g'
     else
         # sed 's/ /\n/g' converts spaces to new lines
         echo "${versions}" | sed 's/ /\n/g' | head -n 1
@@ -459,7 +461,7 @@ function get_latest_version() {
 # sort it from last to first
 # remove v from beginning of version
 function get_versions() {
-    # returns empty in case we exceeded github rate limit
+    # returns empty in case we exceeded github rate limit. This can happen if we are running this script too many times in a short period.
     if [[ "$(github_rate_limit)" == "0" ]]; then
         return
     fi


### PR DESCRIPTION
There's an issue with the script when we hit the github rate limit. When this happens we download an RC if its the most recent release. One could reproduce this by running the old curl command that this PR replaces.