### PR TITLE
Bump sumologicextension

### DIFF
--- a/otelcolbuilder/.otelcol-builder.yaml
+++ b/otelcolbuilder/.otelcol-builder.yaml
@@ -242,6 +242,6 @@ replaces:
   # version which gets then translated into a replace in go.mod file.
   # This does not replace the version that sumologicexporter depends on.
   - github.com/SumoLogic/sumologic-otel-collector/pkg/extension/opampextension => ../../pkg/extension/opampextension
-  - github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension v0.108.0 => github.com/SumoLogic/opentelemetry-collector-contrib/extension/sumologicextension bf012a09b9651cddda4a907ad4ff17834a0b81ef
+  - github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension v0.108.0 => github.com/SumoLogic/opentelemetry-collector-contrib/extension/sumologicextension 6afd5814da3e09014683ab0e4a08f8f781bc904f
   - github.com/SumoLogic/sumologic-otel-collector/pkg/configprovider/globprovider => ../../pkg/configprovider/globprovider
   - github.com/SumoLogic/sumologic-otel-collector/pkg/configprovider/opampprovider => ../../pkg/configprovider/opampprovider


### PR DESCRIPTION
Bumps sumologicextension to the latest commit in our fork which includes a fix for version conversion ƒor fips builds.