### PR TITLE
fix(otelcol-config): add missing extension config

### DIFF
--- a/pkg/tools/otelcol-config/remote_control.go
+++ b/pkg/tools/otelcol-config/remote_control.go
@@ -56,6 +56,10 @@ func makeNewSumologicRemoteYAML(ctx *actionContext, conf ConfDir) error {
 				"remote_configuration_directory": remoteConfigDir,
 				"endpoint":                       DefaultSumoLogicOpampEndpoint,
 			},
+			"sumologic": map[string]any{
+				"installation_token":              "${SUMOLOGIC_INSTALLATION_TOKEN}",
+				"collector_credentials_directory": "/var/lib/otelcol-sumo/credentials",
+			},
 		},
 		"receivers": map[string]any{
 			"nop": map[string]any{},
@@ -64,6 +68,10 @@ func makeNewSumologicRemoteYAML(ctx *actionContext, conf ConfDir) error {
 			"nop": map[string]any{},
 		},
 		"service": map[string]any{
+			"extensions": []string{
+				"sumologic",
+				"opamp",
+			},
 			"pipelines": map[string]any{
 				"metrics/default": map[string]any{
 					"receivers": []string{"nop"},

--- a/pkg/tools/otelcol-config/remote_control_test.go
+++ b/pkg/tools/otelcol-config/remote_control_test.go
@@ -82,9 +82,15 @@ extensions:
   opamp:
     endpoint: wss://opamp-events.sumologic.com/v1/opamp
     remote_configuration_directory: /etc/otelcol-sumo/opamp.d
+  sumologic:
+    collector_credentials_directory: /var/lib/otelcol-sumo/credentials
+    installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
 receivers:
   nop: {}
 service:
+  extensions:
+    - sumologic
+    - opamp
   pipelines:
     logs/default:
       exporters:


### PR DESCRIPTION
The sumologic & opamp services have to be added to the service to function. Also added missing `installation_token` and `collector_credentials_directory` fields to the sumologic extension config.