### PR TITLE
Removing stanza decode package

### DIFF
--- a/pkg/receiver/jobreceiver/go.mod
+++ b/pkg/receiver/jobreceiver/go.mod
@@ -16,6 +16,7 @@ require (
 	go.opentelemetry.io/collector/receiver v1.33.0
 	go.opentelemetry.io/collector/receiver/receivertest v0.127.0
 	go.uber.org/zap v1.27.0
+	golang.org/x/text v0.25.0
 	gopkg.in/h2non/filetype.v1 v1.0.5
 )
 
@@ -86,7 +87,6 @@ require (
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
 	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
-	golang.org/x/text v0.25.0 // indirect
 	gonum.org/v1/gonum v0.16.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a // indirect
 	google.golang.org/grpc v1.72.1 // indirect

--- a/pkg/receiver/jobreceiver/output/logentries/utf8raw.go
+++ b/pkg/receiver/jobreceiver/output/logentries/utf8raw.go
@@ -1,0 +1,20 @@
+package logentries
+
+import (
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/transform"
+)
+
+// UTF8Raw is a variant of the UTF-8 encoding without replacing invalid UTF-8 sequences.
+// It behaves in the same way as [encoding.Nop], but is differentiated from nop encoding, which we treat in a special way.
+var UTF8Raw encoding.Encoding = utf8raw{}
+
+type utf8raw struct{}
+
+func (utf8raw) NewDecoder() *encoding.Decoder {
+	return &encoding.Decoder{Transformer: transform.Nop}
+}
+
+func (utf8raw) NewEncoder() *encoding.Encoder {
+	return &encoding.Encoder{Transformer: transform.Nop}
+}


### PR DESCRIPTION
in v0.129.0 contrib release stanza/decode is removed and move to internal package in textutils. as internal package cannot be used outside replicated required method

removing pr: https://github.com/open-telemetry/opentelemetry-collector/pull/13071/files#diff-1c4cd801df522f4a92edbfb0fea95364ed074a391ea47c284ddc078f512f7b6a

Breaking change in 0.129
https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.129.0

textutils: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/ff61b386f62d4e26f57d2517264686b1552b7252/internal/coreinternal/textutils/encoding.go#L4

