### PR TITLE
feat(otelcol-config): add --set-fleet-id flag for fleet-based registration

### DIFF
--- a/.changelog/2146.added.txt
+++ b/.changelog/2146.added.txt
@@ -1,0 +1,1 @@
+feat(otelcol-config): add --set-fleet-id flag for fleet-based registration

--- a/pkg/tools/otelcol-config/flag.go
+++ b/pkg/tools/otelcol-config/flag.go
@@ -28,6 +28,7 @@ const (
 	flagEnableClobber        = "enable-clobber"
 	flagDisableClobber       = "disable-clobber"
 	flagSetCollectorName     = "set-collector-name"
+	flagSetFleetID           = "set-fleet-id"
 )
 
 const (
@@ -51,6 +52,7 @@ const (
 	enableClobberUsage        = "enables clobber (deletes any existing collector with the same name)."
 	disableClobberUsage       = "disables clobber (prevents deletion of existing collectors with the same name)."
 	setCollectorNameUsage     = "sets the collector name in the sumologic extension"
+	setFleetIDUsage           = "sets the fleet ID for fleet-based registration"
 )
 
 type flagValues struct {
@@ -75,6 +77,7 @@ type flagValues struct {
 	EnableClobber        bool
 	DisableClobber       bool
 	SetCollectorName     string
+	SetFleetID           string
 }
 
 func newFlagValues() *flagValues {
@@ -106,6 +109,7 @@ func makeFlagSet(fv *flagValues) *pflag.FlagSet {
 	flags.BoolVar(&fv.EnableClobber, flagEnableClobber, false, enableClobberUsage)
 	flags.BoolVar(&fv.DisableClobber, flagDisableClobber, false, disableClobberUsage)
 	flags.StringVarP(&fv.SetCollectorName, flagSetCollectorName, "N", "", setCollectorNameUsage)
+	flags.StringVar(&fv.SetFleetID, flagSetFleetID, "", setFleetIDUsage)
 
 	return flags
 }

--- a/pkg/tools/otelcol-config/flag_actions.go
+++ b/pkg/tools/otelcol-config/flag_actions.go
@@ -34,6 +34,7 @@ var flagActions = map[string]action{
 	flagEnableClobber:        EnableClobberAction,
 	flagDisableClobber:       DisableClobberAction,
 	flagSetCollectorName:     SetCollectorNameAction,
+	flagSetFleetID:           SetFleetIDAction,
 }
 
 func nullAction(*actionContext) error {
@@ -64,4 +65,5 @@ var actionOrder = []string{
 	flagEnableClobber,
 	flagDisableClobber,
 	flagSetCollectorName,
+	flagSetFleetID,
 }

--- a/pkg/tools/otelcol-config/flag_test.go
+++ b/pkg/tools/otelcol-config/flag_test.go
@@ -214,3 +214,14 @@ func TestSetCollectorName(t *testing.T) {
 		t.Errorf("bad flag values: got %v, want %v", got, want)
 	}
 }
+
+func TestSetFleetID(t *testing.T) {
+	fv := newFlagValues()
+	fs := makeFlagSet(fv)
+	if err := fs.Parse([]string{"otelcol-config", "--set-fleet-id", "000000000ABC1234"}); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := fv.SetFleetID, "000000000ABC1234"; !cmp.Equal(got, want) {
+		t.Errorf("bad flag values: got %v, want %v", got, want)
+	}
+}

--- a/pkg/tools/otelcol-config/fleet_id.go
+++ b/pkg/tools/otelcol-config/fleet_id.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/mikefarah/yq/v4/pkg/yqlib"
+	"gopkg.in/yaml.v3"
+)
+
+var validHexPattern = regexp.MustCompile(`^[0-9a-fA-F]{16}$`)
+
+func validateFleetID(id string) error {
+	id = strings.TrimSpace(id)
+
+	if id == "" {
+		return fmt.Errorf("fleet ID cannot be empty")
+	}
+
+	if !validHexPattern.MatchString(id) {
+		return fmt.Errorf("fleet ID must be exactly 16 hexadecimal characters (e.g. 000000000ABC1234)")
+	}
+
+	return nil
+}
+
+func SetFleetIDAction(ctx *actionContext) error {
+	conf, err := ReadConfigDir(ctx.ConfigDir)
+	if err != nil {
+		return err
+	}
+
+	fleetID := strings.TrimSpace(ctx.Flags.SetFleetID)
+
+	if err := validateFleetID(fleetID); err != nil {
+		return err
+	}
+
+	var writer func([]byte) (int, error)
+	var doc []byte
+
+	switch {
+	case conf.SumologicRemote != nil || ctx.Flags.EnableRemoteControl:
+		writer = ctx.WriteSumologicRemote
+		doc = conf.SumologicRemote
+	case ctx.Flags.Override:
+		writer = ctx.WriteConfDOverrides
+		doc = conf.ConfD[ConfDOverrides]
+	default:
+		writer = ctx.WriteConfD
+		doc = conf.ConfD[ConfDSettings]
+	}
+
+	encoder := yqlib.YamlFormat.EncoderFactory()
+	decoder := yqlib.YamlFormat.DecoderFactory()
+	eval := yqlib.NewStringEvaluator()
+
+	if len(doc) == 0 {
+		buf := new(bytes.Buffer)
+		enc := yaml.NewEncoder(buf)
+		enc.SetIndent(2)
+		settings := map[string]any{
+			"extensions": map[string]any{
+				"sumologic": map[string]any{
+					"fleet_id": fleetID,
+				},
+			},
+		}
+		if err := enc.Encode(settings); err != nil {
+			panic(err)
+		}
+		doc = buf.Bytes()
+	} else {
+		expression := fmt.Sprintf(".extensions.sumologic.fleet_id = %q", fleetID)
+		result, err := eval.EvaluateAll(expression, string(doc), encoder, decoder)
+		if err != nil {
+			return fmt.Errorf("couldn't set fleet ID: error evaluating yq expression: %s", err)
+		}
+		doc = []byte(result)
+	}
+
+	_, err = writer(doc)
+	if err != nil {
+		return fmt.Errorf("couldn't write updated config: %s", err)
+	}
+
+	return nil
+}

--- a/pkg/tools/otelcol-config/fleet_id_test.go
+++ b/pkg/tools/otelcol-config/fleet_id_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"io"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+)
+
+func TestSetFleetIDAction(t *testing.T) {
+	tests := []struct {
+		Name           string
+		Flags          []string
+		Conf           fs.FS
+		ExpectedWriter []byte
+		ExpectedErr    bool
+	}{
+		{
+			Name:           "valid fleet ID, no existing config",
+			Flags:          []string{"--set-fleet-id", "000000000ABC1234"},
+			Conf:           fstest.MapFS{},
+			ExpectedWriter: []byte("extensions:\n  sumologic:\n    fleet_id: 000000000ABC1234\n"),
+		},
+		{
+			Name:  "valid fleet ID, remote control enabled",
+			Flags: []string{"--set-fleet-id", "000000000ABC1234"},
+			Conf: fstest.MapFS{
+				SumologicRemoteDotYaml: &fstest.MapFile{
+					Data: []byte("extensions:\n  opamp:\n    enabled: true\n"),
+				},
+			},
+			ExpectedWriter: []byte("extensions:\n  opamp:\n    enabled: true\n  sumologic:\n    fleet_id: 000000000ABC1234\n"),
+		},
+		{
+			Name:           "valid fleet ID with override",
+			Flags:          []string{"--set-fleet-id", "00000000DEADBEEF", "--override"},
+			Conf:           fstest.MapFS{},
+			ExpectedWriter: []byte("extensions:\n  sumologic:\n    fleet_id: 00000000DEADBEEF\n"),
+		},
+		{
+			Name:           "valid lowercase hex",
+			Flags:          []string{"--set-fleet-id", "abcdef0123456789"},
+			Conf:           fstest.MapFS{},
+			ExpectedWriter: []byte("extensions:\n  sumologic:\n    fleet_id: abcdef0123456789\n"),
+		},
+		{
+			Name:        "invalid: empty string",
+			Flags:       []string{"--set-fleet-id", ""},
+			Conf:        fstest.MapFS{},
+			ExpectedErr: true,
+		},
+		{
+			Name:        "invalid: too short",
+			Flags:       []string{"--set-fleet-id", "ABC1234"},
+			Conf:        fstest.MapFS{},
+			ExpectedErr: true,
+		},
+		{
+			Name:        "invalid: too long",
+			Flags:       []string{"--set-fleet-id", "000000000ABC12345"},
+			Conf:        fstest.MapFS{},
+			ExpectedErr: true,
+		},
+		{
+			Name:        "invalid: non-hex characters",
+			Flags:       []string{"--set-fleet-id", "000000000ABCXYZ1"},
+			Conf:        fstest.MapFS{},
+			ExpectedErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			writer := newTestWriter(test.ExpectedWriter).Write
+			errWriter := errWriter{}.Write
+
+			flagValues := newFlagValues()
+			flagSet := makeFlagSet(flagValues)
+
+			if err := flagSet.Parse(test.Flags); err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+
+			var (
+				settingsWriter, overridesWriter, sumologicRemoteWriter func([]byte) (int, error)
+			)
+
+			switch {
+			case flagValues.Override:
+				settingsWriter = errWriter
+				sumologicRemoteWriter = errWriter
+				overridesWriter = writer
+			case flagValues.EnableRemoteControl || remoteControlEnabled(t, test.Conf):
+				settingsWriter = errWriter
+				overridesWriter = errWriter
+				sumologicRemoteWriter = writer
+			default:
+				overridesWriter = errWriter
+				sumologicRemoteWriter = errWriter
+				settingsWriter = writer
+			}
+
+			ctx := &actionContext{
+				ConfigDir:            test.Conf,
+				Flags:                flagValues,
+				Stdout:               io.Discard,
+				Stderr:               io.Discard,
+				WriteConfD:           settingsWriter,
+				WriteConfDOverrides:  overridesWriter,
+				WriteSumologicRemote: sumologicRemoteWriter,
+			}
+
+			err := SetFleetIDAction(ctx)
+			if err != nil && !test.ExpectedErr {
+				t.Fatal(err)
+			}
+			if err == nil && test.ExpectedErr {
+				t.Fatal("expected non-nil error")
+			}
+		})
+	}
+}
+
+func TestValidateFleetID(t *testing.T) {
+	tests := []struct {
+		Name    string
+		ID      string
+		WantErr bool
+	}{
+		{"valid uppercase", "000000000ABC1234", false},
+		{"valid lowercase", "abcdef0123456789", false},
+		{"valid mixed case", "00aaBB11ccDD2233", false},
+		{"empty", "", true},
+		{"too short", "ABC1234", true},
+		{"too long", "000000000ABC12345", true},
+		{"non-hex chars", "000000000ABCXYZ1", true},
+		{"spaces", "  ", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			err := validateFleetID(test.ID)
+			if (err != nil) != test.WantErr {
+				t.Errorf("validateFleetID(%q) error = %v, wantErr %v", test.ID, err, test.WantErr)
+			}
+		})
+	}
+}

--- a/pkg/tools/otelcol-config/remote_control.go
+++ b/pkg/tools/otelcol-config/remote_control.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -59,6 +60,13 @@ func makeNewSumologicRemoteYAML(ctx *actionContext, conf ConfDir) error {
 
 	if ctx.Flags.SetCollectorName != "" {
 		sumologicExt["collector_name"] = ctx.Flags.SetCollectorName
+	}
+
+	if ctx.Flags.SetFleetID != "" {
+		if err := validateFleetID(ctx.Flags.SetFleetID); err != nil {
+			return err
+		}
+		sumologicExt["fleet_id"] = strings.TrimSpace(ctx.Flags.SetFleetID)
 	}
 
 	var sumoRemoteConfig = map[string]any{

--- a/pkg/tools/otelcol-config/remote_control_test.go
+++ b/pkg/tools/otelcol-config/remote_control_test.go
@@ -136,3 +136,70 @@ service:
 		t.Fatal(err)
 	}
 }
+
+func TestEnableRemoteControlWithFleetID(t *testing.T) {
+	values := &flagValues{
+		EnableRemoteControl: true,
+		SetCollectorName:    "my-collector",
+		SetFleetID:          "000000000ABC1234",
+	}
+	const expData = `exporters:
+  nop: {}
+extensions:
+  file_storage:
+    compaction:
+      directory: /var/lib/otelcol-sumo/file_storage
+      on_rebound: true
+    directory: /var/lib/otelcol-sumo/file_storage
+  health_check:
+    endpoint: localhost:13133
+  opamp:
+    endpoint: wss://opamp-collectors.sumologic.com/v1/opamp
+    remote_configuration_directory: /etc/otelcol-sumo/opamp.d
+  sumologic:
+    clobber: false
+    collector_credentials_directory: /var/lib/otelcol-sumo/credentials
+    collector_name: my-collector
+    fleet_id: 000000000ABC1234
+    installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
+    time_zone: UTC
+receivers:
+  nop: {}
+service:
+  extensions:
+    - sumologic
+    - health_check
+    - file_storage
+    - opamp
+  pipelines:
+    logs/default:
+      exporters:
+        - nop
+      receivers:
+        - nop
+    metrics/default:
+      exporters:
+        - nop
+      receivers:
+        - nop
+    traces/default:
+      exporters:
+        - nop
+      receivers:
+        - nop
+`
+	slrWriter := newTestWriter([]byte(expData))
+	ctx := &actionContext{
+		ConfigDir:            fstest.MapFS{},
+		Flags:                values,
+		Stdout:               errWriter{},
+		Stderr:               errWriter{},
+		WriteConfD:           errWriter{}.Write,
+		WriteConfDOverrides:  errWriter{}.Write,
+		WriteSumologicRemote: slrWriter.Write,
+	}
+
+	if err := EnableRemoteControlAction(ctx); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/tools/otelcol-config/smoke_test.go
+++ b/pkg/tools/otelcol-config/smoke_test.go
@@ -51,6 +51,7 @@ func TestLocallyManagedSmoke(t *testing.T) {
 		"--write-kv", ".hello.world = \"yes\"",
 		"--enable-clobber",
 		"--set-collector-name", "my-collector",
+		"--set-fleet-id", "000000000ABC1234",
 	}
 
 	os.Args = flags
@@ -72,6 +73,7 @@ func TestRemotelyManagedSmoke(t *testing.T) {
 		"--set-api-url", "https://example.com",
 		"--enable-remote-control",
 		"--set-collector-name", "my-collector",
+		"--set-fleet-id", "000000000ABC1234",
 	}
 
 	os.Args = flags


### PR DESCRIPTION
### Summary

  - Adds --set-fleet-id flag to otelcol-config that writes .extensions.sumologic.fleet_id to the collector config
  - Fleet ID is validated as exactly 16 hexadecimal characters (matching the backend API format, e.g. 000000000ABC1234)
  - Supports all config write targets: conf.d/ settings, overrides(--override), and sumologic-remote.yaml (when remote control is enabled)
  - Wires fleet_id into the initial sumologic-remote.yaml template when --enable-remote-control and --set-fleet-id are used together

### Why

Backend support for fleetId in the collector registration API (Sanyaku/sumologic#154871) allows collectors to be assigned to a fleet during registration. This change provides the CLI mechanism for installers/admins to set the fleet ID before first start.

#### Usage

  ##### Set fleet ID (local config)
  `otelcol-config --set-fleet-id "000000000ABC1234"`

#### Test plan

  - Unit tests for valid/invalid fleet IDs (fleet_id_test.go)
  - Validation test: exactly 16 hex chars required
  - Write target tests: conf.d settings, overrides, sumologic-remote.yaml
  - Remote control integration test (remote_control_test.go)
  - Flag parsing test (flag_test.go)
  - Smoke tests for both locally and remotely managed modes
  - E2E: build binary, run otelcol-config --set-fleet-id, verify YAML output
  - E2E: collector registers with fleet ID and auto-links to fleet