### PR TITLE
Add find-build-num tool

### DIFF
--- a/pkg/tools/find-build-number/Makefile
+++ b/pkg/tools/find-build-number/Makefile
@@ -1,0 +1,8 @@
+include ../../Makefile.Common
+
+.PHONY: build
+build:
+	go build -v -o udpdemux .
+
+.PHONY: test
+test: build

--- a/pkg/tools/find-build-number/go.mod
+++ b/pkg/tools/find-build-number/go.mod
@@ -1,0 +1,11 @@
+module github.com/SumoLogic/sumologic-otel-collector/pkg/tools/find-build-number
+
+go 1.23.1
+
+require (
+	github.com/google/go-github/v66 v66.0.0
+	golang.org/x/oauth2 v0.23.0
+	gopkg.in/yaml.v2 v2.4.0
+)
+
+require github.com/google/go-querystring v1.1.0 // indirect

--- a/pkg/tools/find-build-number/go.sum
+++ b/pkg/tools/find-build-number/go.sum
@@ -1,0 +1,14 @@
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-github/v66 v66.0.0 h1:ADJsaXj9UotwdgK8/iFZtv7MLc8E8WBl62WLd/D/9+M=
+github.com/google/go-github/v66 v66.0.0/go.mod h1:+4SO9Zkuyf8ytMj0csN1NR/5OTR+MfqPp8P8dVlcvY4=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
+golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/pkg/tools/find-build-number/main.go
+++ b/pkg/tools/find-build-number/main.go
@@ -47,23 +47,25 @@ func getJobMetadata(ctx context.Context, client *github.Client, ref string) (job
 		return meta, err
 	}
 
+	var runID int64
 	for _, checkRun := range list.CheckRuns {
 		if !strings.HasPrefix(*checkRun.Name, "Trigger Packaging") {
 			continue
 		}
-		annotations, _, err := client.Checks.ListCheckRunAnnotations(ctx, otcOrg, otcRepo, *checkRun.ID, nil)
-		if err != nil {
-			return meta, err
-		}
-		for _, anno := range annotations {
-			switch *anno.Title {
-			case otcVersionAnnotation:
-				meta.OTCVersion = *anno.Message
-			case otcSumoVersionAnnotation:
-				meta.OTCSumoVersion = *anno.Message
-			case workflowIDAnnotation:
-				meta.WorkflowID = *anno.Message
-			}
+		runID = *checkRun.ID
+	}
+	annotations, _, err := client.Checks.ListCheckRunAnnotations(ctx, otcOrg, otcRepo, runID, nil)
+	if err != nil {
+		return meta, err
+	}
+	for _, anno := range annotations {
+		switch *anno.Title {
+		case otcVersionAnnotation:
+			meta.OTCVersion = *anno.Message
+		case otcSumoVersionAnnotation:
+			meta.OTCSumoVersion = *anno.Message
+		case workflowIDAnnotation:
+			meta.WorkflowID = *anno.Message
 		}
 	}
 

--- a/pkg/tools/find-build-number/main.go
+++ b/pkg/tools/find-build-number/main.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/google/go-github/v66/github"
+	"golang.org/x/oauth2"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	otcOrg  = "SumoLogic"
+	otcRepo = "sumologic-otel-collector"
+)
+
+const (
+	workflowIDAnnotation     = "Workflow ID"
+	otcVersionAnnotation     = "OTC Version"
+	otcSumoVersionAnnotation = "OTC Sumo Version"
+)
+
+type Inputs struct {
+	Ref         string `yaml:"ref"`
+	GithubToken string `yaml:"github_token"`
+}
+
+type Outputs struct {
+	BuildVersion string `json:"build_version"`
+	BuildNumber  string `json:"build_number"`
+}
+
+type jobMetadata struct {
+	WorkflowID     string
+	OTCVersion     string
+	OTCSumoVersion string
+}
+
+func getJobMetadata(ctx context.Context, client *github.Client, ref string) (jobMetadata, error) {
+	var meta jobMetadata
+
+	list, _, err := client.Checks.ListCheckRunsForRef(ctx, otcOrg, otcRepo, ref, nil)
+	if err != nil {
+		return meta, err
+	}
+
+	for _, checkRun := range list.CheckRuns {
+		if !strings.HasPrefix(*checkRun.Name, "Trigger Packaging") {
+			continue
+		}
+		annotations, _, err := client.Checks.ListCheckRunAnnotations(ctx, otcOrg, otcRepo, *checkRun.ID, nil)
+		if err != nil {
+			return meta, err
+		}
+		for _, anno := range annotations {
+			switch *anno.Title {
+			case otcVersionAnnotation:
+				meta.OTCVersion = *anno.Message
+			case otcSumoVersionAnnotation:
+				meta.OTCSumoVersion = *anno.Message
+			case workflowIDAnnotation:
+				meta.WorkflowID = *anno.Message
+			}
+		}
+	}
+
+	return meta, nil
+}
+
+func main() {
+	var inputs Inputs
+
+	if err := yaml.NewDecoder(os.Stdin).Decode(&inputs); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to parse STDIN as JSON: %s\n", err)
+		fmt.Println(`Expected input: {"github_token": "xxxxxx", "ref": "abcdef"}`)
+		os.Exit(1)
+	}
+
+	if inputs.GithubToken == "" {
+		fmt.Fprintf(os.Stderr, "The github_token JSON attribute must be set\n")
+		os.Exit(1)
+	}
+
+	if inputs.Ref == "" {
+		fmt.Fprintln(os.Stderr, "The ref JSON attribute must be set (commit SHA or tag)")
+		os.Exit(1)
+	}
+
+	// setup github client
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: inputs.GithubToken},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+	githubClient := github.NewClient(tc)
+
+	meta, err := getJobMetadata(ctx, githubClient, inputs.Ref)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	var workflowID int64
+	if _, err := fmt.Sscanf(meta.WorkflowID, "%d", &workflowID); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid workflow id: %q: %s\n", meta.WorkflowID, err)
+		os.Exit(1)
+	}
+
+	run, _, err := githubClient.Actions.GetWorkflowRunByID(ctx, otcOrg, otcRepo, workflowID)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	outputs := Outputs{
+		BuildVersion: fmt.Sprintf("%s-sumo-%s", meta.OTCVersion, meta.OTCSumoVersion),
+		BuildNumber:  fmt.Sprintf("%d", *run.RunNumber),
+	}
+
+	outputJSON, err := json.Marshal(&outputs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to marshal outputs JSON: %s\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(string(outputJSON))
+}


### PR DESCRIPTION
The find_build_num tool is useful for finding which package build corresponds to a particular sumologic-otel-collector SHA or tag.

This code is not part of the Sumo OTC distribution - it is glue code for relating jobs between the sumologic-otel-collector repository and the sumologic-otel-collector-packaging repository.