### PR TITLE
otelcol-config: set file perms to 0660, not 0600

### DIFF
--- a/pkg/tools/otelcol-config/conf_loader_test.go
+++ b/pkg/tools/otelcol-config/conf_loader_test.go
@@ -150,15 +150,15 @@ func TestConfLoader(t *testing.T) {
 func TestConfLoaderDanglingSymlinks(t *testing.T) {
 	tempdir := t.TempDir()
 
-	if err := os.Mkdir(filepath.Join(tempdir, ConfDotD), 0700); err != nil {
+	if err := os.Mkdir(filepath.Join(tempdir, ConfDotD), 0770); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := os.Mkdir(filepath.Join(tempdir, ConfDotDAvailable), 0700); err != nil {
+	if err := os.Mkdir(filepath.Join(tempdir, ConfDotDAvailable), 0770); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := os.WriteFile(filepath.Join(tempdir, ConfDotD, ConfDSettings), []byte("extensions:\n  sumologic:\n    installation_token: abcdef\n"), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(tempdir, ConfDotD, ConfDSettings), []byte("extensions:\n  sumologic:\n    installation_token: abcdef\n"), 0660); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/tools/otelcol-config/linker_test.go
+++ b/pkg/tools/otelcol-config/linker_test.go
@@ -22,17 +22,17 @@ func TestHostMetricsLinker(t *testing.T) {
 	}
 
 	availPath := filepath.Join(dir, ConfDotDAvailable)
-	if err := os.Mkdir(availPath, 0700); err != nil {
+	if err := os.Mkdir(availPath, 0770); err != nil {
 		t.Fatal(err)
 	}
 
 	confdPath := filepath.Join(dir, ConfDotD)
-	if err := os.Mkdir(confdPath, 0700); err != nil {
+	if err := os.Mkdir(confdPath, 0770); err != nil {
 		t.Fatal(err)
 	}
 
 	configPath := filepath.Join(availPath, hostmetricsFilename)
-	if err := os.WriteFile(configPath, []byte("configuration: yes"), 0600); err != nil {
+	if err := os.WriteFile(configPath, []byte("configuration: yes"), 0660); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/tools/otelcol-config/main.go
+++ b/pkg/tools/otelcol-config/main.go
@@ -82,7 +82,7 @@ func getSortedActions(fs *pflag.FlagSet) []string {
 
 func getConfDWriter(values *flagValues, fileName string) func(doc []byte) (int, error) {
 	return func(doc []byte) (int, error) {
-		return len(doc), os.WriteFile(filepath.Join(values.ConfigDir, ConfDotD, fileName), doc, 0600)
+		return len(doc), os.WriteFile(filepath.Join(values.ConfigDir, ConfDotD, fileName), doc, 0660)
 	}
 }
 
@@ -97,7 +97,7 @@ func getSumologicRemoteWriter(values *flagValues) func([]byte) (int, error) {
 			return 0, os.Remove(docPath)
 		}
 
-		if err := os.WriteFile(docPath, doc, 0600); err != nil {
+		if err := os.WriteFile(docPath, doc, 0660); err != nil {
 			return 0, fmt.Errorf("error writing sumologic-remote.yaml: %s", err)
 		}
 
@@ -184,11 +184,11 @@ func getSystemdEnabled() bool {
 func getInstallationTokenWriter(values *flagValues) func([]byte) (int, error) {
 	return func(token []byte) (int, error) {
 		tokenDir := filepath.Join(values.ConfigDir, "env")
-		if err := os.MkdirAll(tokenDir, 0700); err != nil {
+		if err := os.MkdirAll(tokenDir, 0770); err != nil {
 			return 0, err
 		}
 		tokenPath := filepath.Join(tokenDir, "token.env")
-		return len(token), os.WriteFile(tokenPath, token, 0600)
+		return len(token), os.WriteFile(tokenPath, token, 0660)
 	}
 }
 

--- a/pkg/tools/otelcol-config/smoke_test.go
+++ b/pkg/tools/otelcol-config/smoke_test.go
@@ -9,16 +9,16 @@ import (
 )
 
 func createSkeleton(dir string) error {
-	if err := os.Mkdir(filepath.Join(dir, ConfDotD), 0700); err != nil {
+	if err := os.Mkdir(filepath.Join(dir, ConfDotD), 0770); err != nil {
 		return err
 	}
-	if err := os.Mkdir(filepath.Join(dir, ConfDotDAvailable), 0700); err != nil {
+	if err := os.Mkdir(filepath.Join(dir, ConfDotDAvailable), 0770); err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(dir, ConfDotDAvailable, getHostMetricsFilename()), []byte("hostmetrics"), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, ConfDotDAvailable, getHostMetricsFilename()), []byte("hostmetrics"), 0660); err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(dir, ConfDotDAvailable, ephemeralYAML), []byte("ephemeral"), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, ConfDotDAvailable, ephemeralYAML), []byte("ephemeral"), 0660); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Allows users to modify configuration by being a member of the otelcol-sumo group, instead of needing sudo.