### PR TITLE
fix(ci): add ref name input to post-release

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,12 +1,18 @@
 name: "Post release tasks"
 
 run-name: >
-  ${{ format('Post Release Tasks for Release: {0}', github.ref_name) }}
+  ${{ format('Post Release Tasks for Release: {0}', inputs.ref_name || github.ref_name) }}
 
 on:
   release:
     types: [released]
   workflow_dispatch:
+    inputs:
+      ref_name:
+        description: |
+          The ref name (e.g. tag name) that should be used as a trigger for this workflow.
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -19,21 +25,23 @@ jobs:
   create-pkg-tags:
     name: Create package tags
     runs-on: ubuntu-24.04
+    env:
+      REF_NAME: ${{ inputs.ref_name || github.ref_name }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: "${{github.ref_name}}"
+          ref: "${{ env.REF_NAME }}"
 
       - name: Set Git user name & email
         run: |
-          git config --global user.email "opensource-collection-team@sumologic.com"
-          git config --global user.name "Sumo Logic Open Source Collection"
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "github-actions"
 
       - name: Create & push package tags
         run: |
           for dir in $(find ./pkg -type f -name "go.mod" ! -path "*pkg/test/*" -exec dirname {} \; | sort); do
-            tag_name="${dir:2}/${{github.ref_name}}";
+            tag_name="${dir:2}/${REF_NAME}";
             echo "Creating tag for: ${tag_name}";
-            git tag -a "${tag_name}" -s -m "${tag_name}" "${{github.ref_name}}";
+            git tag -a "${tag_name}" -m "${tag_name}" "${REF_NAME}";
             git push origin "${tag_name}"
           done


### PR DESCRIPTION
PR #1766 added the ability to manually trigger the `post-release` workflow but it only allows for specifying which ref to use when reading the workflow definition & repository contents. This prevents us from manually triggering the workflow using a newer workflow definition in cases where the workflow definition for a tag could be broken.

This commit adds a new `ref_name` input to allow specifying which tag to run the `post-release` workflow for.

I have tested this by manually triggering the workflow using `fix-release-workflow` as the branch and `v0.124.1-sumo-0` as the ref_name. Results: https://github.com/SumoLogic/sumologic-otel-collector/actions/runs/15333425664/job/43145406864