### PR TITLE
fix(opamp): remove expandconverter from OpAMP config provider to fix $1 pattern crash

### DIFF
--- a/.changelog/2076.fixed.txt
+++ b/.changelog/2076.fixed.txt
@@ -1,0 +1,1 @@
+fix(opamp): remove expandconverter from OpAMP config provider to fix $1 pattern crash

--- a/otelcolbuilder/.gitignore
+++ b/otelcolbuilder/.gitignore
@@ -1,5 +1,6 @@
 cmd/*
 !cmd/collector_config_test.go
+!cmd/configprovider_test.go
 !cmd/collector_windows.go
 !cmd/testdata/
 !cmd/configprovider.go

--- a/otelcolbuilder/cmd/collector_config_test.go
+++ b/otelcolbuilder/cmd/collector_config_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
-	"go.opentelemetry.io/collector/confmap/converter/expandconverter"
 	"go.opentelemetry.io/collector/confmap/provider/envprovider"
 	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
 	"go.opentelemetry.io/collector/confmap/provider/httpprovider"
@@ -110,8 +109,12 @@ func TestBuiltCollectorWithConfigurationFiles(t *testing.T) {
 			locations := []string{tc.configFile}
 
 			// this is copied from the generated main.go
+			// DefaultScheme must be set to "env" to match what the otelcol command
+			// does in updateSettingsUsingFlags — this allows ${VAR} references in
+			// config files (e.g. ${TMPDIR}) to be expanded via the env provider.
 			settings := otelcol.ConfigProviderSettings{
 				ResolverSettings: confmap.ResolverSettings{
+					DefaultScheme: "env",
 					ProviderFactories: []confmap.ProviderFactory{
 						globprovider.NewFactory(),
 						opampprovider.NewFactory(),
@@ -121,9 +124,7 @@ func TestBuiltCollectorWithConfigurationFiles(t *testing.T) {
 						httpsprovider.NewFactory(),
 						yamlprovider.NewFactory(),
 					},
-					ConverterFactories: []confmap.ConverterFactory{
-						expandconverter.NewFactory(),
-					},
+					ConverterFactories: []confmap.ConverterFactory{},
 				},
 			}
 			settings.ResolverSettings.URIs = locations

--- a/otelcolbuilder/cmd/configprovider.go
+++ b/otelcolbuilder/cmd/configprovider.go
@@ -22,7 +22,6 @@ import (
 	"slices"
 
 	"go.opentelemetry.io/collector/confmap"
-	"go.opentelemetry.io/collector/confmap/converter/expandconverter"
 	"go.opentelemetry.io/collector/confmap/provider/envprovider"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/otelcol"
@@ -92,8 +91,7 @@ func NewOpAmpConfigProviderSettings(location string) otelcol.ConfigProviderSetti
 	return otelcol.ConfigProviderSettings{
 		ResolverSettings: confmap.ResolverSettings{
 			URIs:               []string{location},
-			ProviderFactories:  []confmap.ProviderFactory{opampprovider.NewFactory(), envprovider.NewFactory()},
-			ConverterFactories: []confmap.ConverterFactory{expandconverter.NewFactory()},
+			ProviderFactories: []confmap.ProviderFactory{opampprovider.NewFactory(), envprovider.NewFactory()},
 		},
 	}
 }

--- a/otelcolbuilder/cmd/configprovider_test.go
+++ b/otelcolbuilder/cmd/configprovider_test.go
@@ -1,0 +1,75 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap"
+)
+
+// TestNewOpAmpConfigProviderSettingsHasNoExpandConverter verifies that the
+// OpAMP config provider does not include the expandconverter. The
+// expandconverter uses os.Expand which interprets $1, $2, etc. as shell
+// variables. When a config contains regex replacement patterns like "$1"
+// (e.g. replace_pattern with capture groups), the expandconverter would
+// fail with "environment variable "1" has invalid name" because confmap's
+// escapeDollarSigns does not escape $N where N is a digit.
+//
+// Regression test for: SUMO-282987
+func TestNewOpAmpConfigProviderSettingsHasNoExpandConverter(t *testing.T) {
+	settings := NewOpAmpConfigProviderSettings("opamp:/some/path")
+	assert.Empty(t, settings.ResolverSettings.ConverterFactories,
+		"expandconverter must not be present: it double-processes $1 patterns causing "+
+			"\"environment variable '1' has invalid name\" when using remote Source Templates "+
+			"with hashing regex processing rules")
+}
+
+// TestOpAmpConfigWithDollarPatternsResolvesWithoutError verifies that an
+// OpAMP-delivered config containing "$1" regex capture group references (as
+// used in replace_pattern for hashing processing rules) resolves without
+// error.
+//
+// Previously, the expandconverter in NewOpAmpConfigProviderSettings caused:
+//
+//	"environment variable "1" has invalid name: must match regex ..."
+//
+// because os.Expand (used by expandconverter) treats "$1" as a shell
+// variable reference, and confmap's escapeDollarSigns does not escape
+// digit-only variable names.
+//
+// Regression test for: SUMO-282987
+func TestOpAmpConfigWithDollarPatternsResolvesWithoutError(t *testing.T) {
+	opampConfigPath, err := filepath.Abs(
+		filepath.Join("testdata", "opamp_replace_pattern", "opamp.yaml"),
+	)
+	require.NoError(t, err)
+
+	settings := NewOpAmpConfigProviderSettings("opamp:" + opampConfigPath)
+
+	resolver, err := confmap.NewResolver(settings.ResolverSettings)
+	require.NoError(t, err)
+
+	_, err = resolver.Resolve(context.Background())
+	require.NoError(t, err,
+		"config containing $1 replacement patterns must resolve without error "+
+			"when using OpAMP config provider (SUMO-282987)")
+
+	require.NoError(t, resolver.Shutdown(context.Background()))
+}

--- a/otelcolbuilder/cmd/testdata/opamp_replace_pattern/opamp.yaml
+++ b/otelcolbuilder/cmd/testdata/opamp_replace_pattern/opamp.yaml
@@ -1,0 +1,4 @@
+extensions:
+  opamp:
+    endpoint: "wss://example.com/v1/opamp"
+    remote_configuration_directory: ./testdata/opamp_replace_pattern/remote_config

--- a/otelcolbuilder/cmd/testdata/opamp_replace_pattern/remote_config/replace_pattern.yaml
+++ b/otelcolbuilder/cmd/testdata/opamp_replace_pattern/remote_config/replace_pattern.yaml
@@ -1,0 +1,6 @@
+processors:
+  transform/hash_passwords:
+    log_statements:
+      - context: log
+        statements:
+          - 'replace_pattern(body, "password=([A-Za-z0-9]+)", "$1", SHA256, "password=%s")'


### PR DESCRIPTION
### Problem
When using a remote Source Template (ST) with a hashing regex processing rule, the agent crashes during startup with: failed to setup configuration components: environment variable "1" has invalid name: must match regex ...
This only happens with remotely managed configs (OpAMP). Locally managed configs work fine.

### Root Cause
The processing pipeline for config values is:

1. confmap's escapeDollarSigns — leaves $1 untouched (digits are not valid env var name starts)
2. expandconverter — runs os.Expand("$1", ...) which treats $1 as a shell variable, calls the mapping function with "1", which fails env var name validation → crash

`NewOpAmpConfigProviderSettings` included `expandconverter.NewFactory()` in its `ConverterFactories`, but the local config path did not. This discrepancy was introduced when the local path was migrated to the otelcol builder (which removed `expandconverter`) but `NewOpAmpConfigProviderSettings `was missed.

Note: `expandconverter` has been officially deprecated since [otelcol v0.107.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.107.0) precisely because it causes double-escaping issues when used alongside confmap's resolver.

###Fix
Removed `expandconverter.NewFactory()` from `NewOpAmpConfigProviderSettings` in `otelcolbuilder/cmd/configprovider.go`, making the OpAMP config provider consistent with the local config path.

###Testing
Added regression tests in `otelcolbuilder/cmd/configprovider_test.go`:

- TestNewOpAmpConfigProviderSettingsHasNoExpandConverter — asserts ConverterFactories is empty
- TestOpAmpConfigWithDollarPatternsResolvesWithoutError — end-to-end resolution of a config with $1 capture group patterns using OpAMP provider settings

Also, tested end 2 end and verfied the hash is working fine.