### PR TITLE
otelcol-config: fix a bug in conf.d loading

### DIFF
--- a/pkg/tools/otelcol-config/conf_loader.go
+++ b/pkg/tools/otelcol-config/conf_loader.go
@@ -86,6 +86,12 @@ func getDir(root fs.FS, dirName string) (result map[string][]byte, err error) {
 		}
 		contents, err := fs.ReadFile(dirFS, entry.Name())
 		if err != nil {
+			if err == fs.ErrNotExist {
+				continue
+			}
+			if _, ok := err.(*fs.PathError); ok {
+				continue
+			}
 			return nil, err
 		}
 		result[entry.Name()] = contents

--- a/pkg/tools/otelcol-config/conf_loader_test.go
+++ b/pkg/tools/otelcol-config/conf_loader_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
 	"testing/fstest"
 
@@ -142,5 +144,41 @@ func TestConfLoader(t *testing.T) {
 				t.Errorf("conf dir not as expected: %s", cmp.Diff(want, got))
 			}
 		})
+	}
+}
+
+func TestConfLoaderDanglingSymlinks(t *testing.T) {
+	tempdir := t.TempDir()
+
+	if err := os.Mkdir(filepath.Join(tempdir, ConfDotD), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Mkdir(filepath.Join(tempdir, ConfDotDAvailable), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(tempdir, ConfDotD, ConfDSettings), []byte("extensions:\n  sumologic:\n    installation_token: abcdef\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Symlink(filepath.Join(tempdir, ConfDotDAvailable, "foobar.yaml"), filepath.Join(tempdir, ConfDotD, "foobar.yaml")); err != nil {
+		t.Fatal(err)
+	}
+
+	conf, err := ReadConfigDir(os.DirFS(tempdir))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exp := ConfDir{
+		ConfD: map[string][]byte{
+			ConfDSettings: []byte("extensions:\n  sumologic:\n    installation_token: abcdef\n"),
+		},
+		ConfDAvailable: map[string][]byte{},
+	}
+
+	if !cmp.Equal(conf, exp) {
+		t.Errorf("conf dir not as expected: %s", cmp.Diff(exp, conf))
 	}
 }


### PR DESCRIPTION
This commit fixes a bug in otelcol-config where conf.d does not load properly when a dangling symlink exists.