### PR TITLE
Update Chef,Ansible,Puppet to use cdn url for install script

### DIFF
--- a/.changelog/1818.changed.txt
+++ b/.changelog/1818.changed.txt
@@ -1,0 +1,1 @@
+chore: Update Chef,Ansible,Puppet to use cdn url for install script

--- a/examples/ansible/install_sumologic_otel_collector.yaml
+++ b/examples/ansible/install_sumologic_otel_collector.yaml
@@ -7,7 +7,7 @@
   tasks:
     - name: Download install script
       ansible.builtin.get_url:
-        url: "https://github.com/SumoLogic/sumologic-otel-collector-packaging/releases/latest/download/install.sh"
+        url: "https://download-otel.sumologic.com/latest/download/install.sh"
         dest: /tmp/install.sh
         mode: 0755
     - name: Create install script argument list

--- a/examples/chef/sumologic-otel-collector/resources/default.rb
+++ b/examples/chef/sumologic-otel-collector/resources/default.rb
@@ -25,7 +25,7 @@ DOWNLOAD_TIMEOUT = 300
 BINARY_PATH = '/usr/local/bin/otelcol-sumo'
 BINARY_CONFIG = '/etc/otelcol-sumo/conf.d'
 INSTALL_SCRIPT_PATH = "/tmp/install.sh"
-INSTALL_SCRIPT_URL = "https://github.com/SumoLogic/sumologic-otel-collector-packaging/releases/latest/download/install.sh"
+INSTALL_SCRIPT_URL = "https://download-otel.sumologic.com/latest/download/install.sh"
 
 action :default do
   run_action :get_install_script

--- a/examples/puppet/modules/install_otel_collector/manifests/init.pp
+++ b/examples/puppet/modules/install_otel_collector/manifests/init.pp
@@ -27,7 +27,7 @@ class install_otel_collector (
   Optional[String] $version = undef,
   String $src_config_path = 'puppet:///modules/install_otel_collector/conf.d',
 ) {
-  $install_script_url = 'https://github.com/SumoLogic/sumologic-otel-collector-packaging/releases/latest/download/install.sh'
+  $install_script_url = 'https://download-otel.sumologic.com/latest/download/install.sh'
   $install_script_path = '/tmp/install.sh'
   $download_timeout = 300
 


### PR DESCRIPTION
Update Chef,Ansible,Puppet to use cdn url for install script

https://download-otel.sumologic.com/latest/download/install.sh is working fine 