### PR TITLE
chore(ci): remove ref for pkg trigger

### DIFF
--- a/.github/workflows/workflow-trigger-packaging.yml
+++ b/.github/workflows/workflow-trigger-packaging.yml
@@ -34,7 +34,7 @@ jobs:
           REPO: SumoLogic/sumologic-otel-collector-packaging
           WORKFLOW: build_packages.yml
         run: |
-          gh workflow run --repo ${REPO} ${WORKFLOW} --ref use-binary-version --json << EOF
+          gh workflow run --repo ${REPO} ${WORKFLOW} --json << EOF
             {
               "workflow_id": "${{ inputs.workflow_id }}"
             }


### PR DESCRIPTION
Removes the git ref override that was added for testing. I meant to make this change before #1693 was merged.