### PR TITLE
otelcol-config: fix ownership, perms, and hostmetrics filename

### DIFF
--- a/pkg/tools/otelcol-config/darwin_test.go
+++ b/pkg/tools/otelcol-config/darwin_test.go
@@ -1,5 +1,0 @@
-//go:build darwin
-
-package main
-
-const hostmetricsFilename = hostmetricsDarwin

--- a/pkg/tools/otelcol-config/linker_test.go
+++ b/pkg/tools/otelcol-config/linker_test.go
@@ -31,7 +31,7 @@ func TestHostMetricsLinker(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	configPath := filepath.Join(availPath, hostmetricsFilename)
+	configPath := filepath.Join(availPath, hostmetricsYAML)
 	if err := os.WriteFile(configPath, []byte("configuration: yes"), 0660); err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +42,7 @@ func TestHostMetricsLinker(t *testing.T) {
 		t.Fatal(fmt.Errorf("can't link config path %s: %s", configPath, err))
 	}
 
-	linkPath := filepath.Join(dir, ConfDotD, hostmetricsFilename)
+	linkPath := filepath.Join(dir, ConfDotD, hostmetricsYAML)
 
 	stat, err := os.Lstat(linkPath)
 	if err != nil {

--- a/pkg/tools/otelcol-config/linux_test.go
+++ b/pkg/tools/otelcol-config/linux_test.go
@@ -1,5 +1,0 @@
-//go:build linux
-
-package main
-
-const hostmetricsFilename = hostmetricsLinux

--- a/pkg/tools/otelcol-config/main.go
+++ b/pkg/tools/otelcol-config/main.go
@@ -15,9 +15,8 @@ import (
 )
 
 const (
-	hostmetricsLinux  = "hostmetrics-linux.yaml"
-	hostmetricsDarwin = "hostmetrics-darwin.yaml"
-	ephemeralYAML     = "ephemeral.yaml"
+	hostmetricsYAML = "hostmetrics.yaml"
+	ephemeralYAML   = "ephemeral.yaml"
 )
 
 // errorCoder is here to give actions a way to set the exit status of the program
@@ -109,17 +108,6 @@ func getSumologicRemoteWriter(values *flagValues) func([]byte) (int, error) {
 	}
 }
 
-func getHostMetricsFilename() string {
-	switch runtime.GOOS {
-	case "linux":
-		return hostmetricsLinux
-	case "darwin":
-		return hostmetricsDarwin
-	default:
-		panic("unsupported os: " + runtime.GOOS)
-	}
-}
-
 func isLinkError(err error) bool {
 	_, linkError := err.(*os.LinkError)
 	return linkError
@@ -154,13 +142,11 @@ func getUnlinker(values *flagValues, filename string) func() error {
 }
 
 func getHostMetricsLinker(values *flagValues) func() error {
-	filename := getHostMetricsFilename()
-	return getLinker(values, filename)
+	return getLinker(values, hostmetricsYAML)
 }
 
 func getHostMetricsUnlinker(values *flagValues) func() error {
-	filename := getHostMetricsFilename()
-	return getUnlinker(values, filename)
+	return getUnlinker(values, hostmetricsYAML)
 }
 
 func getEphemeralLinker(values *flagValues) func() error {

--- a/pkg/tools/otelcol-config/main_unix.go
+++ b/pkg/tools/otelcol-config/main_unix.go
@@ -50,7 +50,3 @@ func setConfigOwner(values *flagValues, docPath string) error {
 
 	return nil
 }
-
-func setSumologicRemoteOwner(values *flagValues) error {
-	return setConfigOwner(values, SumologicRemoteDotYaml)
-}

--- a/pkg/tools/otelcol-config/main_windows.go
+++ b/pkg/tools/otelcol-config/main_windows.go
@@ -3,6 +3,6 @@
 package main
 
 // this is only a stub for Windows build support
-func setSumologicRemoteOwner(*flagValues) error {
+func setConfigOwner(*flagValues, string) error {
 	return nil
 }

--- a/pkg/tools/otelcol-config/smoke_test.go
+++ b/pkg/tools/otelcol-config/smoke_test.go
@@ -15,7 +15,7 @@ func createSkeleton(dir string) error {
 	if err := os.Mkdir(filepath.Join(dir, ConfDotDAvailable), 0770); err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(dir, ConfDotDAvailable, getHostMetricsFilename()), []byte("hostmetrics"), 0660); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, ConfDotDAvailable, hostmetricsYAML), []byte("hostmetrics"), 0660); err != nil {
 		return err
 	}
 	if err := os.WriteFile(filepath.Join(dir, ConfDotDAvailable, ephemeralYAML), []byte("ephemeral"), 0660); err != nil {


### PR DESCRIPTION
Correctly set ownership & permissions of configuration files. The owner/group used will match the owner/group of `/etc/otelcol-sumo/sumologic.yaml`. The permissions used is `0600`.

Also fixes the name of the `hostmetrics.yaml` symlink.