### PR TITLE
otelcol-config: write installation token to env var

### DIFF
--- a/pkg/tools/otelcol-config/action_context.go
+++ b/pkg/tools/otelcol-config/action_context.go
@@ -11,15 +11,17 @@ import (
 // actionContext is not like context.Context, and is not for cancellation or
 // for carrying values across API boundaries. It is for abstracting I/O.
 type actionContext struct {
-	ConfigDir            fs.FS
-	Flags                *flagValues
-	Stdout               io.Writer
-	Stderr               io.Writer
-	WriteConfD           func([]byte) (int, error)
-	WriteConfDOverrides  func([]byte) (int, error)
-	WriteSumologicRemote func([]byte) (int, error)
-	LinkHostMetrics      func() error
-	UnlinkHostMetrics    func() error
-	LinkEphemeral        func() error
-	UnlinkEphemeral      func() error
+	ConfigDir                 fs.FS
+	Flags                     *flagValues
+	Stdout                    io.Writer
+	Stderr                    io.Writer
+	WriteConfD                func([]byte) (int, error)
+	WriteConfDOverrides       func([]byte) (int, error)
+	WriteSumologicRemote      func([]byte) (int, error)
+	LinkHostMetrics           func() error
+	UnlinkHostMetrics         func() error
+	LinkEphemeral             func() error
+	UnlinkEphemeral           func() error
+	SystemdEnabled            bool
+	WriteInstallationTokenEnv func([]byte) (int, error)
 }

--- a/pkg/tools/otelcol-config/installation_token.go
+++ b/pkg/tools/otelcol-config/installation_token.go
@@ -9,6 +9,10 @@ import (
 )
 
 func SetInstallationTokenAction(ctx *actionContext) error {
+	if ctx.SystemdEnabled {
+		return setInstallationTokenSystemd(ctx)
+	}
+
 	conf, err := ReadConfigDir(ctx.ConfigDir)
 	if err != nil {
 		return err
@@ -63,5 +67,14 @@ func SetInstallationTokenAction(ctx *actionContext) error {
 		return fmt.Errorf("couldn't write installation token: %s", err)
 	}
 
+	return nil
+}
+
+func setInstallationTokenSystemd(ctx *actionContext) error {
+	tokenDoc := fmt.Sprintf("SUMOLOGIC_INSTALLATION_TOKEN=%s\n", ctx.Flags.InstallationToken)
+	_, err := ctx.WriteInstallationTokenEnv([]byte(tokenDoc))
+	if err != nil {
+		return fmt.Errorf("couldn't write token.env: %s", err)
+	}
 	return nil
 }


### PR DESCRIPTION
When systemd is enabled, we expect tokens to be written to $CONFIGDIR/env/token.env