### PR TITLE
fix: update PR labeler to use v6 config format

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,18 +1,23 @@
 # Add 'documentation' label to any change to *.md files
 documentation:
-- any: ['**/*.md']
+- changed-files:
+  - any-glob-to-any-file: ['**/*.md']
 
 # Add 'docker' label to any change in docker related files
 docker:
-- any: ['**/Dockerfile*', '**/.dockerignore']
+- changed-files:
+  - any-glob-to-any-file: ['**/Dockerfile*', '**/.dockerignore']
 
 # Add 'github_actions' label to any change .github/ directory
 github_actions:
-- any: ['.github/**', '.github/*']
+- changed-files:
+  - any-glob-to-any-file: ['.github/**']
 
 # Add 'go' label to any change *.go files
 go:
-- any: ['**/*.go']
+- changed-files:
+  - any-glob-to-any-file: ['**/*.go']
 
 osc:
-- any: ['**']
+- changed-files:
+  - any-glob-to-any-file: ['**']

--- a/.github/workflows/pr_labeler.yaml
+++ b/.github/workflows/pr_labeler.yaml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   triage:
     runs-on: ubuntu-24.04
@@ -11,5 +15,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/labeler@v6
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true


### PR DESCRIPTION
## Summary

The PR labeler workflow (#2093, #2096) was not applying labels because:

1. **Wrong config format**: The `labeler.yml` was using v4 syntax (`- any: ['pattern']`) which is not recognized by `actions/labeler@v6`. The v6 action expects `- changed-files: - any-glob-to-any-file: ['pattern']`.

2. **Missing permissions**: The workflow lacked explicit `pull-requests: write` permission, causing `Resource not accessible by integration` errors when the action tried to set labels.

## Changes

- Updated `.github/labeler.yml` to use the v6 `changed-files` / `any-glob-to-any-file` format
- Added `permissions` block with `contents: read` and `pull-requests: write`
- Removed unnecessary `repo-token` parameter (defaults to `github.token` in v6)

## Test

Verified on a fork: https://github.com/shubham-sumo/sumologic-otel-collector/pull/1

- Previous run failed with permission error: https://github.com/shubham-sumo/sumologic-otel-collector/actions/runs/26214493970
- After fix, labels applied successfully: https://github.com/shubham-sumo/sumologic-otel-collector/actions/runs/26214576294