### PR TITLE
bugfix(otelcol-config): quote tag names

### DIFF
--- a/pkg/tools/otelcol-config/add_tag.go
+++ b/pkg/tools/otelcol-config/add_tag.go
@@ -31,8 +31,8 @@ func AddTagAction(ctx *actionContext) error {
 	doc := conf.ConfD[docName]
 
 	const (
-		keyFmt      = ".extensions.sumologic.collector_fields.%s = %s"
-		quoteKeyFmt = ".extensions.sumologic.collector_fields.%s = %q"
+		keyFmt      = ".extensions.sumologic.collector_fields.%q = %s"
+		quoteKeyFmt = ".extensions.sumologic.collector_fields.%q = %q"
 	)
 
 	for tagName, tag := range ctx.Flags.AddTags {

--- a/pkg/tools/otelcol-config/add_tag_test.go
+++ b/pkg/tools/otelcol-config/add_tag_test.go
@@ -106,6 +106,12 @@ func TestAddTagAction(t *testing.T) {
 			Flags:    []string{"--add-tag", `foo=[1,2,3,4]`, "--override"},
 			ExpWrite: []byte("extensions:\n  sumologic:\n    collector_fields:\n      foo:\n        - 1\n        - 2\n        - 3\n        - 4\n"),
 		},
+		{
+			Name:     "dot in tag name",
+			Conf:     fstest.MapFS{},
+			Flags:    []string{"--add-tag", "foo.bar=baz"},
+			ExpWrite: []byte("extensions:\n  sumologic:\n    collector_fields:\n      foo.bar: baz\n"),
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
In `otelcol-config`, `--add-tag` is creating hierarchical tag structures when a `.` exists in the tag name. However, the backend only accepts string values. This change makes sure that tags have a flat structure.