### PR TITLE
bugfix: fix a concurrency error in the jobreceiver

### DIFF
--- a/.changelog/1660.fixed.txt
+++ b/.changelog/1660.fixed.txt
@@ -1,0 +1,1 @@
+fix(jobreceiver): resolve a concurrency issue in the command executor


### PR DESCRIPTION
This commit fixes a concurrency error in the jobreceiver, where the stdin and stderr streams can be read after they are closed, generating spurious errors.

Without this commit applied, the tests in the command package will fail about one time in 30. This can easily be verified:

```
$ go test -count 100
```

After this commit is applied, the tests will always pass even after hundreds of runs.

What this change fixes:

`exec.Cmd.Wait` was being called before the final read to the stdout and stderr readers. This lead to the readers encountering a read-after-close error.

The `exec.Cmd` pipes are eschewed in favour of raw `io.Pipe`s, which are closed outside of `cmd.Wait`. For more information on this technique, see the link below.

https://github.com/golang/go/issues/60309#issuecomment-1555290330