### PR TITLE
chore(CI): remove windows-2019 runner

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -304,9 +304,6 @@ jobs:
           - arch_os: windows_amd64
             base_image_tag: ltsc2022
             runs-on: windows-2022
-          - arch_os: windows_amd64
-            base_image_tag: ltsc2019
-            runs-on: windows-2019
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -365,9 +365,6 @@ jobs:
           - arch_os: windows_amd64
             base_image_tag: ltsc2022
             runs-on: windows-2022
-          - arch_os: windows_amd64
-            base_image_tag: ltsc2019
-            runs-on: windows-2019
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Windows Server 2019 is at EOL and not supported by GHA anymore.