### PR TITLE
chore: New release candidate for 0.118.0-sumo-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.118.0-sumo-1]
 
-### Released 2025-03-18
-
 ### Fixed
 
-- fix(version): Fix the collector version [#1738]
+- fix(version): Fix the collector version reported to SumoLogic [#1743]
 
-[#1738]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1738
+[#1743]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1743
 [v0.118.0-sumo-1]: https://github.com/SumoLogic/sumologic-otel-collector/releases/v0.118.0-sumo-1
 
 ## [v0.118.0-sumo-0]

--- a/otelcolbuilder/.otelcol-builder.yaml
+++ b/otelcolbuilder/.otelcol-builder.yaml
@@ -220,7 +220,7 @@ replaces:
   # version which gets then translated into a replace in go.mod file.
   # This does not replace the version that sumologicexporter depends on.
   - github.com/SumoLogic/sumologic-otel-collector/pkg/extension/opampextension => ../../pkg/extension/opampextension
-  - github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension v0.118.0 => github.com/SumoLogic/opentelemetry-collector-contrib/extension/sumologicextension f0c5bb5bac63056954a5387222a776a85696c9c0
+  - github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension v0.118.0 => github.com/SumoLogic/opentelemetry-collector-contrib/extension/sumologicextension f45c0be5c566abb6aeefd7cab10a31e1684dca4f
   - github.com/SumoLogic/sumologic-otel-collector/pkg/configprovider/globprovider => ../../pkg/configprovider/globprovider
   - github.com/SumoLogic/sumologic-otel-collector/pkg/configprovider/opampprovider => ../../pkg/configprovider/opampprovider
   - github.com/SumoLogic/sumologic-otel-collector/pkg/configprovider/providerutil => ../../pkg/configprovider/providerutil


### PR DESCRIPTION
New release candidate for 0.118.0-sumo-1

Added the version sanitization commit to v118 - https://github.com/SumoLogic/opentelemetry-collector-contrib/commits/build-number-fix-v0_118
