### PR TITLE
chore: consolidate code signing, fix retry logic

### DIFF
--- a/.github/workflows/workflow-build-otelcol-config-platform.yml
+++ b/.github/workflows/workflow-build-otelcol-config-platform.yml
@@ -125,7 +125,21 @@ jobs:
         env:
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
         working-directory: ./pkg/tools/otelcol-config
-        run: make ${{ inputs.platform }}-sign
+        run: |
+          signed=false
+
+          for _ in $(seq 1 5); do
+            if make ${{ inputs.platform }}-sign; then
+              signed=true
+              break
+            fi
+            sleep 5
+          done
+
+          if ! $signed; then
+            echo "Failed to sign binary & dmg file"
+            exit 1
+          fi
 
       - name: Store binary as action artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/.github/workflows/workflow-build-otelcol-platform.yml
+++ b/.github/workflows/workflow-build-otelcol-platform.yml
@@ -271,10 +271,20 @@ jobs:
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
         working-directory: ./otelcolbuilder/
         run: |
+          signed=false
+
           for _ in $(seq 1 5); do
-          # shellcheck disable=SC2015
-          make ${{ inputs.platform }}-sign && break || sleep 5
+            if make ${{ inputs.platform }}-sign; then
+              signed=true
+              break
+            fi
+            sleep 5
           done
+
+          if ! $signed; then
+            echo "Failed to sign binary & dmg file"
+            exit 1
+          fi
 
       - name: Sign Windows binary
         if: runner.os == 'Windows' && inputs.signing-enabled

--- a/otelcolbuilder/Makefile
+++ b/otelcolbuilder/Makefile
@@ -1,6 +1,6 @@
-#################################################################################
+################################################################################
 # Path variables & stop implicit rules
-#################################################################################
+################################################################################
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 current_dir := $(patsubst %/,%,$(dir $(mkfile_path)))
@@ -16,9 +16,9 @@ $(parent_dir)/common.mk:
 $(toolchains_dir)/Makefile:
 	@true
 
-#################################################################################
+################################################################################
 # Override variables & include makefile dependencies
-#################################################################################
+################################################################################
 
 # A list of one or more space-delimited paths to files that are used to determine
 # if the cache should be invalidated. When these files change, the cache is
@@ -31,9 +31,9 @@ include $(parent_dir)/common.mk
 # Include the toolchains Makefile
 include $(toolchains_dir)/Makefile
 
-#################################################################################
+################################################################################
 # Variables
-#################################################################################
+################################################################################
 
 BINARY_NAME ?= otelcol-sumo
 OCB_VERSION ?= 0.130.1
@@ -249,36 +249,17 @@ otelcol-sumo-darwin_amd64:
 otelcol-sumo-darwin_arm64:
 	GOOS=darwin  GOARCH=arm64 $(MAKE) build BINARY_NAME=$(BINARY_NAME)$(FIPS_SUFFIX)-darwin_arm64
 
-.PHONY: darwin-sign
-darwin-sign: BINARY_PATH = cmd/$(BINARY_NAME)
-darwin-sign: DMG_PATH = $(BINARY_PATH).dmg
-darwin-sign:
-	$(eval DMG_SOURCE_DIR = $(shell mktemp -d -t "$(BINARY_NAME)-dmg"))
-	codesign --timestamp --options=runtime -s "$(DEVELOPER_SIGNING_IDENTITY)" -v "$(BINARY_PATH)"
-	cp "$(BINARY_PATH)" "$(DMG_SOURCE_DIR)"
-	hdiutil create "$(DMG_PATH)" -ov -volname "$(DMG_VOLUME_NAME)" -fs APFS -format UDZO -srcfolder "$(DMG_SOURCE_DIR)"
-	xcrun notarytool submit --apple-id "$(AC_USERNAME)" --password "$(AC_PASSWORD)" --team-id "$(DEVELOPER_TEAM_ID)" --progress --wait "$(DMG_PATH)"
-	xcrun stapler staple "$(DMG_PATH)"
-
-.PHONY: darwin_amd64-sign
-darwin_amd64-sign: BINARY_NAME=otelcol-sumo-darwin_amd64
-darwin_amd64-sign: darwin-sign
-
-.PHONY: darwin_arm64-sign
-darwin_arm64-sign: BINARY_NAME=otelcol-sumo-darwin_arm64
-darwin_arm64-sign: darwin-sign
-
 .PHONY: otelcol-sumo-linux_amd64
 otelcol-sumo-linux_amd64:
 	GOOS=linux   GOARCH=amd64 $(MAKE) build BINARY_NAME=$(BINARY_NAME)$(FIPS_SUFFIX)-linux_amd64
 
-.PHONY: otelcol-sumo-linux_arm64
-otelcol-sumo-linux_arm64:
-	GOOS=linux   GOARCH=arm64 $(MAKE) build BINARY_NAME=$(BINARY_NAME)$(FIPS_SUFFIX)-linux_arm64
-
 .PHONY: otelcol-sumo-linux_arm
 otelcol-sumo-linux_arm:
 	GOOS=linux   GOARCH=arm $(MAKE) build BINARY_NAME=$(BINARY_NAME)$(FIPS_SUFFIX)-linux_arm
+
+.PHONY: otelcol-sumo-linux_arm64
+otelcol-sumo-linux_arm64:
+	GOOS=linux   GOARCH=arm64 $(MAKE) build BINARY_NAME=$(BINARY_NAME)$(FIPS_SUFFIX)-linux_arm64
 
 .PHONY: otelcol-sumo-windows_amd64
 otelcol-sumo-windows_amd64:
@@ -299,3 +280,20 @@ otelcol-sumo-linux-fips_amd64:
 		CGO_ENABLED=1 \
 		CC="$(toolchains_dir)/toolchain_amd64/bin/x86_64-linux-musl-gcc" \
 		EXTRA_LDFLAGS="-linkmode external -extldflags '-static'"
+
+################################################################################
+# Signing targets
+################################################################################
+
+.PHONY: darwin-sign-otelcol
+darwin-sign-otelcol: BIN_PATH = cmd/$(BINARY_NAME)
+darwin-sign-otelcol: DMG_BIN_FILENAME = otelcol-sumo
+darwin-sign-otelcol: darwin-sign
+
+.PHONY: darwin_amd64-sign
+darwin_amd64-sign: BINARY_NAME=otelcol-sumo-darwin_amd64
+darwin_amd64-sign: darwin-sign-otelcol
+
+.PHONY: darwin_arm64-sign
+darwin_arm64-sign: BINARY_NAME=otelcol-sumo-darwin_arm64
+darwin_arm64-sign: darwin-sign-otelcol

--- a/pkg/tools/otelcol-config/Makefile
+++ b/pkg/tools/otelcol-config/Makefile
@@ -81,29 +81,12 @@ ifeq ($(HOST_OS),Darwin)
 	AC_PASSWORD ?= $(shell echo $$AC_PASSWORD)
 	DEVELOPER_TEAM_ID ?= 8F28635Z7X
 	DEVELOPER_SIGNING_IDENTITY ?= Developer ID Application: Sumo Logic, Inc. ($(DEVELOPER_TEAM_ID))
+	DMG_VOLUME_NAME ?= Sumo Logic OpenTelemetry Collector Config Tool
 endif
 
 ################################################################################
-# Functions
+# Build targets
 ################################################################################
-
-# Check that given variables are set and all have non-empty values,
-# die with an error otherwise.
-#
-# PARAMS:
-#   1. Variable name(s) to test.
-#   2. (optional) Error message to print.
-#
-# EXAMPLE:
-# @:$(call check_defined, ENV_REGION, you must set ENV_REGION=usc1|awsuse2)
-#
-check_defined = \
-	$(strip $(foreach 1,$1, \
-		$(call __check_defined,$1,$(strip $(value 2)))))
-__check_defined = \
-	$(if $(value $1),, \
-		$(error Undefined $1$(if $2, ($2))$(if $(value @), \
-			required by target `$@')))
 
 .PHONY: build
 build:
@@ -179,7 +162,6 @@ otelcol-config-linux-fips_arm64:
 ################################################################################
 
 .PHONY: otelcol-config-dmg
-otelcol-config-dmg: DMG_VOLUME_NAME=Sumo Logic OpenTelemetry Collector Config Tool
 otelcol-config-dmg:
 	$(call check_defined, BIN_PATH, BIN_PATH must be set to the path of the otelcol-config binary)
 	$(call check_defined, DMG_PATH, DMG_PATH must be set to the path of the DMG file that will be created)
@@ -188,32 +170,18 @@ otelcol-config-dmg:
 	hdiutil create "$(DMG_PATH)" -ov -volname "$(DMG_VOLUME_NAME)" -fs APFS -format UDZO -srcfolder "$(TMP_DIR)"
 
 ################################################################################
-# Code signing targets
+# Signing targets
 ################################################################################
 
-.PHONY: darwin-sign-binary
-darwin-sign-binary:
-	$(call check_defined, BIN_PATH, BIN_PATH must be set to the path of the binary to sign)
-	codesign --timestamp --options=runtime -s "$(DEVELOPER_SIGNING_IDENTITY)" -v "$(BIN_PATH)"
-
-.PHONY: darwin-sign-dmg
-darwin-sign-dmg: DMG_PATH=$(BIN_PATH).dmg
-darwin-sign-dmg:
-	$(call check_defined, DMG_PATH, DMG_PATH must be set to the path of the DMG file to sign)
-	xcrun notarytool submit --apple-id "$(AC_USERNAME)" --password "$(AC_PASSWORD)" --team-id "$(DEVELOPER_TEAM_ID)" --progress --wait "$(DMG_PATH)"
-	xcrun stapler staple "$(DMG_PATH)"
-
-.PHONY: darwin-dmg-and-sign
-darwin-dmg-and-sign: DMG_PATH=$(BINARY_NAME).dmg
-darwin-dmg-and-sign:
-	$(MAKE) darwin-sign-binary BIN_PATH=$(BINARY_NAME)
-	$(MAKE) otelcol-config-dmg BIN_PATH=$(BINARY_NAME) DMG_PATH=$(DMG_PATH)
-	$(MAKE) darwin-sign-dmg DMG_PATH=$(BINARY_NAME).dmg
+.PHONY: darwin-sign-otelcol-config
+darwin-sign-otelcol-config: BIN_PATH = $(BINARY_NAME)
+darwin-sign-otelcol-config: DMG_BIN_FILENAME = otelcol-config
+darwin-sign-otelcol-config: darwin-sign
 
 .PHONY: darwin_amd64-sign
 darwin_amd64-sign: BINARY_NAME=otelcol-config-darwin_amd64
-darwin_amd64-sign: darwin-dmg-and-sign
+darwin_amd64-sign: darwin-sign-otelcol-config
 
 .PHONY: darwin_arm64-sign
 darwin_arm64-sign: BINARY_NAME=otelcol-config-darwin_arm64
-darwin_arm64-sign: darwin-dmg-and-sign
+darwin_arm64-sign: darwin-sign-otelcol-config


### PR DESCRIPTION
Fixes #1824.

I've updated the Makefiles & GitHub Workflows to be more resilient to failures.

The following improvements have been made:
* Binary signing is skipped if the binary has already been signed
* DMG file is removed, if it exists, before staging & creating a DMG file
* GitHub Workflow step for signing with retry logic will now exit 1 if all retries failed
* Both otelcol-sumo and otelcol-config now use common targets from `common.mk` for DMG creation, signing, and notarization

