### PR TITLE
chore(ci): create pkg tags after release publish

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,33 @@
+name: "Post release tasks"
+
+run-name: >
+  ${{ format('Post Release Tasks for Release: {0}', github.ref_name) }}
+
+on:
+  release:
+    types: [released]
+
+permissions:
+  contents: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  create-pkg-tags:
+    name: Create package tags
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: "${{github.ref_name}}"
+
+      - name: Create & push package tags
+        run: |
+          for dir in $(find ./pkg -type f -name "go.mod" ! -path "*pkg/test/*" -exec dirname {} \; | sort); do
+            tag_name="${dir:2}/${{github.ref_name}}";
+            echo "Creating tag for: ${tag_name}";
+            git tag -a "${tag_name}" -s -m "${tag_name}" "${{github.ref_name}}";
+            git push origin "${tag_name}"
+          done


### PR DESCRIPTION
As a part of the release process, we used to create tags for each of the exportable packages under the `pkgs` directory. This was lost when we switched to the new release workflow. This PR adds a new `post-release` workflow to reimplement the creation of these tags. It will create and push tags automatically when a release is published. (e.g. draft -> published)

**NOTE** I've done some rudimentary testing but I don't think we can know if this will work until the next release.