### PR TITLE
Sumo 262874

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ Thumbs.db
 
 # 1Password
 .op/
+
+.idea

--- a/pkg/extension/sumologicextension/go.mod
+++ b/pkg/extension/sumologicextension/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension v0.124.1
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status v0.124.1
 	github.com/shirou/gopsutil/v3 v3.24.4
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.30.0

--- a/pkg/extension/sumologicextension/go.sum
+++ b/pkg/extension/sumologicextension/go.sum
@@ -67,6 +67,7 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension v0.124.1 h1:EOWN8UDLVxisYfjaz66cgcFR4SF0BfEBFE6lrECQGGU=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension v0.124.1/go.mod h1:vPFPau/fW9Mc78UEbDdpsjuFiHFyaZVLu8zT0BfK/Gw=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status v0.124.1/go.mod h1:RDou18f13EnC+TDHQEvNunf2RnFCf2TTRvBOo+eGWwE=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
1. adding health event loop in sumologic extension
2. currently it collect components health event in a map and prints it in console
3. inspiration: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35892/files 
4. **todo**: move these changes to contrib repo and release sumologicextension version after local testing



**Local Run Logs**

health event is  {
  "Healthy": true,
  "Status": "StatusOK",
  "StatusTimeUnixNano": 1748951206594106000,
  "componentHealth": {
    "extensions": {
      "Healthy": true,
      "Status": "StatusOK",
      "StatusTimeUnixNano": 1748951206582042000,
      "componentHealth": {
        "extension:file_storage": {
          "Healthy": true,
          "Status": "StatusOK",
          "StatusTimeUnixNano": 1748951183447919000
        },
        "extension:health_check": {
          "Healthy": true,
          "Status": "StatusOK",
          "StatusTimeUnixNano": 1748951183450551000
        },
        "extension:sumologic": {
          "Healthy": true,
          "Status": "StatusOK",
          "StatusTimeUnixNano": 1748951206582042000
        }
      }
    },
    "pipeline:logs/default": {
      "Healthy": true,
      "Status": "StatusOK",
      "StatusTimeUnixNano": 1748951206594021000,
      "componentHealth": {
        "exporter:sumologic": {
          "Healthy": true,
          "Status": "StatusOK",
          "StatusTimeUnixNano": 1748951206593664000
        },
        "processor:batch": {
          "Healthy": true,
          "Status": "StatusOK",
          "StatusTimeUnixNano": 1748951206593934000
        },
        "processor:memory_limiter": {
          "Healthy": true,
          "Status": "StatusOK",
          "StatusTimeUnixNano": 1748951206593971000
        },
        "processor:sumologic": {
          "Healthy": true,
          "Status": "StatusOK",
          "StatusTimeUnixNano": 1748951206593798000
        },
        "receiver:otlp": {
          "Healthy": true,
          "Status": "StatusOK",
          "StatusTimeUnixNano": 1748951206594021000
        }
      }
    },
    "pipeline:metrics/default": {
      "Healthy": true,
      "Status": "StatusOK",
      "StatusTimeUnixNano": 1748951206594106000,
      "componentHealth": {
        "exporter:sumologic": {
          "Healthy": true,
          "Status": "StatusOK",
          "StatusTimeUnixNano": 1748951206585899000
        },
        "processor:batch": {
          "Healthy": true,
          "Status": "StatusOK",
          "StatusTimeUnixNano": 1748951206586429000
        },
        "processor:memory_limiter": {
          "Healthy": true,
          "Status": "StatusOK",
          "StatusTimeUnixNano": 1748951206594073000
        },
        "processor:sumologic": {
          "Healthy": true,
          "Status": "StatusOK",
          "StatusTimeUnixNano": 1748951206586266000
        },
        "receiver:otlp": {
          "Healthy": true,
          "Status": "StatusOK",
          "StatusTimeUnixNano": 1748951206594106000
        }
      }
    },
    "pipeline:traces/default": {
      "Healthy": true,
      "Status": "StatusOK",
      "StatusTimeUnixNano": 1748951206591616000,
      "componentHealth": {
        "exporter:sumologic": {
          "Healthy": true,
          "Status": "StatusOK",
          "StatusTimeUnixNano": 1748951206588488000
        },
        "processor:batch": {
          "Healthy": true,
          "Status": "StatusOK",
          "StatusTimeUnixNano": 1748951206588710000
        },
        "processor:memory_limiter": {
          "Healthy": true,
          "Status": "StatusOK",
          "StatusTimeUnixNano": 1748951206588749000
        },
        "processor:sumologic": {
          "Healthy": true,
          "Status": "StatusOK",
          "StatusTimeUnixNano": 1748951206588647000
        },
        "receiver:otlp": {
          "Healthy": true,
          "Status": "StatusOK",
          "StatusTimeUnixNano": 1748951206591616000
        }
      }
    }
  }
}
2025-06-03T17:16:46.593+0530	info	queuebatch/persistent_queue.go:157	Initializing new persistent queue
2025-06-03T17:16:46.593+0530	info	sumologicprocessor@v0.124.0/processor.go:72	Sumo Logic Processor has started.	{"add_cloud_namespace": true, "translate_attributes": true, "translate_telegraf_attributes": true, "nest_attributes": false, "aggregate_attributes": false, "field_attributes": false, "translate_docker_metrics": false}
2025-06-03T17:16:46.594+0530	info	healthcheck/handler.go:132	Health Check state change	{"status": "ready"}
2025-06-03T17:16:46.594+0530	info	sumologicextension/extension.go:1126	read!!!!!!!!!	{"collector_name": "prod-www-2105927136.us-east-1.elb.amazonaws.com", "collector_id": "00005AF3107A4001"}
2025-06-03T17:16:46.594+0530	info	sumologicextension/extension.go:1128	read22222222!!!!!!!!!	{"collector_name": "prod-www-2105927136.us-east-1.elb.amazonaws.com", "collector_id": "00005AF3107A4001"}
2025-06-03T17:16:46.594+0530	info	service@v0.124.0/service.go:289	**Everything is ready. Begin running and processing data.**
2025-06-03T17:16:46.594+0530


**shutdown logs**

2025-06-03T17:17:32.277+0530	info	sumologicextension/extension.go:1229	stopping component health event loop, closeChan stopped	{"collector_name": "prod-www-2105927136.us-east-1.elb.amazonaws.com", "collector_id": "00005AF3107A4001"}
2025-06-03T17:17:32.277+0530	info	sumologicextension/extension.go:1190	componentHealthEventLoop finished	{"collector_name": "prod-www-2105927136.us-east-1.elb.amazonaws.com", "collector_id": "00005AF3107A4001"}
2025-06-03T17:17:32.277+0530	info	sumologicextension/extension.go:609	Heartbeat sender turned off	{"collector_name": "prod-www-2105927136.us-east-1.elb.amazonaws.com", "collector_id": "00005AF3107A4001"}
2025-06-03T17:17:32.277+0530	info	sumologicextension/extension.go:1164	stopping health aggregator event loop	{"collector_name": "prod-www-2105927136.us-east-1.elb.amazonaws.com", "collector_id": "00005AF3107A4001"}
2025-06-03T17:17:32.277+0530	info	sumologicextension/extension.go:1158	unsubscribed from health event aggregator	{"collector_name": "prod-www-2105927136.us-east-1.elb.amazonaws.com", "collector_id": "00005AF3107A4001"}
2025-06-03T17:17:32.277+0530	info	sumologicextension/extension.go:1115	discarding event received after shutdown	{"collector_name": "prod-www-2105927136.us-east-1.elb.amazonaws.com", "collector_id": "00005AF3107A4001", "source": {}, "event": {}}
2025-06-03T17:17:32.277+0530	info	sumologicextension/extension.go:1115	discarding event received after shutdown	{"collector_name": "prod-www-2105927136.us-east-1.elb.amazonaws.com", "collector_id": "00005AF3107A4001", "source": {}, "event": {}}
2025-06-03T17:17:32.277+0530	info	sumologicextension/extension.go:1115	discarding event received after shutdown	{"collector_name": "prod-www-2105927136.us-east-1.elb.amazonaws.com", "collector_id": "00005AF3107A4001", "source": {}, "event": {}}
2025-06-03T17:17:32.277+0530	info	sumologicextension/extension.go:1115	discarding event received after shutdown	{"collector_name": "prod-www-2105927136.us-east-1.elb.amazonaws.com", "collector_id": "00005AF3107A4001", "source": {}, "event": {}}
2025-06-03T17:17:32.277+0530	info	sumologicextension/extension.go:1115	discarding event received after shutdown	{"collector_name": "prod-www-2105927136.us-east-1.elb.amazonaws.com", "collector_id": "00005AF3107A4001", "source": {}, "event": {}}
2025-06-03T17:17:32.277+0530	info	service@v0.124.0/service.go:345	Shutdown complete.


health event is  {
  "Healthy": false,
  "Status": "StatusStopping",
  "StatusTimeUnixNano": 1748951252277083000,
  "componentHealth": {
    "extensions": {
      "Healthy": false,
      "Status": "StatusStopping",
      "StatusTimeUnixNano": 1748951252277083000,
      "componentHealth": {
        "extension:file_storage": {
          "Healthy": true,
          "Status": "StatusOK",
          "StatusTimeUnixNano": 1748951183447919000
        },
        "extension:health_check": {
          "Healthy": true,
          "Status": "StatusOK",
          "StatusTimeUnixNano": 1748951183450551000
        },
        "extension:sumologic": {
          "Healthy": false,
          "Status": "StatusStopping",
          "StatusTimeUnixNano": 1748951252277083000
        }
      }
    },
    "pipeline:logs/default": {
      "Healthy": false,
      "Status": "StatusStopped",
      "StatusTimeUnixNano": 1748951252277063000,
      "componentHealth": {
        "exporter:sumologic": {
          "Healthy": false,
          "Status": "StatusStopped",
          "StatusTimeUnixNano": 1748951252277063000
        },
        "processor:batch": {
          "Healthy": false,
          "Status": "StatusStopped",
          "StatusTimeUnixNano": 1748951252276843000
        },
        "processor:memory_limiter": {
          "Healthy": false,
          "Status": "StatusStopped",
          "StatusTimeUnixNano": 1748951252276807000
        },
        "processor:sumologic": {
          "Healthy": false,
          "Status": "StatusStopped",
          "StatusTimeUnixNano": 1748951252276883000
        },
        "receiver:otlp": {
          "Healthy": false,
          "Status": "StatusStopped",
          "StatusTimeUnixNano": 1748951252275252000
        }
      }
    },
    "pipeline:metrics/default": {
      "Healthy": false,
      "Status": "StatusStopped",
      "StatusTimeUnixNano": 1748951252276768000,
      "componentHealth": {
        "exporter:sumologic": {
          "Healthy": false,
          "Status": "StatusStopped",
          "StatusTimeUnixNano": 1748951252276768000
        },
        "processor:batch": {
          "Healthy": false,
          "Status": "StatusStopped",
          "StatusTimeUnixNano": 1748951252276269000
        },
        "processor:memory_limiter": {
          "Healthy": false,
          "Status": "StatusStopped",
          "StatusTimeUnixNano": 1748951252276210000
        },
        "processor:sumologic": {
          "Healthy": false,
          "Status": "StatusStopped",
          "StatusTimeUnixNano": 1748951252276357000
        },
        "receiver:otlp": {
          "Healthy": false,
          "Status": "StatusStopped",
          "StatusTimeUnixNano": 1748951252275252000
        }
      }
    },
    "pipeline:traces/default": {
      "Healthy": false,
      "Status": "StatusStopped",
      "StatusTimeUnixNano": 1748951252276131000,
      "componentHealth": {
        "exporter:sumologic": {
          "Healthy": false,
          "Status": "StatusStopped",
          "StatusTimeUnixNano": 1748951252276131000
        },
        "processor:batch": {
          "Healthy": false,
          "Status": "StatusStopped",
          "StatusTimeUnixNano": 1748951252275491000
        },
        "processor:memory_limiter": {
          "Healthy": false,
          "Status": "StatusStopped",
          "StatusTimeUnixNano": 1748951252275380000
        },
        "processor:sumologic": {
          "Healthy": false,
          "Status": "StatusStopped",
          "StatusTimeUnixNano": 1748951252275786000
        },
        "receiver:otlp": {
          "Healthy": false,
          "Status": "StatusStopped",
          "StatusTimeUnixNano": 1748951252275252000
        }
      }
    }
  }
}


