### PR TITLE
chore: Prepare release for v0.108.0-sumo-0

### DIFF
--- a/.changelog/1678.changed.txt
+++ b/.changelog/1678.changed.txt
@@ -1,1 +1,0 @@
-chore: Upgraded otel core to 0.108.0

--- a/.changelog/1681.fixed.txt
+++ b/.changelog/1681.fixed.txt
@@ -1,1 +1,0 @@
-Remove unnecessary warnings from the k8s tagger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes -->
 
-## [v0.106.1-sumo-1]
+## [v0.108.0-sumo-0]
+
+### Released 2024-10-03
+
+### Changed
+
+- chore: Upgraded otel core to 0.108.0 [#1678]
+
+### Fixed
+
+- Remove unnecessary warnings from the k8s tagger [#1681]
+
+[#1678]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1678
+[#1681]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1681
+
+[v0.108.0-sumo-0]: https://github.com/SumoLogic/sumologic-otel-collector/releases/v0.108.0-sumo-0## [v0.106.1-sumo-1]
 
 ### Released 2024-09-11
 
@@ -16,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(version): Fixing the changelog and version for otel collector [#1674]
 
 [#1674]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1674
+
 [v0.106.1-sumo-1]: https://github.com/SumoLogic/sumologic-otel-collector/releases/v0.106.1-sumo-1## [v0.106.1-sumo-0]
 
 ## [v0.106.1-sumo-0]


### PR DESCRIPTION
- releasing v108, ran ```make update-changelog VERSION=0.108.0-sumo-0```