### PR TITLE
Disable signing for forked PR's

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -274,6 +274,7 @@ jobs:
     with:
       go-version: ${{ needs.determine-build-info.outputs.go-version }}
       version: ${{ needs.determine-build-info.outputs.version-with-sha }}
+      signing-enabled: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     secrets: inherit
 
   build-otelcol-config:
@@ -283,4 +284,5 @@ jobs:
       - determine-build-info
     with:
       go-version: ${{ needs.determine-build-info.outputs.go-version }}
+      signing-enabled: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     secrets: inherit


### PR DESCRIPTION
Why?
https://sumologic.atlassian.net/browse/SUMO-278702

Repository secrets.* are not available for forked repo PR's since exposed secrets for forked repo's will be a security flaw since anyone can fork a repo and get access to producution secrets. 

Due to this, any [forked repo PR](https://github.com/SumoLogic/sumologic-otel-collector/actions/runs/24546289872/job/71774764799?pr=2053) fails due to signing certificate not available error.

Fix:
Skip signing step for forked PR's , only build and test them.