### PR TITLE
RE-7213 Add skip changelog

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       - skip-changelog
 
   - package-ecosystem: "gomod"
-    directory: "/pkg"
+    directory: "/pkg/**"
     schedule:
       interval: "daily"
 


### PR DESCRIPTION
RE-7213 Add skip changelog

Changed gomod config from directory: "/pkg" to directories: ["/pkg/**"] so Dependabot applies the skip-changelog label to all gomod PRs automatically. Previously, the directory (singular) field only matched /pkg exactly.
