### PR TITLE
chore: Removing v0.118.0-sumo-1 from the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes -->
 
-## [v0.118.0-sumo-1]
-
-### Fixed
-
-- fix(version): Fix the collector version reported to SumoLogic [#1744]
-
-[#1744]: https://github.com/SumoLogic/sumologic-otel-collector/pull/1743
-[v0.118.0-sumo-1]: https://github.com/SumoLogic/sumologic-otel-collector/releases/v0.118.0-sumo-1
-
 ## [v0.118.0-sumo-0]
 
 ### Changed


### PR DESCRIPTION
Removing v0.118.0-sumo-1 from the changelog as we don't need a patch, the version reported in v0.118.0-sumo-0 is correct.