### PR TITLE
otrm: support tags in otelcol-config

### DIFF
--- a/pkg/tools/otelcol-config/add_tag.go
+++ b/pkg/tools/otelcol-config/add_tag.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 
 	"github.com/mikefarah/yq/v4/pkg/yqlib"
@@ -12,10 +11,6 @@ func AddTagAction(ctx *actionContext) error {
 	conf, err := ReadConfigDir(ctx.ConfigDir)
 	if err != nil {
 		return err
-	}
-
-	if conf.SumologicRemote != nil {
-		return errors.New("add-tag not supported for remote-controlled collectors")
 	}
 
 	docName := ConfDSettings
@@ -29,6 +24,12 @@ func AddTagAction(ctx *actionContext) error {
 	decoder := yqlib.YamlFormat.DecoderFactory()
 	eval := yqlib.NewStringEvaluator()
 	doc := conf.ConfD[docName]
+
+	if conf.SumologicRemote != nil {
+		doc = conf.SumologicRemote
+		writeDoc = ctx.WriteSumologicRemote
+		docName = SumologicRemoteDotYaml
+	}
 
 	const (
 		keyFmt      = ".extensions.sumologic.collector_fields.%q = %s"

--- a/pkg/tools/otelcol-config/add_tag_test.go
+++ b/pkg/tools/otelcol-config/add_tag_test.go
@@ -112,6 +112,16 @@ func TestAddTagAction(t *testing.T) {
 			Flags:    []string{"--add-tag", "foo.bar=baz"},
 			ExpWrite: []byte("extensions:\n  sumologic:\n    collector_fields:\n      foo.bar: baz\n"),
 		},
+		{
+			Name: "add tag to sumologic-remote.yaml",
+			Conf: fstest.MapFS{
+				SumologicRemoteDotYaml: &fstest.MapFile{
+					Data: []byte("extensions:\n  sumologic:\n    collector_fields:\n      foo: bar\n"),
+				},
+			},
+			Flags:    []string{"--add-tag", "bar=baz"},
+			ExpWrite: []byte("extensions:\n  sumologic:\n    collector_fields:\n      foo: bar\n      bar: baz\n"),
+		},
 	}
 
 	for _, test := range tests {
@@ -137,6 +147,11 @@ func TestAddTagAction(t *testing.T) {
 				settingsWriter,
 				overridesWriter,
 			)
+			if _, ok := test.Conf.(fstest.MapFS)[SumologicRemoteDotYaml]; ok {
+				actionContext.WriteConfD = errWriter{}.Write
+				actionContext.WriteConfDOverrides = errWriter{}.Write
+				actionContext.WriteSumologicRemote = newTestWriter(test.ExpWrite).Write
+			}
 			err := AddTagAction(actionContext)
 			if test.ExpErr && err == nil {
 				t.Fatal("expected non-nil error")

--- a/pkg/tools/otelcol-config/delete_tag_test.go
+++ b/pkg/tools/otelcol-config/delete_tag_test.go
@@ -10,12 +10,13 @@ import (
 
 func TestDeleteTagAction(t *testing.T) {
 	tests := []struct {
-		Name                   string
-		Conf                   fs.FS
-		Flags                  []string
-		ExpConfDWrite          []byte
-		ExpConfDOverridesWrite []byte
-		ExpErr                 bool
+		Name                    string
+		Conf                    fs.FS
+		Flags                   []string
+		ExpConfDWrite           []byte
+		ExpConfDOverridesWrite  []byte
+		ExpSumoLogicRemoteWrite []byte
+		ExpErr                  bool
 	}{
 		{
 			Name:  "doc missing",
@@ -111,11 +112,23 @@ func TestDeleteTagAction(t *testing.T) {
 			Flags:         []string{"--delete-tag", "foo.bar"},
 			ExpConfDWrite: []byte("extensions:\n  sumologic:\n    collector_fields: {}\n"),
 		},
+		{
+			Name: "delete tag from sumologic-remote.yaml",
+			Conf: fstest.MapFS{
+				SumologicRemoteDotYaml: &fstest.MapFile{
+					Data: []byte("extensions:\n  sumologic:\n    collector_fields:\n      foo: bar\n      bar: baz\n"),
+				},
+			},
+			Flags:                   []string{"--delete-tag", "bar"},
+			ExpSumoLogicRemoteWrite: []byte("extensions:\n  sumologic:\n    collector_fields:\n      foo: bar\n"),
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			var settingsWriter, overridesWriter func([]byte) (int, error)
+			var settingsWriter, overridesWriter, sumologicRemoteWriter func([]byte) (int, error)
+
+			sumologicRemoteWriter = errWriter{}.Write
 
 			if test.ExpConfDWrite != nil {
 				settingsWriter = newTestWriter(test.ExpConfDWrite).Write
@@ -129,6 +142,12 @@ func TestDeleteTagAction(t *testing.T) {
 				overridesWriter = errWriter{}.Write
 			}
 
+			if test.ExpSumoLogicRemoteWrite != nil {
+				settingsWriter = errWriter{}.Write
+				overridesWriter = errWriter{}.Write
+				sumologicRemoteWriter = newTestWriter(test.ExpSumoLogicRemoteWrite).Write
+			}
+
 			stdoutBuf := new(bytes.Buffer)
 			stderrBuf := new(bytes.Buffer)
 
@@ -140,6 +159,8 @@ func TestDeleteTagAction(t *testing.T) {
 				settingsWriter,
 				overridesWriter,
 			)
+
+			actionContext.WriteSumologicRemote = sumologicRemoteWriter
 
 			err := DeleteTagAction(actionContext)
 			if test.ExpErr && err == nil {


### PR DESCRIPTION
This commit adds support for adding and removing tags when remote control is enabled. This is necessary to bootstrap the connection to the backend, and so must be supported.