### PR TITLE
fix(opamp): multiple fixes for opamp

### DIFF
--- a/otelcolbuilder/.otelcol-builder.yaml
+++ b/otelcolbuilder/.otelcol-builder.yaml
@@ -227,7 +227,6 @@ providers:
   - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.108.0
   - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.108.0
 
-
 excludes:
   - github.com/knadh/koanf v1.5.0
 
@@ -243,5 +242,6 @@ replaces:
   # version which gets then translated into a replace in go.mod file.
   # This does not replace the version that sumologicexporter depends on.
   - github.com/SumoLogic/sumologic-otel-collector/pkg/extension/opampextension => ../../pkg/extension/opampextension
+  - github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension v0.108.0 => github.com/SumoLogic/opentelemetry-collector-contrib/extension/sumologicextension bf012a09b9651cddda4a907ad4ff17834a0b81ef
   - github.com/SumoLogic/sumologic-otel-collector/pkg/configprovider/globprovider => ../../pkg/configprovider/globprovider
   - github.com/SumoLogic/sumologic-otel-collector/pkg/configprovider/opampprovider => ../../pkg/configprovider/opampprovider

--- a/pkg/extension/opampextension/opamp_agent_test.go
+++ b/pkg/extension/opampextension/opamp_agent_test.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	errMsgRemoteConfigNotAccepted = "OpAMP agent does not accept remote configuration"
-	errMsgInvalidConfigName       = "cannot validate config named " +
+	errMsgInvalidConfigName       = "cannot validate config: " +
 		"service::pipelines::logs/localfilesource/0aa79379-c764-4d3d-9d66-03f6df029a07: " +
 		"references processor \"batch\" which is not configured"
 	errMsgInvalidInterval = "'max_elapsed_time' must be non-negative"

--- a/pkg/tools/otelcol-config/remote_control.go
+++ b/pkg/tools/otelcol-config/remote_control.go
@@ -52,6 +52,16 @@ func makeNewSumologicRemoteYAML(ctx *actionContext, conf ConfDir) error {
 
 	var sumoRemoteConfig = map[string]any{
 		"extensions": map[string]any{
+			"file_storage": map[string]any{
+				"compaction": map[string]any{
+					"directory":  "/var/lib/otelcol-sumo/file_storage",
+					"on_rebound": true,
+				},
+				"directory": "/var/lib/otelcol-sumo/file_storage",
+			},
+			"health_check": map[string]any{
+				"endpoint": "localhost:13133",
+			},
 			"opamp": map[string]any{
 				"remote_configuration_directory": remoteConfigDir,
 				"endpoint":                       DefaultSumoLogicOpampEndpoint,
@@ -70,6 +80,8 @@ func makeNewSumologicRemoteYAML(ctx *actionContext, conf ConfDir) error {
 		"service": map[string]any{
 			"extensions": []string{
 				"sumologic",
+				"health_check",
+				"file_storage",
 				"opamp",
 			},
 			"pipelines": map[string]any{

--- a/pkg/tools/otelcol-config/remote_control_test.go
+++ b/pkg/tools/otelcol-config/remote_control_test.go
@@ -79,6 +79,13 @@ func TestEnableRemoteControlConfigFileNotPresent(t *testing.T) {
 	const expData = `exporters:
   nop: {}
 extensions:
+  file_storage:
+    compaction:
+      directory: /var/lib/otelcol-sumo/file_storage
+      on_rebound: true
+    directory: /var/lib/otelcol-sumo/file_storage
+  health_check:
+    endpoint: localhost:13133
   opamp:
     endpoint: wss://opamp-events.sumologic.com/v1/opamp
     remote_configuration_directory: /etc/otelcol-sumo/opamp.d
@@ -90,6 +97,8 @@ receivers:
 service:
   extensions:
     - sumologic
+    - health_check
+    - file_storage
     - opamp
   pipelines:
     logs/default:


### PR DESCRIPTION
* Uses new sumologicextension from our fork of opentelemetry-collector-contrib. This is necessary for now as the changes are not available on upstream and upstream is using a newer version of the collector.

* Updated the OpAmp agent to output the filename (includes the source template ID) when processing source templates.

* Added the `file_storage` and `health_check` extensions to the generated `sumologic-remote.yaml` config when using otelcol-config.