### PR TITLE
otelcol-config: set a default for --config

### DIFF
--- a/pkg/tools/otelcol-config/flag.go
+++ b/pkg/tools/otelcol-config/flag.go
@@ -36,7 +36,7 @@ const (
 	enableRemoteControlUsage  = "enables remote control via opamp"
 	disableRemoteControlUsage = "disables remote control, uses local configuration only"
 	setOpAmpEndpointUsage     = "sets the opamp endpoint (eg: wss://example.com)"
-	configUsage               = "path to sumologic configuration directory (normally /etc/otelcol-sumo)"
+	configUsage               = "path to sumologic configuration directory"
 	writeKVUsage              = `write key-value in conf.d with yq expression (eg: --write-kv '.extensions.sumologic.foo = "bar"')`
 	getKVUsage                = "read key-value from conf.d with yq path (eg: --read-kv .extensions.sumologic.foo)"
 	overrideUsage             = "for write-kv, override all other user settings"
@@ -81,7 +81,7 @@ func makeFlagSet(fv *flagValues) *pflag.FlagSet {
 	flags.BoolVar(&fv.EnableRemoteControl, flagEnableRemoteControl, false, enableRemoteControlUsage)
 	flags.BoolVar(&fv.DisableRemoteControl, flagDisableRemoteControl, false, disableRemoteControlUsage)
 	flags.StringVarP(&fv.SetOpAmpEndpoint, flagSetOpAmpEndpoint, "e", "", setOpAmpEndpointUsage)
-	flags.StringVarP(&fv.ConfigDir, flagConfigDir, "c", "", configUsage)
+	flags.StringVarP(&fv.ConfigDir, flagConfigDir, "c", "/etc/otelcol-sumo", configUsage)
 	flags.StringArrayVar(&fv.WriteKV, flagWriteKV, nil, writeKVUsage)
 	flags.StringArrayVar(&fv.ReadKV, flagReadKV, nil, getKVUsage)
 	flags.BoolVar(&fv.Override, flagOverride, false, overrideUsage)

--- a/pkg/tools/otelcol-config/flag_test.go
+++ b/pkg/tools/otelcol-config/flag_test.go
@@ -174,7 +174,18 @@ func TestSetOpampEndpoint(t *testing.T) {
 func TestConfigDir(t *testing.T) {
 	fv := newFlagValues()
 	fs := makeFlagSet(fv)
-	if err := fs.Parse([]string{"otelcol-config", "--config", "/etc/otelcol-sumo"}); err != nil {
+	if err := fs.Parse([]string{"otelcol-config", "--config", "/etc/foosumo"}); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := fv.ConfigDir, "/etc/foosumo"; !cmp.Equal(got, want) {
+		t.Errorf("bad flag values: got %v, want %v", got, want)
+	}
+}
+
+func TestConfigDirUnset(t *testing.T) {
+	fv := newFlagValues()
+	fs := makeFlagSet(fv)
+	if err := fs.Parse([]string{"otelcol-config"}); err != nil {
 		t.Fatal(err)
 	}
 	if got, want := fv.ConfigDir, "/etc/otelcol-sumo"; !cmp.Equal(got, want) {


### PR DESCRIPTION
This commit fixes a bug in otelcol-config, where if --config is not set, the program does not use the expected default of /etc/otelcol-sumo.