### PR TITLE
otelcol-config: chown sumologic-remote.yaml

### DIFF
--- a/pkg/tools/otelcol-config/main.go
+++ b/pkg/tools/otelcol-config/main.go
@@ -109,55 +109,6 @@ func getSumologicRemoteWriter(values *flagValues) func([]byte) (int, error) {
 	}
 }
 
-func setSumologicRemoteOwner(values *flagValues) error {
-	if runtime.GOOS == "windows" {
-		// windows does not have the concept of uid and gid ownership
-		return nil
-	}
-
-	baseConfigPath := filepath.Join(values.ConfigDir, SumologicDotYaml)
-	docPath := filepath.Join(values.ConfigDir, SumologicRemoteDotYaml)
-
-	// check who owns the base configuration file
-	stat, err := os.Stat(baseConfigPath)
-	if err != nil {
-		// maybe it doesn't exist, stat the parent dir instead
-		stat, err = os.Stat(values.ConfigDir)
-		if err != nil {
-			// something is seriously wrong
-			return fmt.Errorf("error reading config dir: %s", err)
-		}
-	}
-
-	var uid, gid uint32
-
-	sys, ok := stat.Sys().(*syscall.Stat_t)
-	if ok {
-		uid = sys.Uid
-		gid = sys.Gid
-	} else {
-		// we're not on a supported platform for chown
-		return nil
-	}
-
-	if int(uid) == syscall.Getuid() {
-		// we're already that user
-		return nil
-	}
-
-	// set the owner to be consistent with the other configuration
-	if err := os.Chown(docPath, int(uid), int(gid)); err != nil {
-		if err.(*os.PathError).Err == syscall.EPERM {
-			// we don't have permission to chown, skip it
-			return nil
-		}
-		return err
-	}
-
-	return nil
-
-}
-
 func getHostMetricsFilename() string {
 	switch runtime.GOOS {
 	case "linux":

--- a/pkg/tools/otelcol-config/main_unix.go
+++ b/pkg/tools/otelcol-config/main_unix.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// use chown to set the owner of sumologic-remote.yaml to otelcol-sumo
+// or whatever the user should be, based on the ownership of sumologic.yaml
+// or its parent directory
+func setSumologicRemoteOwner(values *flagValues) error {
+	baseConfigPath := filepath.Join(values.ConfigDir, SumologicDotYaml)
+	docPath := filepath.Join(values.ConfigDir, SumologicRemoteDotYaml)
+
+	// check who owns the base configuration file
+	stat, err := os.Stat(baseConfigPath)
+	if err != nil {
+		// maybe it doesn't exist, stat the parent dir instead
+		stat, err = os.Stat(values.ConfigDir)
+		if err != nil {
+			// something is seriously wrong
+			return fmt.Errorf("error reading config dir: %s", err)
+		}
+	}
+
+	var uid, gid uint32
+
+	sys, ok := stat.Sys().(*syscall.Stat_t)
+	if ok {
+		uid = sys.Uid
+		gid = sys.Gid
+	} else {
+		// we're not on a supported platform for chown
+		return nil
+	}
+
+	if int(uid) == syscall.Getuid() {
+		// we're already that user
+		return nil
+	}
+
+	// set the owner to be consistent with the other configuration
+	if err := os.Chown(docPath, int(uid), int(gid)); err != nil {
+		if err.(*os.PathError).Err == syscall.EPERM {
+			// we don't have permission to chown, skip it
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}

--- a/pkg/tools/otelcol-config/main_unix.go
+++ b/pkg/tools/otelcol-config/main_unix.go
@@ -25,24 +25,20 @@ func setSumologicRemoteOwner(values *flagValues) error {
 		}
 	}
 
-	var uid, gid uint32
-
 	sys, ok := stat.Sys().(*syscall.Stat_t)
-	if ok {
-		uid = sys.Uid
-		gid = sys.Gid
-	} else {
-		// we're not on a supported platform for chown
+	if !ok {
+		// the platform does not has the expected sys somehow,
+		// so just bail out with no error
 		return nil
 	}
 
-	if int(uid) == syscall.Getuid() {
+	if int(sys.Uid) == syscall.Getuid() {
 		// we're already that user
 		return nil
 	}
 
 	// set the owner to be consistent with the other configuration
-	if err := os.Chown(docPath, int(uid), int(gid)); err != nil {
+	if err := os.Chown(docPath, int(sys.Uid), int(sys.Gid)); err != nil {
 		if err.(*os.PathError).Err == syscall.EPERM {
 			// we don't have permission to chown, skip it
 			return nil

--- a/pkg/tools/otelcol-config/main_windows.go
+++ b/pkg/tools/otelcol-config/main_windows.go
@@ -1,0 +1,6 @@
+package main
+
+// this is only a stub for Windows build support
+func setSumologicRemoteOwner(*flagValues) error {
+	return nil
+}


### PR DESCRIPTION
This commit makes otelcol-config set the UID and GID of sumologic-remote.yaml to the same UID and GID as sumologic.yaml, when the tool is running with elevated privileges.

If the tool is not running with elevated privileges, then sumologic-remote.yaml will be owned by the user running otelcol-config.