### PR TITLE
fix(otelcol-config): update default remote config

### DIFF
--- a/pkg/tools/otelcol-config/remote_control.go
+++ b/pkg/tools/otelcol-config/remote_control.go
@@ -53,9 +53,30 @@ func makeNewSumologicRemoteYAML(ctx *actionContext, conf ConfDir) error {
 	var sumoRemoteConfig = map[string]any{
 		"extensions": map[string]any{
 			"opamp": map[string]any{
-				"enabled":                        true,
 				"remote_configuration_directory": remoteConfigDir,
 				"endpoint":                       DefaultSumoLogicOpampEndpoint,
+			},
+		},
+		"receivers": map[string]any{
+			"nop": map[string]any{},
+		},
+		"exporters": map[string]any{
+			"nop": map[string]any{},
+		},
+		"service": map[string]any{
+			"pipelines": map[string]any{
+				"metrics/default": map[string]any{
+					"receivers": []string{"nop"},
+					"exporters": []string{"nop"},
+				},
+				"logs/default": map[string]any{
+					"receivers": []string{"nop"},
+					"exporters": []string{"nop"},
+				},
+				"traces/default": map[string]any{
+					"receivers": []string{"nop"},
+					"exporters": []string{"nop"},
+				},
 			},
 		},
 	}

--- a/pkg/tools/otelcol-config/remote_control_test.go
+++ b/pkg/tools/otelcol-config/remote_control_test.go
@@ -76,11 +76,31 @@ func TestEnableRemoteControlConfigFileNotPresent(t *testing.T) {
 	values := &flagValues{
 		EnableRemoteControl: true,
 	}
-	const expData = `extensions:
+	const expData = `exporters:
+  nop: {}
+extensions:
   opamp:
-    enabled: true
     endpoint: wss://opamp-events.sumologic.com/v1/opamp
     remote_configuration_directory: /etc/otelcol-sumo/opamp.d
+receivers:
+  nop: {}
+service:
+  pipelines:
+    logs/default:
+      exporters:
+        - nop
+      receivers:
+        - nop
+    metrics/default:
+      exporters:
+        - nop
+      receivers:
+        - nop
+    traces/default:
+      exporters:
+        - nop
+      receivers:
+        - nop
 `
 	slrWriter := newTestWriter([]byte(expData))
 	ctx := &actionContext{


### PR DESCRIPTION
A minimum of one receiver, one exporter, and one pipeline are necessary for otelcol to start. This adds the default pipelines from the default non-remote config but with only a nop receiver & nop exporter.