### PR TITLE
Build otelcol-config statically

### DIFF
--- a/.github/workflows/workflow-build-otelcol-config.yml
+++ b/.github/workflows/workflow-build-otelcol-config.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           echo "cache-key=go-build-${{ env.GO_VERSION }}-otelcol-config${FIPS_SUFFIX}-${{inputs.arch_os}}-${{ hashFiles('pkg/tools/otelcol-config/go.sum') }}" >> $GITHUB_OUTPUT
           echo "restore-keys=go-build-${{ env.GO_VERSION }}-otelcol-config${FIPS_SUFFIX}-${{inputs.arch_os}}-" >> $GITHUB_OUTPUT
-          echo "toolchain-cache-key=toolchain-${{inputs.arch_os}}-${{ hashFiles('pkg/tools/otelcol-config/build-fips/config.mak', 'pkg/tools/otelcol-config/build-fips/Makefile') }}" >> $GITHUB_OUTPUT
+          echo "toolchain-cache-key=toolchain-${{inputs.arch_os}}-${{ hashFiles('toolchains/config.mak', 'toolchains/Makefile') }}" >> $GITHUB_OUTPUT
 
       - uses: actions/cache/restore@v4
         with:
@@ -77,7 +77,7 @@ jobs:
             ${{ steps.get-cache-key.outputs.restore-keys }}
 
       - name: Build
-        if: '! inputs.fips'
+        if: "! inputs.fips"
         run: make otelcol-config-${{inputs.arch_os}}
         working-directory: ./pkg/tools/otelcol-config
 
@@ -93,19 +93,6 @@ jobs:
         id: rebuild-toolchain
         if: ${{ steps.restore-toolchain-cache.outcome == 'success' && steps.restore-toolchain-cache.outputs.cache-hit != 'true' }}
         run: make toolchain-${{ inputs.arch_os }} OUTPUT=/opt/toolchain -j3
-        working-directory: ./toolchains
-
-      - name: Build (FIPS)
-        if: inputs.fips && contains(inputs.arch_os, 'linux')
-        run: |
-          CC=$(find /opt/toolchain/bin -type f -name "*-linux-musl-gcc")
-          test "$CC"
-          echo "Using toolchain: $CC"
-          make otelcol-config-${{inputs.arch_os}} \
-            FIPS_SUFFIX="-fips" \
-            CGO_ENABLED="1" \
-            CC="$CC" \
-            EXTRA_LDFLAGS="-linkmode external -extldflags '-static'"
         working-directory: ./pkg/tools/otelcol-config
 
       - name: Build (FIPS)
@@ -118,12 +105,23 @@ jobs:
             FIPS_SUFFIX="-fips" \
             CGO_ENABLED="1" \
             CC="$CC" \
-            EXTRA_LDFLAGS="-linkmode external -extldflags '-static'"
+            LDFLAGS="-linkmode external -extldflags '-static'"
         working-directory: ./pkg/tools/otelcol-config
 
       - name: Set binary name
         id: set-binary-name
         run: echo "binary_name=otelcol-config${FIPS_SUFFIX}-${{inputs.arch_os}}" >> $GITHUB_OUTPUT
+
+      - name: Show file info
+        working-directory: ./pkg/tools/otelcol-config
+        run: |
+          file ${{ steps.set-binary-name.outputs.binary_name }}
+
+      - name: Show ldd info
+        if: contains(inputs.arch_os, 'linux')
+        working-directory: ./pkg/tools/otelcol-config
+        run: |
+          ldd ${{ steps.set-binary-name.outputs.binary_name }} || true
 
       - name: Show BoringSSL symbols
         if: inputs.fips && contains(inputs.arch_os, 'linux')

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Determine if Windows package should be signed
         if: runner.os == 'Windows'
         env:
-          WINDOWS_CERTIFICATE: '${{ secrets.microsoft_certificate }}'
+          WINDOWS_CERTIFICATE: "${{ secrets.microsoft_certificate }}"
         run: |
           if [ -n "${WINDOWS_CERTIFICATE}" ]; then
               echo "WINDOWS_SIGNING_ENABLED=true" >> $GITHUB_ENV
@@ -134,7 +134,7 @@ jobs:
         working-directory: ./otelcolbuilder
 
       - name: Build
-        if: '! inputs.fips'
+        if: "! inputs.fips"
         run: make otelcol-sumo-${{inputs.arch_os}}
         working-directory: ./otelcolbuilder
 
@@ -173,6 +173,17 @@ jobs:
       - name: Set binary name
         id: set-binary-name
         run: echo "binary_name=otelcol-sumo${OTELCOL_FIPS_SUFFIX}-${{inputs.arch_os}}${OTELCOL_BINARY_EXTENSION}" >> $GITHUB_OUTPUT
+
+      - name: Show file info
+        working-directory: ./otelcolbuilder/cmd
+        run: |
+          file ${{ steps.set-binary-name.outputs.binary_name }}
+
+      - name: Show ldd info
+        if: contains(inputs.arch_os, 'linux')
+        working-directory: ./otelcolbuilder/cmd
+        run: |
+          ldd ${{ steps.set-binary-name.outputs.binary_name }} || true
 
       - name: Show BoringSSL symbols
         if: inputs.fips && contains(inputs.arch_os, 'linux')
@@ -216,11 +227,11 @@ jobs:
         if: runner.os == 'Windows' && env.WINDOWS_SIGNING_ENABLED == 'true'
         uses: skymatic/code-sign-action@v3
         with:
-          certificate: '${{ secrets.microsoft_certificate }}'
-          password: '${{ secrets.microsoft_certificate_password }}'
-          certificatesha1: '${{ secrets.microsoft_certificate_hash }}'
-          certificatename: '${{ secrets.microsoft_certificate_name }}'
-          description: '${{ secrets.microsoft_description }}'
+          certificate: "${{ secrets.microsoft_certificate }}"
+          password: "${{ secrets.microsoft_certificate_password }}"
+          certificatesha1: "${{ secrets.microsoft_certificate_hash }}"
+          certificatename: "${{ secrets.microsoft_certificate_name }}"
+          description: "${{ secrets.microsoft_description }}"
           folder: ./otelcolbuilder/cmd
 
       - name: Test binary

--- a/pkg/tools/otelcol-config/Makefile
+++ b/pkg/tools/otelcol-config/Makefile
@@ -9,6 +9,8 @@ GO ?= go
 OS ?= $(shell uname -s | tr A-Z a-z)
 ARCH ?= $(shell uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)
 
+FIPS_SUFFIX ?= ""
+
 # Builds for darwin need to be built with CGO_ENABLED set to 1 because some telegraf
 # plugins that are used within the telegrafreceiver are implemented with CGO.
 # Example of this might be the cpu input plugin using gopsutil to the cpu stats.


### PR DESCRIPTION
The otelcol-config binary is supposed to be built statically but was not due to a bug. This PR fixes the bug along with a few other issues around building / caching otelcol-config that I noticed.