### PR TITLE
Updating directory key

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       - skip-changelog
 
   - package-ecosystem: "gomod"
-    directory: "/pkg/**"
+    directories: "/pkg/**"
     schedule:
       interval: "daily"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
       - skip-changelog
 
   - package-ecosystem: "gomod"
-    directories: "/pkg/**"
+    directories:
+    - "/pkg/**"
     schedule:
       interval: "daily"
 


### PR DESCRIPTION
glob `/**` is only supported in directories and not in directory.

"The directories key supports globbing and the wildcard character *. These features are not supported by the directory key."

[Reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#directories-or-directory--)