### PR TITLE
chore(ci): use ubuntu-24.04 runners

### DIFF
--- a/.github/workflows/_get-version-workflow.yml
+++ b/.github/workflows/_get-version-workflow.yml
@@ -14,7 +14,7 @@ defaults:
 jobs:
   get-version:
     name: Get application version for this revision
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.get-version.outputs.version }}
     steps:

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -13,7 +13,7 @@ on:
       - main
 jobs:
   changelog:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-changelog')"
     env:
       PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/close-jira-task.yaml
+++ b/.github/workflows/close-jira-task.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   close-jira-issue:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Close Jira task
         id: close-jira-task

--- a/.github/workflows/create-jira-task.yml
+++ b/.github/workflows/create-jira-task.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   create-jira-issue:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Create Jira task
         id: create-jira-task

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -18,7 +18,7 @@ jobs:
   # https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
   lint:
     name: Lint (staticcheck)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         arch_os: ["linux_amd64"]
@@ -69,9 +69,9 @@ jobs:
       matrix:
         include:
           - arch_os: linux_amd64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
           - arch_os: linux_amd64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
             boringcrypto: true
           - arch_os: darwin_amd64
             runs-on: macos-15
@@ -90,9 +90,9 @@ jobs:
       matrix:
         include:
           - arch_os: linux_amd64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
           - arch_os: linux_amd64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
             boringcrypto: true
           - arch_os: darwin_amd64
             runs-on: macos-15
@@ -115,14 +115,14 @@ jobs:
       matrix:
         include:
           - arch_os: linux_amd64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
           - arch_os: linux_amd64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
             fips: true
           - arch_os: linux_arm64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
           - arch_os: linux_arm64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
             fips: true
           - arch_os: darwin_amd64
             runs-on: macos-15
@@ -162,14 +162,14 @@ jobs:
           - arch_os: darwin_arm64
             runs-on: macos-15
           - arch_os: linux_amd64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
           - arch_os: linux_amd64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
             fips: true
           - arch_os: linux_arm64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
           - arch_os: linux_arm64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
             fips: true
     with:
       arch_os: ${{ matrix.arch_os }}
@@ -184,7 +184,7 @@ jobs:
 
   build-container-images:
     name: Build container
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - build
       - get-version
@@ -350,7 +350,7 @@ jobs:
 
   push-docker-manifest:
     name: Push joint container manifest
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - build-container-images
       - build-windows-container-images
@@ -453,7 +453,7 @@ jobs:
   # collector workflow run specified for a release.
   install-script:
     name: Store install script
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -475,7 +475,7 @@ jobs:
 
   config-management-assets:
     name: Store Chef cookbook, Puppet module, and Ansible playbook
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pr_labeler.yaml
+++ b/.github/workflows/pr_labeler.yaml
@@ -5,9 +5,9 @@ on:
 
 jobs:
   triage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/labeler@v5
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: true
+      - uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -3,7 +3,7 @@ name: PRs checks
 on:
   pull_request:
     branches:
-      - '**'
+      - "**"
 
 defaults:
   run:
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build-changed:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       any_changed: ${{ steps.changed-files.outputs.any_changed }}
     steps:
@@ -34,7 +34,7 @@ jobs:
             **/Dockerfile*
 
   markdownlint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Check if related files changed
@@ -53,7 +53,7 @@ jobs:
         run: make markdownlint
 
   yamllint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Install yamllint
@@ -62,7 +62,7 @@ jobs:
         run: make yamllint
 
   markdown-link-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Check if related files changed
@@ -74,13 +74,13 @@ jobs:
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         if: steps.changed-files.outputs.any_changed == 'true'
         with:
-          config-file: '.markdown_link_check.json'
+          config-file: ".markdown_link_check.json"
           use-quiet-mode: yes
           check-modified-files-only: yes
           base-branch: ${{ github.base_ref }}
 
   md-links-lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Check if related files changed
@@ -95,7 +95,7 @@ jobs:
           make markdown-links-lint
 
   plugins-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Install yq
@@ -105,7 +105,7 @@ jobs:
         run: ./ci/plugins_check.sh
 
   pre-commit-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -113,7 +113,7 @@ jobs:
 
   check-uniform-dependencies:
     name: Check uniform dependencies
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -121,15 +121,15 @@ jobs:
         run: make check-uniform-dependencies
 
   shellcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       SHELLCHECK_VERSION: 0.10.0
     steps:
       - uses: actions/checkout@v4
       - name: install shellcheck
         run: |
-            curl --retry 10 --retry-max-time 120 --retry-delay 5 -Lo- https://github.com/koalaman/shellcheck/releases/download/v${{ env.SHELLCHECK_VERSION }}/shellcheck-v${{ env.SHELLCHECK_VERSION }}.linux.x86_64.tar.xz | tar -xJf -
-            sudo cp shellcheck-v${{ env.SHELLCHECK_VERSION }}/shellcheck /usr/local/bin && rm -rf shellcheck-v${{ env.SHELLCHECK_VERSION }}
+          curl --retry 10 --retry-max-time 120 --retry-delay 5 -Lo- https://github.com/koalaman/shellcheck/releases/download/v${{ env.SHELLCHECK_VERSION }}/shellcheck-v${{ env.SHELLCHECK_VERSION }}.linux.x86_64.tar.xz | tar -xJf -
+          sudo cp shellcheck-v${{ env.SHELLCHECK_VERSION }}/shellcheck /usr/local/bin && rm -rf shellcheck-v${{ env.SHELLCHECK_VERSION }}
       - name: shellcheck
         run: make shellcheck
 
@@ -143,9 +143,9 @@ jobs:
       matrix:
         include:
           - arch_os: linux_amd64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
           - arch_os: linux_amd64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
             boringcrypto: true
           - arch_os: darwin_arm64
             runs-on: macos-15
@@ -163,9 +163,9 @@ jobs:
       matrix:
         include:
           - arch_os: linux_amd64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
           - arch_os: linux_amd64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
             boringcrypto: true
           - arch_os: darwin_amd64
             runs-on: macos-15
@@ -177,12 +177,12 @@ jobs:
 
   lint:
     name: Lint (staticcheck)
-    runs-on: ubuntu-20.04
-    needs: [ build-changed ]
+    runs-on: ubuntu-24.04
+    needs: [build-changed]
     if: needs.build-changed.outputs.any_changed == 'true'
     strategy:
       matrix:
-        arch_os: [ 'linux_amd64' ]
+        arch_os: ["linux_amd64"]
     steps:
       - uses: actions/checkout@v4
 
@@ -235,12 +235,12 @@ jobs:
       matrix:
         include:
           - arch_os: linux_amd64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
           - arch_os: linux_amd64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
             fips: true
           - arch_os: linux_arm64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
           - arch_os: darwin_amd64
             runs-on: macos-15
           - arch_os: darwin_arm64
@@ -277,14 +277,14 @@ jobs:
           - arch_os: darwin_arm64
             runs-on: macos-15
           - arch_os: linux_amd64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
           - arch_os: linux_amd64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
             fips: true
           - arch_os: linux_arm64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
           - arch_os: linux_arm64
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
             fips: true
     with:
       arch_os: ${{ matrix.arch_os }}
@@ -298,14 +298,14 @@ jobs:
 
   build-and-test-container-images:
     name: Build container
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - build-changed
       - build
     if: needs.build-changed.outputs.any_changed == 'true'
     strategy:
       matrix:
-        arch_os: [ 'linux_amd64', 'linux_arm64']
+        arch_os: ["linux_amd64", "linux_arm64"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -20,7 +20,7 @@ defaults:
 jobs:
   get-version:
     name: Get application version for this revision
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       sha: ${{ steps.get-sha.outputs.git-sha }}
       otc-version: ${{ steps.get-version.outputs.otc-version }}
@@ -78,7 +78,7 @@ jobs:
 
   build-container-images:
     name: Build container
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - get-version
     strategy:
@@ -193,7 +193,7 @@ jobs:
 
   push-docker-manifest:
     name: Push joint container manifest
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       # Require darwin build to succeed to prevent pushing container images
       # when darwin build fails.
@@ -284,7 +284,7 @@ jobs:
 
   create-release:
     name: Create Github release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - get-version
       - build-container-images

--- a/.github/workflows/workflow-build-otelcol-config.yml
+++ b/.github/workflows/workflow-build-otelcol-config.yml
@@ -16,7 +16,7 @@ on:
         default: false
         type: boolean
       runs-on:
-        default: ubuntu-20.04
+        default: ubuntu-24.04
         type: string
       save-cache:
         description: Save the module and build caches.

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -16,7 +16,7 @@ on:
         default: false
         type: boolean
       runs-on:
-        default: ubuntu-20.04
+        default: ubuntu-24.04
         type: string
       save-cache:
         description: Save the module and build caches.

--- a/.github/workflows/workflow-test-otelcol-config.yml
+++ b/.github/workflows/workflow-test-otelcol-config.yml
@@ -12,7 +12,7 @@ on:
         default: false
         type: boolean
       runs-on:
-        default: ubuntu-20.04
+        default: ubuntu-24.04
         type: string
       only-if-changed:
         description: Run only if relevant files changed.

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -12,7 +12,7 @@ on:
         default: false
         type: boolean
       runs-on:
-        default: ubuntu-20.04
+        default: ubuntu-24.04
         type: string
       only-if-changed:
         description: Run only if relevant files changed.

--- a/.github/workflows/workflow-trigger-packaging.yml
+++ b/.github/workflows/workflow-trigger-packaging.yml
@@ -18,7 +18,7 @@ jobs:
   # to download after all jobs have completed.
   trigger-packaging:
     name: Trigger Packaging
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # TODO: output the workflow url
       - name: Trigger packaging workflow


### PR DESCRIPTION
The Ubuntu 20.04 runners will stop functioning in less than two weeks. These changes pin our runners to Ubuntu 24.04.