### PR TITLE
fix(opamp): update default opamp endpoint

### DIFF
--- a/.changelog/1709.fixed.txt
+++ b/.changelog/1709.fixed.txt
@@ -1,0 +1,1 @@
+fix(opamp): Update OpAmp default endpoint to a new one that supports redirection

--- a/examples/sumologic.yaml
+++ b/examples/sumologic.yaml
@@ -28,7 +28,7 @@ extensions:
   ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/extension/opampextension
   opamp:
     remote_configuration_directory: /etc/otelcol-sumo/opamp.d
-    endpoint: wss://opamp-events.sumologic.com/v1/opamp
+    endpoint: wss://opamp-collectors.sumologic.com/v1/opamp
 
 receivers:
   ## Configuration for OTLP Receiver

--- a/pkg/extension/opampextension/opamp_agent.go
+++ b/pkg/extension/opampextension/opamp_agent.go
@@ -44,7 +44,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension"
 )
 
-const DefaultSumoLogicOpAmpURL = "wss://opamp-events.sumologic.com/v1/opamp"
+const DefaultSumoLogicOpAmpURL = "wss://opamp-collectors.sumologic.com/v1/opamp"
 
 type opampAgent struct {
 	cfg    *Config

--- a/pkg/tools/otelcol-config/remote_control.go
+++ b/pkg/tools/otelcol-config/remote_control.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	DefaultSumoLogicOpampEndpoint       = "wss://opamp-events.sumologic.com/v1/opamp"
+	DefaultSumoLogicOpampEndpoint       = "wss://opamp-collectors.sumologic.com/v1/opamp"
 	DefaultConfigurationDirectory       = "/etc/otelcol-sumo"
 	DefaultRemoteConfigurationDirectory = "opamp.d"
 )

--- a/pkg/tools/otelcol-config/remote_control_test.go
+++ b/pkg/tools/otelcol-config/remote_control_test.go
@@ -87,7 +87,7 @@ extensions:
   health_check:
     endpoint: localhost:13133
   opamp:
-    endpoint: wss://opamp-events.sumologic.com/v1/opamp
+    endpoint: wss://opamp-collectors.sumologic.com/v1/opamp
     remote_configuration_directory: /etc/otelcol-sumo/opamp.d
   sumologic:
     collector_credentials_directory: /var/lib/otelcol-sumo/credentials


### PR DESCRIPTION
The OpAmp endpoint with redirection has been moved to a different URL. Updating it.