### PR TITLE
Add nop components to OPAmp extension

### DIFF
--- a/pkg/extension/opampextension/components.go
+++ b/pkg/extension/opampextension/components.go
@@ -3,6 +3,7 @@ package opampextension
 import (
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
+	"go.opentelemetry.io/collector/exporter/nopexporter"
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/extension/ballastextension"
 
@@ -12,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/processor/memorylimiterprocessor"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
+	"go.opentelemetry.io/collector/receiver/nopreceiver"
 	"go.uber.org/multierr"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter"
@@ -59,6 +61,7 @@ func Components() (
 	errs = multierr.Append(errs, err)
 
 	receivers, err := receiver.MakeFactoryMap(
+		nopreceiver.NewFactory(),
 		apachereceiver.NewFactory(),
 		filelogreceiver.NewFactory(),
 		hostmetricsreceiver.NewFactory(),
@@ -79,6 +82,7 @@ func Components() (
 	errs = multierr.Append(errs, err)
 
 	exporters, err := exporter.MakeFactoryMap(
+		nopexporter.NewFactory(),
 		otlpexporter.NewFactory(),
 		sumologicexporter.NewFactory(),
 		syslogexporter.NewFactory(),

--- a/pkg/extension/opampextension/go.mod
+++ b/pkg/extension/opampextension/go.mod
@@ -45,6 +45,7 @@ require (
 	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.108.1
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.108.1
 	go.opentelemetry.io/collector/exporter v0.108.1
+	go.opentelemetry.io/collector/exporter/nopexporter v0.108.0
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.108.0
 	go.opentelemetry.io/collector/extension v0.108.1
 	go.opentelemetry.io/collector/extension/ballastextension v0.108.0
@@ -54,6 +55,7 @@ require (
 	go.opentelemetry.io/collector/processor/batchprocessor v0.108.0
 	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.108.0
 	go.opentelemetry.io/collector/receiver v0.108.1
+	go.opentelemetry.io/collector/receiver/nopreceiver v0.108.0
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.108.0
 	go.opentelemetry.io/collector/semconv v0.108.1
 	go.uber.org/multierr v1.11.0

--- a/pkg/extension/opampextension/go.sum
+++ b/pkg/extension/opampextension/go.sum
@@ -765,6 +765,8 @@ go.opentelemetry.io/collector/consumer/consumertest v0.108.1 h1:WLvi27Vu5nkltjhm
 go.opentelemetry.io/collector/consumer/consumertest v0.108.1/go.mod h1:tRqOtUukG76iBlPTAUwFSU87dDO+x33Gyn2x9mecfko=
 go.opentelemetry.io/collector/exporter v0.108.1 h1:VjtbIwwR2B1GMf69FxVvwcKYIpbkC7v2wBxLt5vjYKI=
 go.opentelemetry.io/collector/exporter v0.108.1/go.mod h1:nD32bomG/yYyqwTZQJFIhRhP++bbk+3oqlx+/RZZ6XY=
+go.opentelemetry.io/collector/exporter/nopexporter v0.108.0 h1:zgiD7XdMDPjGFOoSRnqgDX3yk+UCi1y8ahceufyQadM=
+go.opentelemetry.io/collector/exporter/nopexporter v0.108.0/go.mod h1:7lS/dsgHJIwp7qHvn5O5zOh6btfNl82yFUrJ1zb5olE=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.108.0 h1:QnfkiAZz9SyAxuzpKur+hrCNsfUjJBejWBQzvp8lejI=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.108.0/go.mod h1:JbP/ysqzLTFI4i0BAo+ykSdhDbq0LAbTYjGSpbruJSc=
 go.opentelemetry.io/collector/extension v0.108.1 h1:XNQ9bOegD38gktyLJXlGN2Wb6AbiBi2nAuiOIdg+zA0=
@@ -799,6 +801,8 @@ go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.108.0 h1:4eIMg
 go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.108.0/go.mod h1:bVGW/AR9/qV72YoSgaxVCSM8bJt1QII9Ua2ZGyBNHeU=
 go.opentelemetry.io/collector/receiver v0.108.1 h1:YQgDv69v3fgd6uoiGZ+vUdUPdNzoodbLzjB7XfdQvxs=
 go.opentelemetry.io/collector/receiver v0.108.1/go.mod h1:eKe/VJgdvHr8JsBDma/PF3DlaheTRC2X6AmCUByJCNU=
+go.opentelemetry.io/collector/receiver/nopreceiver v0.108.0 h1:t+cdmQoXIzRKjxTpyneV5Ok+RHrh1P28QYHjBEOcK6Y=
+go.opentelemetry.io/collector/receiver/nopreceiver v0.108.0/go.mod h1:luQPHxdk59Icw1pJotYdcxKyZDj/TYh+pzA7+rkv280=
 go.opentelemetry.io/collector/receiver/otlpreceiver v0.108.0 h1:SHQM1MsxshDStIF8WIh76B3fsVkw3TpAW+gWxefegzc=
 go.opentelemetry.io/collector/receiver/otlpreceiver v0.108.0/go.mod h1:VHom6BQVWOnCdR+iZRAkRbEspGqBOdfMcnC78HKMVAo=
 go.opentelemetry.io/collector/semconv v0.108.1 h1:Txk9tauUnamZaxS5vlf1O0uZ4VD6nioRBR0nX8L/fU4=


### PR DESCRIPTION
This adds the `nop` exporter and receiver to the list of allowed components used in configurations received through OPAmp. This is necessary because QE has such configurations in their tests and those were reported by the collector as being invalid.