### PR TITLE
chore: update go version to oldstable

### DIFF
--- a/.changelog/2077.changed.txt
+++ b/.changelog/2077.changed.txt
@@ -1,0 +1,1 @@
+chore: bump the go version to oldstable

--- a/.changelog/2077.changed.txt
+++ b/.changelog/2077.changed.txt
@@ -1,1 +1,1 @@
-chore: bump the go version to oldstable
+chore: bump the go version to oldstable(1.25.9)

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -13,7 +13,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: "1.25.7"
+  GO_VERSION: "oldstable"
 
 jobs:
   build-changed:

--- a/.github/workflows/workflow-determine-build-info.yml
+++ b/.github/workflows/workflow-determine-build-info.yml
@@ -23,7 +23,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: "1.25.7"
+  GO_VERSION: "oldstable"
 
 jobs:
   determine:

--- a/.github/workflows/workflow-determine-build-info.yml
+++ b/.github/workflows/workflow-determine-build-info.yml
@@ -57,11 +57,20 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "version-with-sha=${with_sha}" >> "$GITHUB_OUTPUT"
 
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+
       - name: Output Go information
         id: go
         shell: bash
         run: |
-          echo "version=${GO_VERSION}" >> "$GITHUB_OUTPUT"
+          # Resolve alias (e.g. "oldstable") to a concrete version (e.g. "1.25.9").
+          # Required because the Windows/Microsoft Go installer does not support aliases.
+          resolved_version="$(go env GOVERSION | sed 's/^go//')"
+          echo "version=${resolved_version}" >> "$GITHUB_OUTPUT"
 
       - name: Output notices
         shell: bash

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -28,7 +28,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: "1.25.7"
+  GO_VERSION: "oldstable"
 
 jobs:
   test:


### PR DESCRIPTION
updating the go version to `oldstable` as used in upstream [https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/8bdbc27272c[…]728361b1306e6a67aaa66/.github/actions/setup-go-tools/action.yml](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/8bdbc27272c9006334a728361b1306e6a67aaa66/.github/actions/setup-go-tools/action.yml#L9)

this will remove the effort of manually updating the go version.